### PR TITLE
go fmt ./go/...

### DIFF
--- a/go/aead/aead_config.go
+++ b/go/aead/aead_config.go
@@ -17,8 +17,8 @@
 package aead
 
 import (
-  "sync"
-  "github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // Config offers convenience methods for initializing aead.Factory()
@@ -32,31 +32,32 @@ import (
 // This divison allows for gradual retiring insecure or obsolete key types.
 var configInstance *config
 var configOnce sync.Once
-type config struct {}
+
+type config struct{}
 
 // Config creates an instance of config if there isn't and returns the instance.
 func Config() *config {
-  configOnce.Do(func() {
-    configInstance = new(config)
-  })
-  return configInstance
+	configOnce.Do(func() {
+		configInstance = new(config)
+	})
+	return configInstance
 }
 
 // RegisterStandardKeyTypes registers standard Aead key types and their managers
 // with the Registry.
 func (c *config) RegisterStandardKeyTypes() (bool, error) {
-  return c.RegisterKeyManager(NewAesGcmKeyManager())
+	return c.RegisterKeyManager(NewAesGcmKeyManager())
 }
 
 // RegisterLegacyKeyTypes registers legacy Aead key types and their managers
 // with the Registry.
 func (c *config) RegisterLegacyKeyTypes() (bool, error) {
-  return false, nil
+	return false, nil
 }
 
 // RegisterKeyManager registers the given keyManager for the key type given in
 // keyManager.KeyType(). It returns true if registration was successful, false if
 // there already exisits a key manager for the key type.
 func (c *config) RegisterKeyManager(keyManager tink.KeyManager) (bool, error) {
-  return tink.Registry().RegisterKeyManager(keyManager)
+	return tink.Registry().RegisterKeyManager(keyManager)
 }

--- a/go/aead/aead_config_test.go
+++ b/go/aead/aead_config_test.go
@@ -16,27 +16,27 @@
 package aead_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/tink/tink"
+	"testing"
 )
 
 func TestConfigInstance(t *testing.T) {
-  c := aead.Config()
-  if c == nil {
-    t.Errorf("Config() returns nil")
-  }
+	c := aead.Config()
+	if c == nil {
+		t.Errorf("Config() returns nil")
+	}
 }
 
 func TestConfigRegistration(t *testing.T) {
-  success, err := aead.Config().RegisterStandardKeyTypes()
-  if !success || err != nil {
-    t.Errorf("cannot register standard key types")
-  }
-  // check for AES-GCM key manager
-  keyManager, err := tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ = keyManager.(*aead.AesGcmKeyManager)
+	success, err := aead.Config().RegisterStandardKeyTypes()
+	if !success || err != nil {
+		t.Errorf("cannot register standard key types")
+	}
+	// check for AES-GCM key manager
+	keyManager, err := tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ = keyManager.(*aead.AesGcmKeyManager)
 }

--- a/go/aead/aead_factory.go
+++ b/go/aead/aead_factory.go
@@ -16,9 +16,9 @@
 package aead
 
 import (
-  "sync"
-  "fmt"
-  "github.com/google/tink/go/tink/tink"
+	"fmt"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // Factory offers methods for obtaining a primitive from a KeysetHandle.
@@ -33,37 +33,38 @@ import (
 // work, the primitive tries all keys with OutputPrefixType_RAW.
 var factoryInstance *factory
 var factoryOnce sync.Once
-type factory struct {}
+
+type factory struct{}
 
 // factory creates an instance of factory if there isn't and returns the instance.
 func Factory() *factory {
-  factoryOnce.Do(func() {
-    factoryInstance = new(factory)
-  })
-  return factoryInstance
+	factoryOnce.Do(func() {
+		factoryInstance = new(factory)
+	})
+	return factoryInstance
 }
 
 // GetPrimitive returns a Aead primitive from the given keyset handle.
 func (f *factory) GetPrimitive(handle *tink.KeysetHandle) (tink.Aead, error) {
-  return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
+	return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
 }
 
 // GetPrimitiveWithCustomerManager returns a Aead primitive from the given
 // keyset handle and custom key manager.
 func (f *factory) GetPrimitiveWithCustomerManager(
-    handle *tink.KeysetHandle, manager tink.KeyManager) (tink.Aead, error) {
-  ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
-  if err != nil {
-    return nil, fmt.Errorf("aead_factory: cannot obtain primitive set: %s", err)
-  }
-  var ret tink.Aead = newPrimitiveSetAead(ps)
-  return ret, nil
+	handle *tink.KeysetHandle, manager tink.KeyManager) (tink.Aead, error) {
+	ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
+	if err != nil {
+		return nil, fmt.Errorf("aead_factory: cannot obtain primitive set: %s", err)
+	}
+	var ret tink.Aead = newPrimitiveSetAead(ps)
+	return ret, nil
 }
 
 // primitiveSetAead is an Aead implementation that uses the underlying primitive
 // set for encryption and decryption.
 type primitiveSetAead struct {
-  ps *tink.PrimitiveSet
+	ps *tink.PrimitiveSet
 }
 
 // Asserts that primitiveSetAead implements the Aead interface.
@@ -71,57 +72,57 @@ var _ tink.Aead = (*primitiveSetAead)(nil)
 
 // newPrimitiveSetAead creates a new instance of primitiveSetAead
 func newPrimitiveSetAead(ps *tink.PrimitiveSet) *primitiveSetAead {
-  ret := new(primitiveSetAead)
-  ret.ps = ps
-  return ret
+	ret := new(primitiveSetAead)
+	ret.ps = ps
+	return ret
 }
 
 // Encrypt encrypts the given plaintext with the given additional authenticated data.
 // It returns the concatenation of the primary's identifier and the ciphertext.
 func (a *primitiveSetAead) Encrypt(pt []byte, ad []byte) ([]byte, error) {
-  primary := a.ps.Primary()
-  var p tink.Aead = (primary.Primitive()).(tink.Aead)
-  ct, err := p.Encrypt(pt, ad)
-  if err != nil {
-    return nil, err
-  }
-  var ret []byte
-  ret = append(ret, primary.Identifier()...)
-  ret = append(ret, ct...)
-  return ret, nil
+	primary := a.ps.Primary()
+	var p tink.Aead = (primary.Primitive()).(tink.Aead)
+	ct, err := p.Encrypt(pt, ad)
+	if err != nil {
+		return nil, err
+	}
+	var ret []byte
+	ret = append(ret, primary.Identifier()...)
+	ret = append(ret, ct...)
+	return ret, nil
 }
 
 // Decrypt decrypts the given ciphertext and authenticates it with the given
 // additional authenticated data. It returns the corresponding plaintext if the
 // ciphertext is authenticated.
 func (a *primitiveSetAead) Decrypt(ct []byte, ad []byte) ([]byte, error) {
-  // try non-raw keys
-  prefixSize := tink.NON_RAW_PREFIX_SIZE
-  if len(ct) > prefixSize {
-    prefix := ct[:prefixSize]
-    ctNoPrefix := ct[prefixSize:]
-    entries, err := a.ps.GetPrimitivesWithByteIdentifier(prefix)
-    if err == nil {
-      for i := 0; i < len(entries); i++ {
-        var p = (entries[i].Primitive()).(tink.Aead)
-        pt, err := p.Decrypt(ctNoPrefix, ad)
-        if err == nil {
-          return pt, nil
-        }
-      }
-    }
-  }
-  // try raw keys
-  entries, err := a.ps.GetRawPrimitives()
-  if err == nil {
-    for i := 0; i < len(entries); i++ {
-      var p = (entries[i].Primitive()).(tink.Aead)
-      pt, err := p.Decrypt(ct, ad)
-      if err == nil {
-        return pt, nil
-      }
-    }
-  }
-  // nothing worked
-  return nil, fmt.Errorf("aead_factory: decryption failed")
+	// try non-raw keys
+	prefixSize := tink.NON_RAW_PREFIX_SIZE
+	if len(ct) > prefixSize {
+		prefix := ct[:prefixSize]
+		ctNoPrefix := ct[prefixSize:]
+		entries, err := a.ps.GetPrimitivesWithByteIdentifier(prefix)
+		if err == nil {
+			for i := 0; i < len(entries); i++ {
+				var p = (entries[i].Primitive()).(tink.Aead)
+				pt, err := p.Decrypt(ctNoPrefix, ad)
+				if err == nil {
+					return pt, nil
+				}
+			}
+		}
+	}
+	// try raw keys
+	entries, err := a.ps.GetRawPrimitives()
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			var p = (entries[i].Primitive()).(tink.Aead)
+			pt, err := p.Decrypt(ct, ad)
+			if err == nil {
+				return pt, nil
+			}
+		}
+	}
+	// nothing worked
+	return nil, fmt.Errorf("aead_factory: decryption failed")
 }

--- a/go/aead/aead_factory_test.go
+++ b/go/aead/aead_factory_test.go
@@ -16,134 +16,134 @@
 package aead_test
 
 import (
-  "bytes"
-  "fmt"
-  "testing"
-  "strings"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/subtle/aes"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/tink/tink"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"bytes"
+	"fmt"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/subtle/aes"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"strings"
+	"testing"
 )
 
 func setupFactoryTest() {
-  aead.Config().RegisterStandardKeyTypes()
+	aead.Config().RegisterStandardKeyTypes()
 }
 
 func TestFactoryInstance(t *testing.T) {
-  f := aead.Factory()
-  if f == nil {
-    t.Errorf("Factory() returns nil")
-  }
+	f := aead.Factory()
+	if f == nil {
+		t.Errorf("Factory() returns nil")
+	}
 }
 
 func TestFactoryMultipleKeys(t *testing.T) {
-  setupFactoryTest()
-  // encrypt with non-raw key
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  primaryKey := keyset.Key[0]
-  if primaryKey.OutputPrefixType == tinkpb.OutputPrefixType_RAW {
-    t.Errorf("expect a non-raw key")
-  }
-  keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  a, err := aead.Factory().GetPrimitive(keysetHandle)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  expectedPrefix, _ := tink.GetOutputPrefix(primaryKey)
-  if err := validateAeadFactoryCipher(a, a, expectedPrefix); err != nil {
-    t.Errorf("invalid cipher: %s", err)
-  }
+	setupFactoryTest()
+	// encrypt with non-raw key
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	primaryKey := keyset.Key[0]
+	if primaryKey.OutputPrefixType == tinkpb.OutputPrefixType_RAW {
+		t.Errorf("expect a non-raw key")
+	}
+	keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	a, err := aead.Factory().GetPrimitive(keysetHandle)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	expectedPrefix, _ := tink.GetOutputPrefix(primaryKey)
+	if err := validateAeadFactoryCipher(a, a, expectedPrefix); err != nil {
+		t.Errorf("invalid cipher: %s", err)
+	}
 
-  // encrypt with a non-primary RAW key and decrypt with the keyset
-  rawKey := keyset.Key[1]
-  if rawKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
-    t.Errorf("expect a raw key")
-  }
-  keyset2 := util.NewKeyset(rawKey.KeyId, []*tinkpb.Keyset_Key{rawKey})
-  keysetHandle2, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset2)
-  a2, err := aead.Factory().GetPrimitive(keysetHandle2)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  if err := validateAeadFactoryCipher(a2, a, tink.RAW_PREFIX); err != nil {
-    t.Errorf("invalid cipher: %s", err)
-  }
+	// encrypt with a non-primary RAW key and decrypt with the keyset
+	rawKey := keyset.Key[1]
+	if rawKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
+		t.Errorf("expect a raw key")
+	}
+	keyset2 := util.NewKeyset(rawKey.KeyId, []*tinkpb.Keyset_Key{rawKey})
+	keysetHandle2, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset2)
+	a2, err := aead.Factory().GetPrimitive(keysetHandle2)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	if err := validateAeadFactoryCipher(a2, a, tink.RAW_PREFIX); err != nil {
+		t.Errorf("invalid cipher: %s", err)
+	}
 
-  // encrypt with a random key not in the keyset, decrypt with the keyset should fail
-  keyset2 = testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  primaryKey = keyset2.Key[0]
-  expectedPrefix, _ = tink.GetOutputPrefix(primaryKey)
-  keysetHandle2, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset2)
-  a2, err = aead.Factory().GetPrimitive(keysetHandle2)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  err = validateAeadFactoryCipher(a2, a, expectedPrefix)
-  if err == nil || !strings.Contains(err.Error(), "decryption failed") {
-    t.Errorf("expect decryption to fail with random key: %s", err)
-  }
+	// encrypt with a random key not in the keyset, decrypt with the keyset should fail
+	keyset2 = testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	primaryKey = keyset2.Key[0]
+	expectedPrefix, _ = tink.GetOutputPrefix(primaryKey)
+	keysetHandle2, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset2)
+	a2, err = aead.Factory().GetPrimitive(keysetHandle2)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	err = validateAeadFactoryCipher(a2, a, expectedPrefix)
+	if err == nil || !strings.Contains(err.Error(), "decryption failed") {
+		t.Errorf("expect decryption to fail with random key: %s", err)
+	}
 }
 
 func TestFactoryRawKeyAsPrimary(t *testing.T) {
-  setupFactoryTest()
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_RAW)
-  if keyset.Key[0].OutputPrefixType != tinkpb.OutputPrefixType_RAW {
-    t.Errorf("primary key is not a raw key")
-  }
-  keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	setupFactoryTest()
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_RAW)
+	if keyset.Key[0].OutputPrefixType != tinkpb.OutputPrefixType_RAW {
+		t.Errorf("primary key is not a raw key")
+	}
+	keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
 
-  a, err := aead.Factory().GetPrimitive(keysetHandle)
-  if err != nil {
-    t.Errorf("cannot get primitive from keyset handle: %s", err)
-  }
-  if err := validateAeadFactoryCipher(a, a, tink.RAW_PREFIX); err != nil {
-    t.Errorf("invalid cipher: %s", err)
-  }
+	a, err := aead.Factory().GetPrimitive(keysetHandle)
+	if err != nil {
+		t.Errorf("cannot get primitive from keyset handle: %s", err)
+	}
+	if err := validateAeadFactoryCipher(a, a, tink.RAW_PREFIX); err != nil {
+		t.Errorf("invalid cipher: %s", err)
+	}
 }
 
 func validateAeadFactoryCipher(encryptCipher tink.Aead,
-                              decryptCipher tink.Aead,
-                              expectedPrefix string) error{
-  prefixSize := len(expectedPrefix)
-  // regular plaintext
-  pt := random.GetRandomBytes(20)
-  ad := random.GetRandomBytes(20)
-  ct, err := encryptCipher.Encrypt(pt, ad)
-  if err != nil {
-    return fmt.Errorf("encryption failed with regular plaintext: %s", err)
-  }
-  decrypted, err := decryptCipher.Decrypt(ct, ad)
-  if err != nil || !bytes.Equal(decrypted, pt) {
-    return fmt.Errorf("decryption failed with regular plaintext: err: %s, pt: %s, decrypted: %s",
-                      err, pt, decrypted)
-  }
-  if string(ct[:prefixSize]) != expectedPrefix {
-    return fmt.Errorf("incorrect prefix with regular plaintext")
-  }
-  if prefixSize+len(pt)+aes.AES_GCM_IV_SIZE+aes.AES_GCM_TAG_SIZE != len(ct) {
-    return fmt.Errorf("lengths of plaintext and ciphertext don't match with regular plaintext")
-  }
+	decryptCipher tink.Aead,
+	expectedPrefix string) error {
+	prefixSize := len(expectedPrefix)
+	// regular plaintext
+	pt := random.GetRandomBytes(20)
+	ad := random.GetRandomBytes(20)
+	ct, err := encryptCipher.Encrypt(pt, ad)
+	if err != nil {
+		return fmt.Errorf("encryption failed with regular plaintext: %s", err)
+	}
+	decrypted, err := decryptCipher.Decrypt(ct, ad)
+	if err != nil || !bytes.Equal(decrypted, pt) {
+		return fmt.Errorf("decryption failed with regular plaintext: err: %s, pt: %s, decrypted: %s",
+			err, pt, decrypted)
+	}
+	if string(ct[:prefixSize]) != expectedPrefix {
+		return fmt.Errorf("incorrect prefix with regular plaintext")
+	}
+	if prefixSize+len(pt)+aes.AES_GCM_IV_SIZE+aes.AES_GCM_TAG_SIZE != len(ct) {
+		return fmt.Errorf("lengths of plaintext and ciphertext don't match with regular plaintext")
+	}
 
-  // short plaintext
-  pt = random.GetRandomBytes(1)
-  ct, err = encryptCipher.Encrypt(pt, ad)
-  if err != nil {
-    return fmt.Errorf("encryption failed with short plaintext: %s", err)
-  }
-  decrypted, err = decryptCipher.Decrypt(ct, ad)
-  if err != nil || !bytes.Equal(decrypted, pt) {
-    return fmt.Errorf("decryption failed with short plaintext: err: %s, pt: %s, decrypted: %s",
-                      err, pt, decrypted)
-  }
-  if string(ct[:prefixSize]) != expectedPrefix {
-    return fmt.Errorf("incorrect prefix with short plaintext")
-  }
-  if prefixSize+len(pt)+aes.AES_GCM_IV_SIZE+aes.AES_GCM_TAG_SIZE != len(ct) {
-    return fmt.Errorf("lengths of plaintext and ciphertext don't match with short plaintext")
-  }
-  return nil
+	// short plaintext
+	pt = random.GetRandomBytes(1)
+	ct, err = encryptCipher.Encrypt(pt, ad)
+	if err != nil {
+		return fmt.Errorf("encryption failed with short plaintext: %s", err)
+	}
+	decrypted, err = decryptCipher.Decrypt(ct, ad)
+	if err != nil || !bytes.Equal(decrypted, pt) {
+		return fmt.Errorf("decryption failed with short plaintext: err: %s, pt: %s, decrypted: %s",
+			err, pt, decrypted)
+	}
+	if string(ct[:prefixSize]) != expectedPrefix {
+		return fmt.Errorf("incorrect prefix with short plaintext")
+	}
+	if prefixSize+len(pt)+aes.AES_GCM_IV_SIZE+aes.AES_GCM_TAG_SIZE != len(ct) {
+		return fmt.Errorf("lengths of plaintext and ciphertext don't match with short plaintext")
+	}
+	return nil
 }

--- a/go/aead/aead_key_templates.go
+++ b/go/aead/aead_key_templates.go
@@ -16,9 +16,9 @@
 package aead
 
 import (
-  "github.com/golang/protobuf/proto"
-  gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"github.com/golang/protobuf/proto"
+	gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // This file contains pre-generated KeyTemplate for Aead keys. One can use these templates
@@ -27,24 +27,24 @@ import (
 // Aes128GcmKeyTemplate is a KeyTemplate of AesGcmKey with the following parameters:
 //   - Key size: 16 bytes
 func Aes128GcmKeyTemplate() *tinkpb.KeyTemplate {
-  return createAesGcmKeyTemplate(16)
+	return createAesGcmKeyTemplate(16)
 }
 
 // Aes256GcmKeyTemplate is a KeyTemplate of AesGcmKey with the following parameters:
 //   - Key size: 32 bytes
 func Aes256GcmKeyTemplate() *tinkpb.KeyTemplate {
-  return createAesGcmKeyTemplate(32)
+	return createAesGcmKeyTemplate(32)
 }
 
 // createAesGcmKeyTemplate creates a new AES-GCM key template with the given key
 // size in bytes.
 func createAesGcmKeyTemplate(keySize uint32) *tinkpb.KeyTemplate {
-  format := &gcmpb.AesGcmKeyFormat{
-    KeySize: keySize,
-  }
-  serializedFormat, _ := proto.Marshal(format)
-  return &tinkpb.KeyTemplate{
-    TypeUrl: AES_GCM_TYPE_URL,
-    Value: serializedFormat,
-  }
+	format := &gcmpb.AesGcmKeyFormat{
+		KeySize: keySize,
+	}
+	serializedFormat, _ := proto.Marshal(format)
+	return &tinkpb.KeyTemplate{
+		TypeUrl: AES_GCM_TYPE_URL,
+		Value:   serializedFormat,
+	}
 }

--- a/go/aead/aead_key_templates_test.go
+++ b/go/aead/aead_key_templates_test.go
@@ -16,38 +16,38 @@
 package aead_test
 
 import (
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/golang/protobuf/proto"
-  gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead/aead"
+	gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestAesGcmKeyTemplates(t *testing.T) {
-  // AES-GCM 128 bit
-  template := aead.Aes128GcmKeyTemplate()
-  if err := checkAesGcmKeyTemplate(template, uint32(16)); err != nil {
-    t.Errorf("invalid AES-128 GCM key template: %s", err)
-  }
-  // AES-GCM 256 bit
-  template = aead.Aes256GcmKeyTemplate()
-  if err := checkAesGcmKeyTemplate(template, uint32(32)); err != nil {
-    t.Errorf("invalid AES-256 GCM key template: %s", err)
-  }
+	// AES-GCM 128 bit
+	template := aead.Aes128GcmKeyTemplate()
+	if err := checkAesGcmKeyTemplate(template, uint32(16)); err != nil {
+		t.Errorf("invalid AES-128 GCM key template: %s", err)
+	}
+	// AES-GCM 256 bit
+	template = aead.Aes256GcmKeyTemplate()
+	if err := checkAesGcmKeyTemplate(template, uint32(32)); err != nil {
+		t.Errorf("invalid AES-256 GCM key template: %s", err)
+	}
 }
 
 func checkAesGcmKeyTemplate(template *tinkpb.KeyTemplate, keySize uint32) error {
-  if template.TypeUrl != aead.AES_GCM_TYPE_URL {
-    return fmt.Errorf("incorrect type url")
-  }
-  keyFormat := new(gcmpb.AesGcmKeyFormat)
-  err := proto.Unmarshal(template.Value, keyFormat)
-  if err != nil {
-    return fmt.Errorf("cannot deserialize key format: %s", err)
-  }
-  if keyFormat.KeySize != keySize {
-    return fmt.Errorf("incorrect key size, expect %d, got %d", keySize, keyFormat.KeySize)
-  }
-  return nil
+	if template.TypeUrl != aead.AES_GCM_TYPE_URL {
+		return fmt.Errorf("incorrect type url")
+	}
+	keyFormat := new(gcmpb.AesGcmKeyFormat)
+	err := proto.Unmarshal(template.Value, keyFormat)
+	if err != nil {
+		return fmt.Errorf("cannot deserialize key format: %s", err)
+	}
+	if keyFormat.KeySize != keySize {
+		return fmt.Errorf("incorrect key size, expect %d, got %d", keySize, keyFormat.KeySize)
+	}
+	return nil
 }

--- a/go/aead/aes_gcm_key_manager.go
+++ b/go/aead/aes_gcm_key_manager.go
@@ -16,22 +16,22 @@
 package aead
 
 import (
-  "fmt"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/subtle/aes"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/golang/protobuf/proto"
-  gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/subtle/aes"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/util"
+	gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 const (
-  // Supported version
-  AES_GCM_KEY_VERSION = 0
+	// Supported version
+	AES_GCM_KEY_VERSION = 0
 
-  // Supported type url
-  AES_GCM_TYPE_URL = "type.googleapis.com/google.crypto.tink.AesGcmKey"
+	// Supported type url
+	AES_GCM_TYPE_URL = "type.googleapis.com/google.crypto.tink.AesGcmKey"
 )
 
 // common errors
@@ -40,120 +40,120 @@ var errInvalidAesGcmKeyFormat = fmt.Errorf("aes_gcm_key_manager: invalid key for
 
 // AesGcmKeyManager is an implementation of KeyManager interface.
 // It generates new AesGcmKey keys and produces new instances of AesGcm subtle.
-type AesGcmKeyManager struct {}
+type AesGcmKeyManager struct{}
 
 // Assert that aesGcmKeyManager implements the KeyManager interface.
 var _ tink.KeyManager = (*AesGcmKeyManager)(nil)
 
 // NewAesGcmKeyManager creates a new aesGcmKeyManager.
 func NewAesGcmKeyManager() *AesGcmKeyManager {
-  return new(AesGcmKeyManager)
+	return new(AesGcmKeyManager)
 }
 
 // GetPrimitiveFromSerializedKey creates an AesGcm subtle for the given
 // serialized AesGcmKey proto.
 func (km *AesGcmKeyManager) GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error) {
-  if len(serializedKey) == 0 {
-    return nil, errInvalidAesGcmKey
-  }
-  key := new(gcmpb.AesGcmKey)
-  if err := proto.Unmarshal(serializedKey, key); err != nil {
-    return nil, errInvalidAesGcmKey
-  }
-  return km.GetPrimitiveFromKey(key)
+	if len(serializedKey) == 0 {
+		return nil, errInvalidAesGcmKey
+	}
+	key := new(gcmpb.AesGcmKey)
+	if err := proto.Unmarshal(serializedKey, key); err != nil {
+		return nil, errInvalidAesGcmKey
+	}
+	return km.GetPrimitiveFromKey(key)
 }
 
 // GetPrimitiveFromKey creates an AesGcm subtle for the given AesGcmKey proto.
 func (km *AesGcmKeyManager) GetPrimitiveFromKey(m proto.Message) (interface{}, error) {
-  key, ok := m.(*gcmpb.AesGcmKey)
-  if !ok {
-    return nil, errInvalidAesGcmKey
-  }
-  if err := km.validateKey(key); err != nil {
-    return nil, err
-  }
-  ret, err := aes.NewAesGcm(key.KeyValue)
-  if err != nil {
-    return nil, fmt.Errorf("aes_gcm_key_manager: cannot create new primitive: %s", err)
-  }
-  return ret, nil
+	key, ok := m.(*gcmpb.AesGcmKey)
+	if !ok {
+		return nil, errInvalidAesGcmKey
+	}
+	if err := km.validateKey(key); err != nil {
+		return nil, err
+	}
+	ret, err := aes.NewAesGcm(key.KeyValue)
+	if err != nil {
+		return nil, fmt.Errorf("aes_gcm_key_manager: cannot create new primitive: %s", err)
+	}
+	return ret, nil
 }
 
 // NewKeyFromSerializedKeyFormat creates a new key according to specification
 // the given serialized AesGcmKeyFormat.
 func (km *AesGcmKeyManager) NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error) {
-  if len(serializedKeyFormat) == 0 {
-    return nil, errInvalidAesGcmKeyFormat
-  }
-  keyFormat := new(gcmpb.AesGcmKeyFormat)
-  if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
-    return nil, errInvalidAesGcmKeyFormat
-  }
-  return km.NewKeyFromKeyFormat(keyFormat)
+	if len(serializedKeyFormat) == 0 {
+		return nil, errInvalidAesGcmKeyFormat
+	}
+	keyFormat := new(gcmpb.AesGcmKeyFormat)
+	if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
+		return nil, errInvalidAesGcmKeyFormat
+	}
+	return km.NewKeyFromKeyFormat(keyFormat)
 }
 
 // NewKeyFromKeyFormat creates a new key according to specification in the
 // given AesGcmKeyFormat.
 func (km *AesGcmKeyManager) NewKeyFromKeyFormat(m proto.Message) (proto.Message, error) {
-  keyFormat, ok := m.(*gcmpb.AesGcmKeyFormat)
-  if !ok {
-    return nil, errInvalidAesGcmKeyFormat
-  }
-  if err := km.validateKeyFormat(keyFormat); err != nil {
-    return nil, fmt.Errorf("aes_gcm_key_manager: invalid key format: %s", err)
-  }
-  keyValue := random.GetRandomBytes(keyFormat.KeySize)
-  return &gcmpb.AesGcmKey{
-    Version: AES_GCM_KEY_VERSION,
-    KeyValue: keyValue,
-  }, nil
+	keyFormat, ok := m.(*gcmpb.AesGcmKeyFormat)
+	if !ok {
+		return nil, errInvalidAesGcmKeyFormat
+	}
+	if err := km.validateKeyFormat(keyFormat); err != nil {
+		return nil, fmt.Errorf("aes_gcm_key_manager: invalid key format: %s", err)
+	}
+	keyValue := random.GetRandomBytes(keyFormat.KeySize)
+	return &gcmpb.AesGcmKey{
+		Version:  AES_GCM_KEY_VERSION,
+		KeyValue: keyValue,
+	}, nil
 }
 
 // NewKeyData creates a new KeyData according to specification in  the given
 // serialized AesGcmKeyFormat. It should be used solely by the key management API.
 func (km *AesGcmKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
-  key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
-  if err != nil {
-    return nil, err
-  }
-  serializedKey, err := proto.Marshal(key)
-  if err != nil {
-    return nil, err
-  }
-  return &tinkpb.KeyData{
-    TypeUrl: AES_GCM_TYPE_URL,
-    Value: serializedKey,
-    KeyMaterialType: tinkpb.KeyData_SYMMETRIC,
-  }, nil
+	key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
+	if err != nil {
+		return nil, err
+	}
+	serializedKey, err := proto.Marshal(key)
+	if err != nil {
+		return nil, err
+	}
+	return &tinkpb.KeyData{
+		TypeUrl:         AES_GCM_TYPE_URL,
+		Value:           serializedKey,
+		KeyMaterialType: tinkpb.KeyData_SYMMETRIC,
+	}, nil
 }
 
 // DoesSupport indicates if this key manager supports the given key type.
 func (_ *AesGcmKeyManager) DoesSupport(typeUrl string) bool {
-  return typeUrl == AES_GCM_TYPE_URL
+	return typeUrl == AES_GCM_TYPE_URL
 }
 
 // GetKeyType returns the key type of keys managed by this key manager.
 func (_ *AesGcmKeyManager) GetKeyType() string {
-  return AES_GCM_TYPE_URL
+	return AES_GCM_TYPE_URL
 }
 
 // validateKey validates the given AesGcmKey.
 func (_ *AesGcmKeyManager) validateKey(key *gcmpb.AesGcmKey) error {
-  err := util.ValidateVersion(key.Version, AES_GCM_KEY_VERSION)
-  if err != nil {
-    return fmt.Errorf("aes_gcm_key_manager: %s", err)
-  }
-  keySize := uint32(len(key.KeyValue))
-  if err := aes.ValidateAesKeySize(keySize); err != nil {
-    return fmt.Errorf("aes_gcm_key_manager: %s", err)
-  }
-  return nil
+	err := util.ValidateVersion(key.Version, AES_GCM_KEY_VERSION)
+	if err != nil {
+		return fmt.Errorf("aes_gcm_key_manager: %s", err)
+	}
+	keySize := uint32(len(key.KeyValue))
+	if err := aes.ValidateAesKeySize(keySize); err != nil {
+		return fmt.Errorf("aes_gcm_key_manager: %s", err)
+	}
+	return nil
 }
 
 // validateKeyFormat validates the given AesGcmKeyFormat.
 func (_ *AesGcmKeyManager) validateKeyFormat(format *gcmpb.AesGcmKeyFormat) error {
-  if err := aes.ValidateAesKeySize(format.KeySize); err != nil {
-    return fmt.Errorf("aes_gcm_key_manager: %s", err)
-  }
-  return nil
+	if err := aes.ValidateAesKeySize(format.KeySize); err != nil {
+		return fmt.Errorf("aes_gcm_key_manager: %s", err)
+	}
+	return nil
 }

--- a/go/aead/aes_gcm_key_manager_test.go
+++ b/go/aead/aes_gcm_key_manager_test.go
@@ -16,266 +16,266 @@
 package aead_test
 
 import (
-  "bytes"
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/subtle/aes"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/golang/protobuf/proto"
-  gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"bytes"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/subtle/aes"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 var keySizes = []uint32{16, 24, 32}
 
 func TestNewAesGcmKeyManager(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  if keyManager == nil {
-    t.Errorf("NewAesGcmKeyManager() returns nil")
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	if keyManager == nil {
+		t.Errorf("NewAesGcmKeyManager() returns nil")
+	}
 }
 
 func TestAesGcmGetPrimitiveBasic(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  for _, keySize := range keySizes {
-    key := testutil.NewAesGcmKey(uint32(keySize))
-    p, err := keyManager.GetPrimitiveFromKey(key)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    if err := validateAesGcmPrimitive(p, key); err != nil {
-      t.Errorf("%s", err)
-    }
+	keyManager := aead.NewAesGcmKeyManager()
+	for _, keySize := range keySizes {
+		key := testutil.NewAesGcmKey(uint32(keySize))
+		p, err := keyManager.GetPrimitiveFromKey(key)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if err := validateAesGcmPrimitive(p, key); err != nil {
+			t.Errorf("%s", err)
+		}
 
-    serializedKey, _ := proto.Marshal(key)
-    p, err = keyManager.GetPrimitiveFromSerializedKey(serializedKey)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    if err := validateAesGcmPrimitive(p, key); err != nil {
-      t.Errorf("%s", err)
-    }
-  }
+		serializedKey, _ := proto.Marshal(key)
+		p, err = keyManager.GetPrimitiveFromSerializedKey(serializedKey)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if err := validateAesGcmPrimitive(p, key); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func TestAesGcmGetPrimitiveWithInvalidInput(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  // invalid AesGcmKey
-  testKeys := genInvalidAesGcmKeys()
-  for i := 0; i < len(testKeys); i++ {
-    if _, err := keyManager.GetPrimitiveFromKey(testKeys[i]); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-    serializedKey, _ := proto.Marshal(testKeys[i])
-    if _, err := keyManager.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil
-  if _, err := keyManager.GetPrimitiveFromKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := keyManager.GetPrimitiveFromSerializedKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty array
-  if _, err := keyManager.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty")
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	// invalid AesGcmKey
+	testKeys := genInvalidAesGcmKeys()
+	for i := 0; i < len(testKeys); i++ {
+		if _, err := keyManager.GetPrimitiveFromKey(testKeys[i]); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+		serializedKey, _ := proto.Marshal(testKeys[i])
+		if _, err := keyManager.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil
+	if _, err := keyManager.GetPrimitiveFromKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := keyManager.GetPrimitiveFromSerializedKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty array
+	if _, err := keyManager.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty")
+	}
 }
 
 func TestAesGcmNewKeyMultipleTimes(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  format := util.NewAesGcmKeyFormat(32)
-  serializedFormat, _ := proto.Marshal(format)
-  keys := make(map[string]bool)
-  nTest := 26
-  for i := 0; i < nTest; i++ {
-    key, _ := keyManager.NewKeyFromSerializedKeyFormat(serializedFormat)
-    serializedKey, _ := proto.Marshal(key)
-    keys[string(serializedKey)] = true
+	keyManager := aead.NewAesGcmKeyManager()
+	format := util.NewAesGcmKeyFormat(32)
+	serializedFormat, _ := proto.Marshal(format)
+	keys := make(map[string]bool)
+	nTest := 26
+	for i := 0; i < nTest; i++ {
+		key, _ := keyManager.NewKeyFromSerializedKeyFormat(serializedFormat)
+		serializedKey, _ := proto.Marshal(key)
+		keys[string(serializedKey)] = true
 
-    key, _ = keyManager.NewKeyFromKeyFormat(format)
-    serializedKey, _ = proto.Marshal(key)
-    keys[string(serializedKey)] = true
-  }
-  if len(keys) != nTest*2 {
-    t.Errorf("key is repeated")
-  }
+		key, _ = keyManager.NewKeyFromKeyFormat(format)
+		serializedKey, _ = proto.Marshal(key)
+		keys[string(serializedKey)] = true
+	}
+	if len(keys) != nTest*2 {
+		t.Errorf("key is repeated")
+	}
 }
 
 func TestAesGcmNewKeyBasic(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  for _, keySize := range keySizes {
-    format := util.NewAesGcmKeyFormat(uint32(keySize))
-    m, err := keyManager.NewKeyFromKeyFormat(format)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    key := m.(*gcmpb.AesGcmKey)
-    if err := validateAesGcmKey(key, format); err != nil {
-      t.Errorf("%s", err)
-    }
+	keyManager := aead.NewAesGcmKeyManager()
+	for _, keySize := range keySizes {
+		format := util.NewAesGcmKeyFormat(uint32(keySize))
+		m, err := keyManager.NewKeyFromKeyFormat(format)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		key := m.(*gcmpb.AesGcmKey)
+		if err := validateAesGcmKey(key, format); err != nil {
+			t.Errorf("%s", err)
+		}
 
-    serializedFormat, _ := proto.Marshal(format)
-    m, err = keyManager.NewKeyFromSerializedKeyFormat(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    key = m.(*gcmpb.AesGcmKey)
-    if err := validateAesGcmKey(key, format); err != nil {
-      t.Errorf("%s", err)
-    }
-  }
+		serializedFormat, _ := proto.Marshal(format)
+		m, err = keyManager.NewKeyFromSerializedKeyFormat(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		key = m.(*gcmpb.AesGcmKey)
+		if err := validateAesGcmKey(key, format); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func TestAesGcmNewKeyWithInvalidInput(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  // bad format
-  badFormats := genInvalidAesGcmKeyFormats()
-  for i := 0; i < len(badFormats); i++ {
-    if _, err := keyManager.NewKeyFromKeyFormat(badFormats[i]); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-    serializedFormat, _ := proto.Marshal(badFormats[i])
-    if _, err := keyManager.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil
-  if _, err := keyManager.NewKeyFromKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := keyManager.NewKeyFromSerializedKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty array
-  if _, err := keyManager.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty")
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	// bad format
+	badFormats := genInvalidAesGcmKeyFormats()
+	for i := 0; i < len(badFormats); i++ {
+		if _, err := keyManager.NewKeyFromKeyFormat(badFormats[i]); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+		serializedFormat, _ := proto.Marshal(badFormats[i])
+		if _, err := keyManager.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil
+	if _, err := keyManager.NewKeyFromKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := keyManager.NewKeyFromSerializedKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty array
+	if _, err := keyManager.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty")
+	}
 }
 
 func TestAesGcmNewKeyDataBasic(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  for _, keySize := range keySizes {
-    format := util.NewAesGcmKeyFormat(uint32(keySize))
-    serializedFormat, _ := proto.Marshal(format)
-    keyData, err := keyManager.NewKeyData(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    if keyData.TypeUrl != aead.AES_GCM_TYPE_URL {
-      t.Errorf("incorrect type url")
-    }
-    if keyData.KeyMaterialType != tinkpb.KeyData_SYMMETRIC {
-      t.Errorf("incorrect key material type")
-    }
-    key := new(gcmpb.AesGcmKey)
-    if err := proto.Unmarshal(keyData.Value, key); err != nil {
-      t.Errorf("incorrect key value")
-    }
-    if err := validateAesGcmKey(key, format); err != nil {
-      t.Errorf("%s", err)
-    }
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	for _, keySize := range keySizes {
+		format := util.NewAesGcmKeyFormat(uint32(keySize))
+		serializedFormat, _ := proto.Marshal(format)
+		keyData, err := keyManager.NewKeyData(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if keyData.TypeUrl != aead.AES_GCM_TYPE_URL {
+			t.Errorf("incorrect type url")
+		}
+		if keyData.KeyMaterialType != tinkpb.KeyData_SYMMETRIC {
+			t.Errorf("incorrect key material type")
+		}
+		key := new(gcmpb.AesGcmKey)
+		if err := proto.Unmarshal(keyData.Value, key); err != nil {
+			t.Errorf("incorrect key value")
+		}
+		if err := validateAesGcmKey(key, format); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func TestAesGcmNewKeyDataWithInvalidInput(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  badFormats := genInvalidAesGcmKeyFormats()
-  for i := 0; i < len(badFormats); i++ {
-    serializedFormat, _ := proto.Marshal(badFormats[i])
-    if _, err := keyManager.NewKeyData(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil input
-  if _, err := keyManager.NewKeyData(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty input
-  if _, err := keyManager.NewKeyData([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty")
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	badFormats := genInvalidAesGcmKeyFormats()
+	for i := 0; i < len(badFormats); i++ {
+		serializedFormat, _ := proto.Marshal(badFormats[i])
+		if _, err := keyManager.NewKeyData(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil input
+	if _, err := keyManager.NewKeyData(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty input
+	if _, err := keyManager.NewKeyData([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty")
+	}
 }
 
 func TestAesGcmDoesSupport(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  if !keyManager.DoesSupport(aead.AES_GCM_TYPE_URL) {
-    t.Errorf("AesGcmKeyManager must support %s", aead.AES_GCM_TYPE_URL)
-  }
-  if keyManager.DoesSupport("some bad type") {
-    t.Errorf("AesGcmKeyManager must support only %s", aead.AES_GCM_TYPE_URL)
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	if !keyManager.DoesSupport(aead.AES_GCM_TYPE_URL) {
+		t.Errorf("AesGcmKeyManager must support %s", aead.AES_GCM_TYPE_URL)
+	}
+	if keyManager.DoesSupport("some bad type") {
+		t.Errorf("AesGcmKeyManager must support only %s", aead.AES_GCM_TYPE_URL)
+	}
 }
 
 func TestAesGcmGetKeyType(t *testing.T) {
-  keyManager := aead.NewAesGcmKeyManager()
-  if keyManager.GetKeyType() != aead.AES_GCM_TYPE_URL {
-    t.Errorf("incorrect key type")
-  }
+	keyManager := aead.NewAesGcmKeyManager()
+	if keyManager.GetKeyType() != aead.AES_GCM_TYPE_URL {
+		t.Errorf("incorrect key type")
+	}
 }
 
 func genInvalidAesGcmKeys() []proto.Message {
-  return []proto.Message{
-    // not a AesGcmKey
-    util.NewAesGcmKeyFormat(32),
-    // bad key size
-    util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(17)),
-    util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(25)),
-    util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(33)),
-    // bad version
-    util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION+1, random.GetRandomBytes(16)),
-  }
+	return []proto.Message{
+		// not a AesGcmKey
+		util.NewAesGcmKeyFormat(32),
+		// bad key size
+		util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(17)),
+		util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(25)),
+		util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(33)),
+		// bad version
+		util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION+1, random.GetRandomBytes(16)),
+	}
 }
 
 func genInvalidAesGcmKeyFormats() []proto.Message {
-  return []proto.Message{
-    // not AesGcmKeyFormat
-    util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(16)),
-    // invalid key size
-    util.NewAesGcmKeyFormat(uint32(15)),
-    util.NewAesGcmKeyFormat(uint32(23)),
-    util.NewAesGcmKeyFormat(uint32(31)),
-  }
+	return []proto.Message{
+		// not AesGcmKeyFormat
+		util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, random.GetRandomBytes(16)),
+		// invalid key size
+		util.NewAesGcmKeyFormat(uint32(15)),
+		util.NewAesGcmKeyFormat(uint32(23)),
+		util.NewAesGcmKeyFormat(uint32(31)),
+	}
 }
 
 func validateAesGcmKey(key *gcmpb.AesGcmKey, format *gcmpb.AesGcmKeyFormat) error {
-  if uint32(len(key.KeyValue)) != format.KeySize {
-    return fmt.Errorf("incorrect key size")
-  }
-  if key.Version != aead.AES_GCM_KEY_VERSION {
-    return fmt.Errorf("incorrect key version")
-  }
-  // try to encrypt and decrypt
-  p, err := aes.NewAesGcm(key.KeyValue)
-  if err != nil {
-    return fmt.Errorf("invalid key")
-  }
-  return validateAesGcmPrimitive(p, key)
+	if uint32(len(key.KeyValue)) != format.KeySize {
+		return fmt.Errorf("incorrect key size")
+	}
+	if key.Version != aead.AES_GCM_KEY_VERSION {
+		return fmt.Errorf("incorrect key version")
+	}
+	// try to encrypt and decrypt
+	p, err := aes.NewAesGcm(key.KeyValue)
+	if err != nil {
+		return fmt.Errorf("invalid key")
+	}
+	return validateAesGcmPrimitive(p, key)
 }
 
 func validateAesGcmPrimitive(p interface{}, key *gcmpb.AesGcmKey) error {
-  cipher := p.(*aes.AesGcm)
-  if !bytes.Equal(cipher.Key, key.KeyValue) {
-    return fmt.Errorf("key and primitive don't match")
-  }
-  // try to encrypt and decrypt
-  pt := random.GetRandomBytes(32)
-  aad := random.GetRandomBytes(32)
-  ct, err := cipher.Encrypt(pt, aad)
-  if err != nil {
-    return fmt.Errorf("encryption failed")
-  }
-  decrypted, err := cipher.Decrypt(ct, aad)
-  if err != nil {
-    return fmt.Errorf("decryption failed")
-  }
-  if !bytes.Equal(decrypted, pt) {
-    return fmt.Errorf("decryption failed")
-  }
-  return nil
+	cipher := p.(*aes.AesGcm)
+	if !bytes.Equal(cipher.Key, key.KeyValue) {
+		return fmt.Errorf("key and primitive don't match")
+	}
+	// try to encrypt and decrypt
+	pt := random.GetRandomBytes(32)
+	aad := random.GetRandomBytes(32)
+	ct, err := cipher.Encrypt(pt, aad)
+	if err != nil {
+		return fmt.Errorf("encryption failed")
+	}
+	decrypted, err := cipher.Decrypt(ct, aad)
+	if err != nil {
+		return fmt.Errorf("decryption failed")
+	}
+	if !bytes.Equal(decrypted, pt) {
+		return fmt.Errorf("decryption failed")
+	}
+	return nil
 }

--- a/go/mac/hmac_key_manager.go
+++ b/go/mac/hmac_key_manager.go
@@ -16,23 +16,23 @@
 package mac
 
 import (
-  "fmt"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/subtle/hmac"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/golang/protobuf/proto"
-  hmacpb "github.com/google/tink/proto/hmac_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/subtle/hmac"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/util"
+	hmacpb "github.com/google/tink/proto/hmac_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 const (
-  // Type url that this manager supports.
-  HMAC_TYPE_URL = "type.googleapis.com/google.crypto.tink.HmacKey"
+	// Type url that this manager supports.
+	HMAC_TYPE_URL = "type.googleapis.com/google.crypto.tink.HmacKey"
 
-  // Current version of this key manager.
-  // Keys with version equal or smaller are supported.
-  HMAC_KEY_VERSION = uint32(0)
+	// Current version of this key manager.
+	// Keys with version equal or smaller are supported.
+	HMAC_KEY_VERSION = uint32(0)
 )
 
 var errInvalidHmacKey = fmt.Errorf("hmac_key_manager: invalid key")
@@ -46,104 +46,104 @@ var _ tink.KeyManager = (*HmacKeyManager)(nil)
 
 // NewHmacKeyManager returns a new HmacKeyManager.
 func NewHmacKeyManager() *HmacKeyManager {
-  return new(HmacKeyManager)
+	return new(HmacKeyManager)
 }
 
 // GetPrimitiveFromSerializedKey constructs a Hmac instance for the given
 // serialized HmacKey.
 func (km *HmacKeyManager) GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error) {
-  if len(serializedKey) == 0 {
-    return nil, errInvalidHmacKey
-  }
-  key := new(hmacpb.HmacKey)
-  if err := proto.Unmarshal(serializedKey, key); err != nil {
-    return nil, errInvalidHmacKey
-  }
-  return km.GetPrimitiveFromKey(key)
+	if len(serializedKey) == 0 {
+		return nil, errInvalidHmacKey
+	}
+	key := new(hmacpb.HmacKey)
+	if err := proto.Unmarshal(serializedKey, key); err != nil {
+		return nil, errInvalidHmacKey
+	}
+	return km.GetPrimitiveFromKey(key)
 }
 
 // GetPrimitiveFromKey constructs a HMAC instance for the given HmacKey.
 func (km *HmacKeyManager) GetPrimitiveFromKey(m proto.Message) (interface{}, error) {
-  key, ok := m.(*hmacpb.HmacKey)
-  if !ok {
-    return nil, errInvalidHmacKey
-  }
-  if err := km.validateKey(key); err != nil {
-    return nil, err
-  }
-  hash := util.GetHashName(key.Params.Hash)
-  hmac, err := hmac.New(hash, key.KeyValue, key.Params.TagSize)
-  if err != nil {
-    return nil, err
-  }
-  return hmac, nil
+	key, ok := m.(*hmacpb.HmacKey)
+	if !ok {
+		return nil, errInvalidHmacKey
+	}
+	if err := km.validateKey(key); err != nil {
+		return nil, err
+	}
+	hash := util.GetHashName(key.Params.Hash)
+	hmac, err := hmac.New(hash, key.KeyValue, key.Params.TagSize)
+	if err != nil {
+		return nil, err
+	}
+	return hmac, nil
 }
 
 // NewKeyFromSerializedKeyFormat generates a new HmacKey according to specification
 // in the given serialized HmacKeyFormat.
 func (km *HmacKeyManager) NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error) {
-  if len(serializedKeyFormat) == 0 {
-    return nil, errInvalidHmacKeyFormat
-  }
-  keyFormat := new(hmacpb.HmacKeyFormat)
-  if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
-    return nil, errInvalidHmacKeyFormat
-  }
-  return km.NewKeyFromKeyFormat(keyFormat)
+	if len(serializedKeyFormat) == 0 {
+		return nil, errInvalidHmacKeyFormat
+	}
+	keyFormat := new(hmacpb.HmacKeyFormat)
+	if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
+		return nil, errInvalidHmacKeyFormat
+	}
+	return km.NewKeyFromKeyFormat(keyFormat)
 }
 
 // NewKeyFromKeyFormat generates a new HmacKey according to specification in
 // the given HmacKeyFormat.
 func (km *HmacKeyManager) NewKeyFromKeyFormat(m proto.Message) (proto.Message, error) {
-  keyFormat, ok := m.(*hmacpb.HmacKeyFormat)
-  if !ok {
-    return nil, errInvalidHmacKeyFormat
-  }
-  if err := km.validateKeyFormat(keyFormat); err != nil {
-    return nil, fmt.Errorf("hmac_key_manager: invalid key format: %s", err)
-  }
-  keyValue := random.GetRandomBytes(keyFormat.KeySize)
-  return util.NewHmacKey(keyFormat.Params, HMAC_KEY_VERSION, keyValue), nil
+	keyFormat, ok := m.(*hmacpb.HmacKeyFormat)
+	if !ok {
+		return nil, errInvalidHmacKeyFormat
+	}
+	if err := km.validateKeyFormat(keyFormat); err != nil {
+		return nil, fmt.Errorf("hmac_key_manager: invalid key format: %s", err)
+	}
+	keyValue := random.GetRandomBytes(keyFormat.KeySize)
+	return util.NewHmacKey(keyFormat.Params, HMAC_KEY_VERSION, keyValue), nil
 }
 
 // NewKeyData generates a new KeyData according to specification in the given
 // serialized HmacKeyFormat. This should be used solely by the key management API.
 func (km *HmacKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
-  key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
-  if err != nil {
-    return nil, err
-  }
-  serializedKey, err := proto.Marshal(key)
-  if err != nil {
-    return nil, errInvalidHmacKeyFormat
-  }
-  return util.NewKeyData(HMAC_TYPE_URL, serializedKey, tinkpb.KeyData_SYMMETRIC), nil
+	key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
+	if err != nil {
+		return nil, err
+	}
+	serializedKey, err := proto.Marshal(key)
+	if err != nil {
+		return nil, errInvalidHmacKeyFormat
+	}
+	return util.NewKeyData(HMAC_TYPE_URL, serializedKey, tinkpb.KeyData_SYMMETRIC), nil
 }
 
 // DoesSupport checks whether this KeyManager supports the given key type.
 func (_ *HmacKeyManager) DoesSupport(typeUrl string) bool {
-  return typeUrl == HMAC_TYPE_URL
+	return typeUrl == HMAC_TYPE_URL
 }
 
 // GetKeyType returns the type URL of keys managed by this KeyManager.
 func (_ *HmacKeyManager) GetKeyType() string {
-  return HMAC_TYPE_URL
+	return HMAC_TYPE_URL
 }
 
 // validateKey validates the given HmacKey. It only validates the version of the
 // key because other parameters will be validated in primitive construction.
 func (_ *HmacKeyManager) validateKey(key *hmacpb.HmacKey) error {
-  err := util.ValidateVersion(key.Version, HMAC_KEY_VERSION)
-  if err != nil {
-    return fmt.Errorf("hmac_key_manager: %s", err)
-  }
-  keySize := uint32(len(key.KeyValue))
-  hash := util.GetHashName(key.Params.Hash)
-  return hmac.ValidateParams(hash, keySize, key.Params.TagSize)
+	err := util.ValidateVersion(key.Version, HMAC_KEY_VERSION)
+	if err != nil {
+		return fmt.Errorf("hmac_key_manager: %s", err)
+	}
+	keySize := uint32(len(key.KeyValue))
+	hash := util.GetHashName(key.Params.Hash)
+	return hmac.ValidateParams(hash, keySize, key.Params.TagSize)
 }
 
 // validateKeyFormat validates the given HmacKeyFormat
 func (_ *HmacKeyManager) validateKeyFormat(format *hmacpb.HmacKeyFormat) error {
-  hash := util.GetHashName(format.Params.Hash)
-  return hmac.ValidateParams(hash, format.KeySize, format.Params.TagSize)
+	hash := util.GetHashName(format.Params.Hash)
+	return hmac.ValidateParams(hash, format.KeySize, format.Params.TagSize)
 }

--- a/go/mac/hmac_key_manager_test.go
+++ b/go/mac/hmac_key_manager_test.go
@@ -16,309 +16,309 @@
 package mac_test
 
 import (
-  "bytes"
-  "fmt"
-  "testing"
-  "reflect"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/google/tink/go/subtle/hmac"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/subtle/subtleutil"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/util/util"
-  "github.com/golang/protobuf/proto"
-  hmacpb "github.com/google/tink/proto/hmac_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"bytes"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/subtle/hmac"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	hmacpb "github.com/google/tink/proto/hmac_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"reflect"
+	"testing"
 )
 
 func TestGetPrimitiveBasic(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  testKeys := genValidHmacKeys()
-  for i := 0; i < len(testKeys); i++ {
-    key := testKeys[i]
-    p, err := km.GetPrimitiveFromKey(key)
-    if err != nil {
-      t.Errorf("unexpected error in test case %d: %s", i, err)
-    }
-    if err := validateHmacPrimitive(p.(*hmac.Hmac), key); err != nil {
-      t.Errorf("%s", err)
-    }
+	km := mac.NewHmacKeyManager()
+	testKeys := genValidHmacKeys()
+	for i := 0; i < len(testKeys); i++ {
+		key := testKeys[i]
+		p, err := km.GetPrimitiveFromKey(key)
+		if err != nil {
+			t.Errorf("unexpected error in test case %d: %s", i, err)
+		}
+		if err := validateHmacPrimitive(p.(*hmac.Hmac), key); err != nil {
+			t.Errorf("%s", err)
+		}
 
-    serializedKey, _ := proto.Marshal(testKeys[i])
-    p, err = km.GetPrimitiveFromSerializedKey(serializedKey)
-    if err != nil {
-      t.Errorf("unexpected error in test case %d: %s", i, err)
-    }
-    if err := validateHmacPrimitive(p.(*hmac.Hmac), key); err != nil {
-      t.Errorf("%s", err)
-    }
-  }
+		serializedKey, _ := proto.Marshal(testKeys[i])
+		p, err = km.GetPrimitiveFromSerializedKey(serializedKey)
+		if err != nil {
+			t.Errorf("unexpected error in test case %d: %s", i, err)
+		}
+		if err := validateHmacPrimitive(p.(*hmac.Hmac), key); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func TestGetPrimitiveWithInvalidInput(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  // invalid key
-  testKeys := genInvalidHmacKeys()
-  for i := 0; i < len(testKeys); i++ {
-    if _, err := km.GetPrimitiveFromKey(testKeys[i]); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-    serializedKey, _ := proto.Marshal(testKeys[i])
-    if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil
-  if _, err := km.GetPrimitiveFromKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty input
-  if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty")
-  }
+	km := mac.NewHmacKeyManager()
+	// invalid key
+	testKeys := genInvalidHmacKeys()
+	for i := 0; i < len(testKeys); i++ {
+		if _, err := km.GetPrimitiveFromKey(testKeys[i]); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+		serializedKey, _ := proto.Marshal(testKeys[i])
+		if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil
+	if _, err := km.GetPrimitiveFromKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty input
+	if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty")
+	}
 }
 
 func TestNewKeyMultipleTimes(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  format := testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32)
-  serializedFormat, _ := proto.Marshal(format)
-  keys := make(map[string]bool)
-  nTest := 26
-  for i := 0; i < nTest; i++ {
-    key, err := km.NewKeyFromSerializedKeyFormat(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    serializedKey, _ := proto.Marshal(key)
-    keys[string(serializedKey)] = true
+	km := mac.NewHmacKeyManager()
+	format := testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32)
+	serializedFormat, _ := proto.Marshal(format)
+	keys := make(map[string]bool)
+	nTest := 26
+	for i := 0; i < nTest; i++ {
+		key, err := km.NewKeyFromSerializedKeyFormat(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		serializedKey, _ := proto.Marshal(key)
+		keys[string(serializedKey)] = true
 
-    key, err = km.NewKeyFromKeyFormat(format)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    serializedKey, _ = proto.Marshal(key)
-    keys[string(serializedKey)] = true
+		key, err = km.NewKeyFromKeyFormat(format)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		serializedKey, _ = proto.Marshal(key)
+		keys[string(serializedKey)] = true
 
-    keyData, err := km.NewKeyData(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    keys[string(keyData.Value)] = true
-  }
-  if len(keys) != nTest*3 {
-    t.Errorf("key is repeated")
-  }
+		keyData, err := km.NewKeyData(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		keys[string(keyData.Value)] = true
+	}
+	if len(keys) != nTest*3 {
+		t.Errorf("key is repeated")
+	}
 }
 
 func TestNewKeyBasic(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  testFormats := genValidHmacKeyFormats()
-  for i := 0; i < len(testFormats); i++ {
-    format := testFormats[i]
-    key, err := km.NewKeyFromKeyFormat(format)
-    if err != nil {
-      t.Errorf("unexpected error in test case %d: %s", i, err)
-    }
-    if err := validateHmacKey(format, key.(*hmacpb.HmacKey)); err != nil {
-      t.Errorf("%s", err)
-    }
+	km := mac.NewHmacKeyManager()
+	testFormats := genValidHmacKeyFormats()
+	for i := 0; i < len(testFormats); i++ {
+		format := testFormats[i]
+		key, err := km.NewKeyFromKeyFormat(format)
+		if err != nil {
+			t.Errorf("unexpected error in test case %d: %s", i, err)
+		}
+		if err := validateHmacKey(format, key.(*hmacpb.HmacKey)); err != nil {
+			t.Errorf("%s", err)
+		}
 
-    serializedFormat, _ := proto.Marshal(format)
-    key, err = km.NewKeyFromSerializedKeyFormat(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error in test case %d: %s", i, err)
-    }
-    if err := validateHmacKey(format, key.(*hmacpb.HmacKey)); err != nil {
-      t.Errorf("%s", err)
-    }
-  }
+		serializedFormat, _ := proto.Marshal(format)
+		key, err = km.NewKeyFromSerializedKeyFormat(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error in test case %d: %s", i, err)
+		}
+		if err := validateHmacKey(format, key.(*hmacpb.HmacKey)); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func TestNewKeyWithInvalidInput(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  // invalid key formats
-  testFormats := genInvalidHmacKeyFormats()
-  for i := 0; i < len(testFormats); i++ {
-    format := testFormats[i]
-    if _, err := km.NewKeyFromKeyFormat(format); err == nil {
-      t.Errorf("expect an error in test case %d: %s", i, err)
-    }
+	km := mac.NewHmacKeyManager()
+	// invalid key formats
+	testFormats := genInvalidHmacKeyFormats()
+	for i := 0; i < len(testFormats); i++ {
+		format := testFormats[i]
+		if _, err := km.NewKeyFromKeyFormat(format); err == nil {
+			t.Errorf("expect an error in test case %d: %s", i, err)
+		}
 
-    serializedFormat, _ := proto.Marshal(format)
-    if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d: %s", i, err)
-    }
-  }
-  // nil
-  if _, err := km.NewKeyFromKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.NewKeyFromSerializedKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty input
-  if _, err := km.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty")
-  }
+		serializedFormat, _ := proto.Marshal(format)
+		if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d: %s", i, err)
+		}
+	}
+	// nil
+	if _, err := km.NewKeyFromKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.NewKeyFromSerializedKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty input
+	if _, err := km.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty")
+	}
 }
 
 func TestNewKeyDataBasic(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  testFormats := genValidHmacKeyFormats()
-  for i := 0; i < len(testFormats); i++ {
-    format := testFormats[i]
-    serializedFormat, _ := proto.Marshal(format)
-    keyData, err := km.NewKeyData(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error in test case %d: %s", i, err)
-    }
-    if keyData.TypeUrl != mac.HMAC_TYPE_URL {
-      t.Errorf("incorrect type url in test case %d", i)
-    }
-    if keyData.KeyMaterialType != tinkpb.KeyData_SYMMETRIC {
-      t.Errorf("incorrect key material type in test case %d", i)
-    }
-    key := new(hmacpb.HmacKey)
-    if err := proto.Unmarshal(keyData.Value, key); err != nil {
-      t.Errorf("invalid key value")
-    }
-    if err := validateHmacKey(format, key); err != nil {
-      t.Errorf("invalid key")
-    }
-  }
+	km := mac.NewHmacKeyManager()
+	testFormats := genValidHmacKeyFormats()
+	for i := 0; i < len(testFormats); i++ {
+		format := testFormats[i]
+		serializedFormat, _ := proto.Marshal(format)
+		keyData, err := km.NewKeyData(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error in test case %d: %s", i, err)
+		}
+		if keyData.TypeUrl != mac.HMAC_TYPE_URL {
+			t.Errorf("incorrect type url in test case %d", i)
+		}
+		if keyData.KeyMaterialType != tinkpb.KeyData_SYMMETRIC {
+			t.Errorf("incorrect key material type in test case %d", i)
+		}
+		key := new(hmacpb.HmacKey)
+		if err := proto.Unmarshal(keyData.Value, key); err != nil {
+			t.Errorf("invalid key value")
+		}
+		if err := validateHmacKey(format, key); err != nil {
+			t.Errorf("invalid key")
+		}
+	}
 }
 
 func TestNewKeyDataWithInvalidInput(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  // invalid key formats
-  testFormats := genInvalidHmacKeyFormats()
-  for i := 0; i < len(testFormats); i++ {
-    format := testFormats[i]
-    serializedFormat, _ := proto.Marshal(format)
-    if _, err := km.NewKeyData(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil input
-  if _, err := km.NewKeyData(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
+	km := mac.NewHmacKeyManager()
+	// invalid key formats
+	testFormats := genInvalidHmacKeyFormats()
+	for i := 0; i < len(testFormats); i++ {
+		format := testFormats[i]
+		serializedFormat, _ := proto.Marshal(format)
+		if _, err := km.NewKeyData(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil input
+	if _, err := km.NewKeyData(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
 }
 
 func TestDoesSupport(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  if !km.DoesSupport(mac.HMAC_TYPE_URL){
-    t.Errorf("HmacKeyManager must support %s", mac.HMAC_TYPE_URL)
-  }
-  if km.DoesSupport("some bad type") {
-    t.Errorf("HmacKeyManager must support only %s", mac.HMAC_TYPE_URL)
-  }
+	km := mac.NewHmacKeyManager()
+	if !km.DoesSupport(mac.HMAC_TYPE_URL) {
+		t.Errorf("HmacKeyManager must support %s", mac.HMAC_TYPE_URL)
+	}
+	if km.DoesSupport("some bad type") {
+		t.Errorf("HmacKeyManager must support only %s", mac.HMAC_TYPE_URL)
+	}
 }
 
 func TestGetKeyType(t *testing.T) {
-  km := mac.NewHmacKeyManager()
-  if km.GetKeyType() != mac.HMAC_TYPE_URL {
-    t.Errorf("incorrect GetKeyType()")
-  }
+	km := mac.NewHmacKeyManager()
+	if km.GetKeyType() != mac.HMAC_TYPE_URL {
+		t.Errorf("incorrect GetKeyType()")
+	}
 }
 
 func TestKeyManagerInterface(t *testing.T) {
-  // This line throws an error if Hmac doesn't implement KeyManager interface
-  var _ tink.KeyManager = (*mac.HmacKeyManager)(nil)
+	// This line throws an error if Hmac doesn't implement KeyManager interface
+	var _ tink.KeyManager = (*mac.HmacKeyManager)(nil)
 }
 
 func genInvalidHmacKeys() []proto.Message {
-  badVersionKey := testutil.NewHmacKey(commonpb.HashType_SHA256, 32)
-  badVersionKey.Version += 1
-  shortKey := testutil.NewHmacKey(commonpb.HashType_SHA256, 32)
-  shortKey.KeyValue = []byte{1, 1}
-  return []proto.Message{
-    // not a HmacKey
-    util.NewHmacParams(commonpb.HashType_SHA256, 32),
-    // bad version
-    badVersionKey,
-    // tag size too big
-    testutil.NewHmacKey(commonpb.HashType_SHA1, 21),
-    testutil.NewHmacKey(commonpb.HashType_SHA256, 33),
-    testutil.NewHmacKey(commonpb.HashType_SHA512, 65),
-    // tag size too small
-    testutil.NewHmacKey(commonpb.HashType_SHA256, 1),
-    // key too short
-    shortKey,
-    // unknown hash type
-    testutil.NewHmacKey(commonpb.HashType_UNKNOWN_HASH, 32),
-  }
+	badVersionKey := testutil.NewHmacKey(commonpb.HashType_SHA256, 32)
+	badVersionKey.Version += 1
+	shortKey := testutil.NewHmacKey(commonpb.HashType_SHA256, 32)
+	shortKey.KeyValue = []byte{1, 1}
+	return []proto.Message{
+		// not a HmacKey
+		util.NewHmacParams(commonpb.HashType_SHA256, 32),
+		// bad version
+		badVersionKey,
+		// tag size too big
+		testutil.NewHmacKey(commonpb.HashType_SHA1, 21),
+		testutil.NewHmacKey(commonpb.HashType_SHA256, 33),
+		testutil.NewHmacKey(commonpb.HashType_SHA512, 65),
+		// tag size too small
+		testutil.NewHmacKey(commonpb.HashType_SHA256, 1),
+		// key too short
+		shortKey,
+		// unknown hash type
+		testutil.NewHmacKey(commonpb.HashType_UNKNOWN_HASH, 32),
+	}
 }
 
 func genInvalidHmacKeyFormats() []proto.Message {
-  shortKeyFormat := testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32)
-  shortKeyFormat.KeySize = 1
-  return []proto.Message{
-    // not a HmacKeyFormat
-    util.NewHmacParams(commonpb.HashType_SHA256, 32),
-    // tag size too big
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA1, 21),
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 33),
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA512, 65),
-    // tag size too small
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 1),
-    // key too short
-    shortKeyFormat,
-    // unknown hash type
-    testutil.NewHmacKeyFormat(commonpb.HashType_UNKNOWN_HASH, 32),
-  }
+	shortKeyFormat := testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32)
+	shortKeyFormat.KeySize = 1
+	return []proto.Message{
+		// not a HmacKeyFormat
+		util.NewHmacParams(commonpb.HashType_SHA256, 32),
+		// tag size too big
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA1, 21),
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 33),
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA512, 65),
+		// tag size too small
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 1),
+		// key too short
+		shortKeyFormat,
+		// unknown hash type
+		testutil.NewHmacKeyFormat(commonpb.HashType_UNKNOWN_HASH, 32),
+	}
 }
 
 func genValidHmacKeyFormats() []*hmacpb.HmacKeyFormat {
-  return []*hmacpb.HmacKeyFormat{
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA1, 20),
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32),
-    testutil.NewHmacKeyFormat(commonpb.HashType_SHA512, 64),
-  }
+	return []*hmacpb.HmacKeyFormat{
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA1, 20),
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA256, 32),
+		testutil.NewHmacKeyFormat(commonpb.HashType_SHA512, 64),
+	}
 }
 
 func genValidHmacKeys() []*hmacpb.HmacKey {
-  return []*hmacpb.HmacKey{
-    testutil.NewHmacKey(commonpb.HashType_SHA1, 20),
-    testutil.NewHmacKey(commonpb.HashType_SHA256, 32),
-    testutil.NewHmacKey(commonpb.HashType_SHA512, 64),
-  }
+	return []*hmacpb.HmacKey{
+		testutil.NewHmacKey(commonpb.HashType_SHA1, 20),
+		testutil.NewHmacKey(commonpb.HashType_SHA256, 32),
+		testutil.NewHmacKey(commonpb.HashType_SHA512, 64),
+	}
 }
 
 // Checks whether the given HmacKey matches the given key HmacKeyFormat
 func validateHmacKey(format *hmacpb.HmacKeyFormat, key *hmacpb.HmacKey) error {
-  if format.KeySize != uint32(len(key.KeyValue)) ||
-      key.Params.TagSize != format.Params.TagSize ||
-      key.Params.Hash != format.Params.Hash {
-    return fmt.Errorf("key format and generated key do not match")
-  }
-  p, err := hmac.New(util.GetHashName(key.Params.Hash), key.KeyValue, key.Params.TagSize)
-  if err != nil {
-    return fmt.Errorf("cannot create primitive from key: %s", err)
-  }
-  return validateHmacPrimitive(p, key)
+	if format.KeySize != uint32(len(key.KeyValue)) ||
+		key.Params.TagSize != format.Params.TagSize ||
+		key.Params.Hash != format.Params.Hash {
+		return fmt.Errorf("key format and generated key do not match")
+	}
+	p, err := hmac.New(util.GetHashName(key.Params.Hash), key.KeyValue, key.Params.TagSize)
+	if err != nil {
+		return fmt.Errorf("cannot create primitive from key: %s", err)
+	}
+	return validateHmacPrimitive(p, key)
 }
 
 // validateHmacPrimitive checks whether the given primitive matches the given HmacKey
 func validateHmacPrimitive(p *hmac.Hmac, key *hmacpb.HmacKey) error {
-  if !bytes.Equal(p.Key, key.KeyValue) ||
-      p.TagSize != key.Params.TagSize ||
-      reflect.ValueOf(p.HashFunc).Pointer() !=
-        reflect.ValueOf(subtleutil.GetHashFunc(util.GetHashName(key.Params.Hash))).Pointer() {
-    return fmt.Errorf("primitive and key do not matched")
-  }
-  data := random.GetRandomBytes(20)
-  mac, err := p.ComputeMac(data)
-  if err != nil {
-    return fmt.Errorf("mac computation failed: %s", err)
-  }
-  if valid, err := p.VerifyMac(mac, data); !valid || err != nil {
-    return fmt.Errorf("mac verification failed: %s", err)
-  }
-  return nil
+	if !bytes.Equal(p.Key, key.KeyValue) ||
+		p.TagSize != key.Params.TagSize ||
+		reflect.ValueOf(p.HashFunc).Pointer() !=
+			reflect.ValueOf(subtleutil.GetHashFunc(util.GetHashName(key.Params.Hash))).Pointer() {
+		return fmt.Errorf("primitive and key do not matched")
+	}
+	data := random.GetRandomBytes(20)
+	mac, err := p.ComputeMac(data)
+	if err != nil {
+		return fmt.Errorf("mac computation failed: %s", err)
+	}
+	if valid, err := p.VerifyMac(mac, data); !valid || err != nil {
+		return fmt.Errorf("mac verification failed: %s", err)
+	}
+	return nil
 }

--- a/go/mac/mac_config.go
+++ b/go/mac/mac_config.go
@@ -16,8 +16,8 @@
 package mac
 
 import (
-  "sync"
-  "github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // Config offers convenience methods for initializing mac.Factory()
@@ -31,31 +31,32 @@ import (
 // This divison allows for gradual retiring insecure or obsolete key types.
 var configInstance *config
 var configOnce sync.Once
-type config struct {}
+
+type config struct{}
 
 // Config creates an instance of config if there isn't and returns the instance.
 func Config() *config {
-  configOnce.Do(func() {
-    configInstance = new(config)
-  })
-  return configInstance
+	configOnce.Do(func() {
+		configInstance = new(config)
+	})
+	return configInstance
 }
 
 // RegisterStandardKeyTypes registers standard Mac key types and their managers
 // with the Registry.
 func (c *config) RegisterStandardKeyTypes() (bool, error) {
-  return c.RegisterKeyManager(NewHmacKeyManager())
+	return c.RegisterKeyManager(NewHmacKeyManager())
 }
 
 // RegisterLegacyKeyTypes registers legacy Mac key types and their managers
 // with the Registry.
 func (c *config) RegisterLegacyKeyTypes() (bool, error) {
-  return false, nil
+	return false, nil
 }
 
 // RegisterKeyManager registers the given keyManager for the key type given in
 // keyManager.KeyType(). It returns true if registration was successful, false if
 // there already exisits a key manager for the key type.
 func (c *config) RegisterKeyManager(keyManager tink.KeyManager) (bool, error) {
-  return tink.Registry().RegisterKeyManager(keyManager)
+	return tink.Registry().RegisterKeyManager(keyManager)
 }

--- a/go/mac/mac_config_test.go
+++ b/go/mac/mac_config_test.go
@@ -16,19 +16,19 @@
 package mac_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/tink/tink"
+	"testing"
 )
 
 func TestRegistration(t *testing.T) {
-  success, err := mac.Config().RegisterStandardKeyTypes()
-  if !success || err != nil {
-    t.Errorf("cannot register standard key types")
-  }
-  keyManager, err := tink.Registry().GetKeyManager(mac.HMAC_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ = keyManager.(*mac.HmacKeyManager)
+	success, err := mac.Config().RegisterStandardKeyTypes()
+	if !success || err != nil {
+		t.Errorf("cannot register standard key types")
+	}
+	keyManager, err := tink.Registry().GetKeyManager(mac.HMAC_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ = keyManager.(*mac.HmacKeyManager)
 }

--- a/go/mac/mac_factory.go
+++ b/go/mac/mac_factory.go
@@ -16,9 +16,9 @@
 package mac
 
 import (
-  "fmt"
-  "sync"
-  "github.com/google/tink/go/tink/tink"
+	"fmt"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // Factory provides methods that allow obtaining a Mac primitive from a KeysetHandle.
@@ -32,37 +32,38 @@ import (
 // the primitive tries all keys with OutputPrefixType_RAW.
 var factoryInstance *factory
 var factoryOnce sync.Once
-type factory struct {}
+
+type factory struct{}
 
 // factory creates an instance of factory if there isn't and returns the instance.
 func Factory() *factory {
-  factoryOnce.Do(func() {
-    factoryInstance = new(factory)
-  })
-  return factoryInstance
+	factoryOnce.Do(func() {
+		factoryInstance = new(factory)
+	})
+	return factoryInstance
 }
 
 // GetPrimitive creates a Mac primitive from the given keyset handle.
 func (f *factory) GetPrimitive(handle *tink.KeysetHandle) (tink.Mac, error) {
-  return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
+	return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
 }
 
 // GetPrimitiveWithCustomerManager creates a Mac primitive from the given
 // keyset handle and a custom key manager.
 func (f *factory) GetPrimitiveWithCustomerManager(
-    handle *tink.KeysetHandle, manager tink.KeyManager) (tink.Mac, error) {
-  ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
-  if err != nil {
-    return nil, fmt.Errorf("mac_factory: cannot obtain primitive set: %s", err)
-  }
-  var mac tink.Mac = newPrimitiveSetMac(ps)
-  return mac, nil
+	handle *tink.KeysetHandle, manager tink.KeyManager) (tink.Mac, error) {
+	ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
+	if err != nil {
+		return nil, fmt.Errorf("mac_factory: cannot obtain primitive set: %s", err)
+	}
+	var mac tink.Mac = newPrimitiveSetMac(ps)
+	return mac, nil
 }
 
 // primitiveSetMac is a MAC implementation that uses the underlying primitive set to compute and
 // verify MACs.
 type primitiveSetMac struct {
-  ps *tink.PrimitiveSet
+	ps *tink.PrimitiveSet
 }
 
 // Asserts that primitiveSetMac implements the Mac interface.
@@ -71,24 +72,24 @@ var _ tink.Mac = (*primitiveSetMac)(nil)
 // newPrimitiveSetMac creates a new instance of primitiveSetMac using the given
 // primitive set.
 func newPrimitiveSetMac(ps *tink.PrimitiveSet) *primitiveSetMac {
-  ret := new(primitiveSetMac)
-  ret.ps = ps
-  return ret
+	ret := new(primitiveSetMac)
+	ret.ps = ps
+	return ret
 }
 
 // ComputeMac calculates a MAC over the given data using the primary primitive
 // and returns the concatenation of the primary's identifier and the calculated mac.
 func (m *primitiveSetMac) ComputeMac(data []byte) ([]byte, error) {
-  primary := m.ps.Primary()
-  var primitive tink.Mac = (primary.Primitive()).(tink.Mac)
-  mac, err := primitive.ComputeMac(data)
-  if err != nil {
-    return nil, err
-  }
-  var ret []byte
-  ret = append(ret, primary.Identifier()...)
-  ret = append(ret, mac...)
-  return ret, nil
+	primary := m.ps.Primary()
+	var primitive tink.Mac = (primary.Primitive()).(tink.Mac)
+	mac, err := primitive.ComputeMac(data)
+	if err != nil {
+		return nil, err
+	}
+	var ret []byte
+	ret = append(ret, primary.Identifier()...)
+	ret = append(ret, mac...)
+	return ret, nil
 }
 
 var errInvalidMac = fmt.Errorf("mac_factory: invalid mac")
@@ -96,36 +97,36 @@ var errInvalidMac = fmt.Errorf("mac_factory: invalid mac")
 // VerifyMac verifies whether the given mac is a correct authentication code
 // for the given data.
 func (m *primitiveSetMac) VerifyMac(mac []byte, data []byte) (bool, error) {
-  // This also rejects raw MAC with size of 4 bytes or fewer. Those MACs are
-  // clearly insecure, thus should be discouraged.
-  prefixSize := tink.NON_RAW_PREFIX_SIZE
-  if len(mac) <= prefixSize {
-    return false, errInvalidMac
-  }
-  // try non raw keys
-  prefix := mac[:prefixSize]
-  macNoPrefix := mac[prefixSize:]
-  entries, err := m.ps.GetPrimitivesWithByteIdentifier(prefix)
-  if err == nil {
-    for i := 0; i < len(entries); i++ {
-      var p tink.Mac = (entries[i].Primitive()).(tink.Mac)
-      valid, err := p.VerifyMac(macNoPrefix, data)
-      if err == nil && valid {
-        return true, nil
-      }
-    }
-  }
-  // try raw keys
-  entries, err = m.ps.GetRawPrimitives()
-  if err == nil {
-    for i := 0; i < len(entries); i++ {
-      var p tink.Mac = (entries[i].Primitive()).(tink.Mac)
-      valid, err := p.VerifyMac(mac, data)
-      if err == nil && valid {
-        return true, nil
-      }
-    }
-  }
-  // nothing worked
-  return false, errInvalidMac
+	// This also rejects raw MAC with size of 4 bytes or fewer. Those MACs are
+	// clearly insecure, thus should be discouraged.
+	prefixSize := tink.NON_RAW_PREFIX_SIZE
+	if len(mac) <= prefixSize {
+		return false, errInvalidMac
+	}
+	// try non raw keys
+	prefix := mac[:prefixSize]
+	macNoPrefix := mac[prefixSize:]
+	entries, err := m.ps.GetPrimitivesWithByteIdentifier(prefix)
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			var p tink.Mac = (entries[i].Primitive()).(tink.Mac)
+			valid, err := p.VerifyMac(macNoPrefix, data)
+			if err == nil && valid {
+				return true, nil
+			}
+		}
+	}
+	// try raw keys
+	entries, err = m.ps.GetRawPrimitives()
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			var p tink.Mac = (entries[i].Primitive()).(tink.Mac)
+			valid, err := p.VerifyMac(mac, data)
+			if err == nil && valid {
+				return true, nil
+			}
+		}
+	}
+	// nothing worked
+	return false, errInvalidMac
 }

--- a/go/mac/mac_factory_test.go
+++ b/go/mac/mac_factory_test.go
@@ -16,118 +16,118 @@
 package mac_test
 
 import (
-  "fmt"
-  "testing"
-  "strings"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/mac/mac"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"strings"
+	"testing"
 )
 
 func TestFactoryMultipleKeys(t *testing.T) {
-  tagSize := uint32(16)
-  keyset := testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_TINK)
-  primaryKey := keyset.Key[0]
-  if primaryKey.OutputPrefixType != tinkpb.OutputPrefixType_TINK {
-    t.Errorf("expect a tink key")
-  }
-  keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	tagSize := uint32(16)
+	keyset := testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_TINK)
+	primaryKey := keyset.Key[0]
+	if primaryKey.OutputPrefixType != tinkpb.OutputPrefixType_TINK {
+		t.Errorf("expect a tink key")
+	}
+	keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
 
-  p, err := mac.Factory().GetPrimitive(keysetHandle)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  expectedPrefix, _ := tink.GetOutputPrefix(primaryKey)
-  if err := verifyMacPrimitive(p, p, expectedPrefix, tagSize); err != nil {
-    t.Errorf("invalid primitive: %s", err)
-  }
+	p, err := mac.Factory().GetPrimitive(keysetHandle)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	expectedPrefix, _ := tink.GetOutputPrefix(primaryKey)
+	if err := verifyMacPrimitive(p, p, expectedPrefix, tagSize); err != nil {
+		t.Errorf("invalid primitive: %s", err)
+	}
 
-  // mac with a primary RAW key, verify with the keyset
-  rawKey := keyset.Key[1]
-  if rawKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
-    t.Errorf("expect a raw key")
-  }
-  keyset2 := util.NewKeyset(rawKey.KeyId, []*tinkpb.Keyset_Key{rawKey})
-  keysetHandle2, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset2)
-  p2, err := mac.Factory().GetPrimitive(keysetHandle2)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  if err := verifyMacPrimitive(p2, p, tink.RAW_PREFIX, tagSize); err != nil {
-    t.Errorf("invalid primitive: %s", err)
-  }
+	// mac with a primary RAW key, verify with the keyset
+	rawKey := keyset.Key[1]
+	if rawKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
+		t.Errorf("expect a raw key")
+	}
+	keyset2 := util.NewKeyset(rawKey.KeyId, []*tinkpb.Keyset_Key{rawKey})
+	keysetHandle2, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset2)
+	p2, err := mac.Factory().GetPrimitive(keysetHandle2)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	if err := verifyMacPrimitive(p2, p, tink.RAW_PREFIX, tagSize); err != nil {
+		t.Errorf("invalid primitive: %s", err)
+	}
 
-  // mac with a random key not in the keyset, verify with the keyset should fail
-  keyset2 = testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_TINK)
-  primaryKey = keyset2.Key[0]
-  expectedPrefix, _ = tink.GetOutputPrefix(primaryKey)
-  keysetHandle2, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset2)
-  p2, err = mac.Factory().GetPrimitive(keysetHandle2)
-  if err != nil {
-    t.Errorf("cannot get primitive from keyset handle")
-  }
-  err = verifyMacPrimitive(p2, p, expectedPrefix, tagSize)
-  if err == nil || !strings.Contains(err.Error(), "mac verification failed") {
-    t.Errorf("Invalid MAC, shouldn't return valid")
-  }
+	// mac with a random key not in the keyset, verify with the keyset should fail
+	keyset2 = testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_TINK)
+	primaryKey = keyset2.Key[0]
+	expectedPrefix, _ = tink.GetOutputPrefix(primaryKey)
+	keysetHandle2, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset2)
+	p2, err = mac.Factory().GetPrimitive(keysetHandle2)
+	if err != nil {
+		t.Errorf("cannot get primitive from keyset handle")
+	}
+	err = verifyMacPrimitive(p2, p, expectedPrefix, tagSize)
+	if err == nil || !strings.Contains(err.Error(), "mac verification failed") {
+		t.Errorf("Invalid MAC, shouldn't return valid")
+	}
 }
 
 func TestFactoryRawKey(t *testing.T) {
-  tagSize := uint32(16)
-  keyset := testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_RAW)
-  primaryKey := keyset.Key[0]
-  if primaryKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
-    t.Errorf("expect a raw key")
-  }
-  keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  p, err := mac.Factory().GetPrimitive(keysetHandle)
-  if err != nil {
-    t.Errorf("GetPrimitive failed: %s", err)
-  }
-  if err := verifyMacPrimitive(p, p, tink.RAW_PREFIX, tagSize); err != nil {
-    t.Errorf("invalid primitive: %s", err)
-  }
+	tagSize := uint32(16)
+	keyset := testutil.NewTestHmacKeyset(tagSize, tinkpb.OutputPrefixType_RAW)
+	primaryKey := keyset.Key[0]
+	if primaryKey.OutputPrefixType != tinkpb.OutputPrefixType_RAW {
+		t.Errorf("expect a raw key")
+	}
+	keysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	p, err := mac.Factory().GetPrimitive(keysetHandle)
+	if err != nil {
+		t.Errorf("GetPrimitive failed: %s", err)
+	}
+	if err := verifyMacPrimitive(p, p, tink.RAW_PREFIX, tagSize); err != nil {
+		t.Errorf("invalid primitive: %s", err)
+	}
 }
 
 func verifyMacPrimitive(computePrimitive tink.Mac, verifyPrimitive tink.Mac,
-                        expectedPrefix string, tagSize uint32) error {
-  data := []byte("hello")
-  tag, err := computePrimitive.ComputeMac(data);
-  if err != nil {
-    return fmt.Errorf("mac computation failed: %s", err)
-  }
-  prefixSize := len(expectedPrefix)
-  if string(tag[:prefixSize]) != expectedPrefix {
-    return fmt.Errorf("incorrect prefix")
-  }
-  if prefixSize+int(tagSize) != len(tag) {
-    return fmt.Errorf("incorrect tag length")
-  }
-  valid, err := verifyPrimitive.VerifyMac(tag, data)
-  if !valid || err != nil {
-    return fmt.Errorf("mac verification failed: %s", err)
-  }
+	expectedPrefix string, tagSize uint32) error {
+	data := []byte("hello")
+	tag, err := computePrimitive.ComputeMac(data)
+	if err != nil {
+		return fmt.Errorf("mac computation failed: %s", err)
+	}
+	prefixSize := len(expectedPrefix)
+	if string(tag[:prefixSize]) != expectedPrefix {
+		return fmt.Errorf("incorrect prefix")
+	}
+	if prefixSize+int(tagSize) != len(tag) {
+		return fmt.Errorf("incorrect tag length")
+	}
+	valid, err := verifyPrimitive.VerifyMac(tag, data)
+	if !valid || err != nil {
+		return fmt.Errorf("mac verification failed: %s", err)
+	}
 
-  // Modify plaintext or tag and make sure VerifyMac failed.
-  var dataAndTag []byte
-  dataAndTag = append(dataAndTag, data...)
-  dataAndTag = append(dataAndTag, tag...)
-  valid, err = verifyPrimitive.VerifyMac(dataAndTag[len(data):], dataAndTag[:len(data)])
-  if !valid || err != nil {
-    return fmt.Errorf("mac verification failed: %s", err)
-  }
-  for i := 0; i < len(dataAndTag); i++ {
-    tmp := dataAndTag[i]
-    for j := 0; j < 8; j++ {
-      dataAndTag[i] ^= 1 << uint8(j)
-      valid, err = verifyPrimitive.VerifyMac(dataAndTag[len(data):], dataAndTag[:len(data)])
-      if valid && err == nil {
-        return fmt.Errorf("invalid tag or plaintext, mac should be invalid")
-      }
-      dataAndTag[i] = tmp
-    }
-  }
-  return nil
+	// Modify plaintext or tag and make sure VerifyMac failed.
+	var dataAndTag []byte
+	dataAndTag = append(dataAndTag, data...)
+	dataAndTag = append(dataAndTag, tag...)
+	valid, err = verifyPrimitive.VerifyMac(dataAndTag[len(data):], dataAndTag[:len(data)])
+	if !valid || err != nil {
+		return fmt.Errorf("mac verification failed: %s", err)
+	}
+	for i := 0; i < len(dataAndTag); i++ {
+		tmp := dataAndTag[i]
+		for j := 0; j < 8; j++ {
+			dataAndTag[i] ^= 1 << uint8(j)
+			valid, err = verifyPrimitive.VerifyMac(dataAndTag[len(data):], dataAndTag[:len(data)])
+			if valid && err == nil {
+				return fmt.Errorf("invalid tag or plaintext, mac should be invalid")
+			}
+			dataAndTag[i] = tmp
+		}
+	}
+	return nil
 }

--- a/go/mac/mac_key_templates.go
+++ b/go/mac/mac_key_templates.go
@@ -16,10 +16,10 @@
 package mac
 
 import (
-  "github.com/golang/protobuf/proto"
-  hmacpb "github.com/google/tink/proto/hmac_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"github.com/golang/protobuf/proto"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	hmacpb "github.com/google/tink/proto/hmac_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // This file contains pre-generated KeyTemplate for MAC.
@@ -30,7 +30,7 @@ import (
 //   - Tag size: 16 bytes
 //   - Hash function: SHA256
 func HmacSha256Tag128KeyTemplate() *tinkpb.KeyTemplate {
-  return createHmacKeyTemplate(32, 16, commonpb.HashType_SHA256)
+	return createHmacKeyTemplate(32, 16, commonpb.HashType_SHA256)
 }
 
 // HmacSha256Tag256KeyTemplate is a KeyTemplate for HmacKey with the following
@@ -39,24 +39,24 @@ func HmacSha256Tag128KeyTemplate() *tinkpb.KeyTemplate {
 //   - Tag size: 32 bytes
 //   - Hash function: SHA256
 func HmacSha256Tag256KeyTemplate() *tinkpb.KeyTemplate {
-  return createHmacKeyTemplate(32, 32, commonpb.HashType_SHA256)
+	return createHmacKeyTemplate(32, 32, commonpb.HashType_SHA256)
 }
 
 // createHmacKeyTemplate creates a new KeyTemplate for Hmac using the given parameters.
 func createHmacKeyTemplate(keySize uint32,
-                          tagSize uint32,
-                          hashType commonpb.HashType) *tinkpb.KeyTemplate {
-  params := hmacpb.HmacParams{
-    Hash: hashType,
-    TagSize: tagSize,
-  }
-  format := hmacpb.HmacKeyFormat{
-    Params: &params,
-    KeySize: keySize,
-  }
-  serializedFormat, _ := proto.Marshal(&format)
-  return &tinkpb.KeyTemplate{
-    TypeUrl: HMAC_TYPE_URL,
-    Value: serializedFormat,
-  }
+	tagSize uint32,
+	hashType commonpb.HashType) *tinkpb.KeyTemplate {
+	params := hmacpb.HmacParams{
+		Hash:    hashType,
+		TagSize: tagSize,
+	}
+	format := hmacpb.HmacKeyFormat{
+		Params:  &params,
+		KeySize: keySize,
+	}
+	serializedFormat, _ := proto.Marshal(&format)
+	return &tinkpb.KeyTemplate{
+		TypeUrl: HMAC_TYPE_URL,
+		Value:   serializedFormat,
+	}
 }

--- a/go/mac/mac_key_templates_test.go
+++ b/go/mac/mac_key_templates_test.go
@@ -16,41 +16,41 @@
 package mac_test
 
 import (
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/golang/protobuf/proto"
-  hmacpb "github.com/google/tink/proto/hmac_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/mac/mac"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	hmacpb "github.com/google/tink/proto/hmac_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestTemplates(t *testing.T) {
-  template := mac.HmacSha256Tag128KeyTemplate()
-  if err := checkTemplate(template, 32, 16, commonpb.HashType_SHA256); err != nil {
-    t.Errorf("incorrect HmacSha256Tag128KeyTemplate: %s", err)
-  }
-  template = mac.HmacSha256Tag256KeyTemplate()
-  if err := checkTemplate(template, 32, 32, commonpb.HashType_SHA256); err != nil {
-    t.Errorf("incorrect HmacSha256Tag256KeyTemplate: %s", err)
-  }
+	template := mac.HmacSha256Tag128KeyTemplate()
+	if err := checkTemplate(template, 32, 16, commonpb.HashType_SHA256); err != nil {
+		t.Errorf("incorrect HmacSha256Tag128KeyTemplate: %s", err)
+	}
+	template = mac.HmacSha256Tag256KeyTemplate()
+	if err := checkTemplate(template, 32, 32, commonpb.HashType_SHA256); err != nil {
+		t.Errorf("incorrect HmacSha256Tag256KeyTemplate: %s", err)
+	}
 }
 
 func checkTemplate(template *tinkpb.KeyTemplate,
-                  keySize uint32,
-                  tagSize uint32,
-                  hashType commonpb.HashType) error {
-  if template.TypeUrl != mac.HMAC_TYPE_URL {
-    return fmt.Errorf("TypeUrl is incorrect")
-  }
-  format := new(hmacpb.HmacKeyFormat)
-  if err := proto.Unmarshal(template.Value, format); err != nil {
-    return fmt.Errorf("unable to unmarshal serialized key format")
-  }
-  if format.KeySize != keySize ||
-      format.Params.Hash != hashType ||
-      format.Params.TagSize != tagSize {
-    return fmt.Errorf("KeyFormat is incorrect")
-  }
-  return nil
+	keySize uint32,
+	tagSize uint32,
+	hashType commonpb.HashType) error {
+	if template.TypeUrl != mac.HMAC_TYPE_URL {
+		return fmt.Errorf("TypeUrl is incorrect")
+	}
+	format := new(hmacpb.HmacKeyFormat)
+	if err := proto.Unmarshal(template.Value, format); err != nil {
+		return fmt.Errorf("unable to unmarshal serialized key format")
+	}
+	if format.KeySize != keySize ||
+		format.Params.Hash != hashType ||
+		format.Params.TagSize != tagSize {
+		return fmt.Errorf("KeyFormat is incorrect")
+	}
+	return nil
 }

--- a/go/signature/ecdsa_sign_key_manager.go
+++ b/go/signature/ecdsa_sign_key_manager.go
@@ -16,24 +16,24 @@
 package signature
 
 import (
-  "fmt"
-  "crypto/ecdsa"
-  "crypto/rand"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/subtle/subtleutil"
-  subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/golang/protobuf/proto"
-  ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/util"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 const (
-  // Supported version
-  ECDSA_SIGN_KEY_VERSION = 0
+	// Supported version
+	ECDSA_SIGN_KEY_VERSION = 0
 
-  // Supported type url
-  ECDSA_SIGN_TYPE_URL = "type.googleapis.com/google.crypto.tink.EcdsaPrivateKey"
+	// Supported type url
+	ECDSA_SIGN_TYPE_URL = "type.googleapis.com/google.crypto.tink.EcdsaPrivateKey"
 )
 
 // common errors
@@ -42,135 +42,135 @@ var errInvalidEcdsaSignKeyFormat = fmt.Errorf("ecdsa_sign_key_manager: invalid k
 
 // EcdsaSignKeyManager is an implementation of KeyManager interface.
 // It generates new EcdsaPrivateKeys and produces new instances of EcdsaSign subtle.
-type EcdsaSignKeyManager struct {}
+type EcdsaSignKeyManager struct{}
 
 // Assert that EcdsaSignKeyManager implements the PrivateKeyManager interface.
 var _ tink.PrivateKeyManager = (*EcdsaSignKeyManager)(nil)
 
 // NewEcdsaSignKeyManager creates a new EcdsaSignKeyManager.
 func NewEcdsaSignKeyManager() *EcdsaSignKeyManager {
-  return new(EcdsaSignKeyManager)
+	return new(EcdsaSignKeyManager)
 }
 
 // GetPrimitiveFromSerializedKey creates an EcdsaSign subtle for the given
 // serialized EcdsaPrivateKey proto.
 func (km *EcdsaSignKeyManager) GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error) {
-  if len(serializedKey) == 0 {
-    return nil, errInvalidEcdsaSignKey
-  }
-  key := new(ecdsapb.EcdsaPrivateKey)
-  if err := proto.Unmarshal(serializedKey, key); err != nil {
-    return nil, errInvalidEcdsaSignKey
-  }
-  return km.GetPrimitiveFromKey(key)
+	if len(serializedKey) == 0 {
+		return nil, errInvalidEcdsaSignKey
+	}
+	key := new(ecdsapb.EcdsaPrivateKey)
+	if err := proto.Unmarshal(serializedKey, key); err != nil {
+		return nil, errInvalidEcdsaSignKey
+	}
+	return km.GetPrimitiveFromKey(key)
 }
 
 // GetPrimitiveFromKey creates an EcdsaSign subtle for the given EcdsaPrivateKey proto.
 func (km *EcdsaSignKeyManager) GetPrimitiveFromKey(m proto.Message) (interface{}, error) {
-  key, ok := m.(*ecdsapb.EcdsaPrivateKey)
-  if !ok {
-    return nil, errInvalidEcdsaSignKey
-  }
-  if err := km.validateKey(key); err != nil {
-    return nil, err
-  }
-  hash, curve, encoding := util.GetEcdsaParamNames(key.PublicKey.Params)
-  ret, err := subtleEcdsa.NewEcdsaSign(hash, curve, encoding, key.KeyValue)
-  if err != nil {
-    return nil, fmt.Errorf("ecdsa_sign_key_manager: %s", err)
-  }
-  return ret, nil
+	key, ok := m.(*ecdsapb.EcdsaPrivateKey)
+	if !ok {
+		return nil, errInvalidEcdsaSignKey
+	}
+	if err := km.validateKey(key); err != nil {
+		return nil, err
+	}
+	hash, curve, encoding := util.GetEcdsaParamNames(key.PublicKey.Params)
+	ret, err := subtleEcdsa.NewEcdsaSign(hash, curve, encoding, key.KeyValue)
+	if err != nil {
+		return nil, fmt.Errorf("ecdsa_sign_key_manager: %s", err)
+	}
+	return ret, nil
 }
 
 // NewKeyFromSerializedKeyFormat creates a new EcdsaPrivateKey according to specification
 // the given serialized EcdsaKeyFormat.
 func (km *EcdsaSignKeyManager) NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error) {
-  if len(serializedKeyFormat) == 0 {
-    return nil, errInvalidEcdsaSignKeyFormat
-  }
-  keyFormat := new(ecdsapb.EcdsaKeyFormat)
-  if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
-    return nil, fmt.Errorf("ecdsa_sign_key_manager: invalid key format: %s", err)
-  }
-  return km.NewKeyFromKeyFormat(keyFormat)
+	if len(serializedKeyFormat) == 0 {
+		return nil, errInvalidEcdsaSignKeyFormat
+	}
+	keyFormat := new(ecdsapb.EcdsaKeyFormat)
+	if err := proto.Unmarshal(serializedKeyFormat, keyFormat); err != nil {
+		return nil, fmt.Errorf("ecdsa_sign_key_manager: invalid key format: %s", err)
+	}
+	return km.NewKeyFromKeyFormat(keyFormat)
 }
 
 // NewKeyFromKeyFormat creates a new key according to specification in the
 // given EcdsaKeyFormat.
 func (km *EcdsaSignKeyManager) NewKeyFromKeyFormat(m proto.Message) (proto.Message, error) {
-  format, ok := m.(*ecdsapb.EcdsaKeyFormat)
-  if !ok {
-    return nil, errInvalidEcdsaSignKeyFormat
-  }
-  if err := km.validateKeyFormat(format); err != nil {
-    return nil, fmt.Errorf("ecdsa_sign_key_manager: %s", err)
-  }
-  // generate key
-  params := format.Params
-  curve := util.GetCurveName(params.Curve)
-  tmpKey, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curve), rand.Reader)
-  keyValue := tmpKey.D.Bytes()
-  pub := util.NewEcdsaPublicKey(ECDSA_SIGN_KEY_VERSION, params, tmpKey.X.Bytes(), tmpKey.Y.Bytes())
-  priv := util.NewEcdsaPrivateKey(ECDSA_SIGN_KEY_VERSION, pub, keyValue)
-  return priv, nil
+	format, ok := m.(*ecdsapb.EcdsaKeyFormat)
+	if !ok {
+		return nil, errInvalidEcdsaSignKeyFormat
+	}
+	if err := km.validateKeyFormat(format); err != nil {
+		return nil, fmt.Errorf("ecdsa_sign_key_manager: %s", err)
+	}
+	// generate key
+	params := format.Params
+	curve := util.GetCurveName(params.Curve)
+	tmpKey, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curve), rand.Reader)
+	keyValue := tmpKey.D.Bytes()
+	pub := util.NewEcdsaPublicKey(ECDSA_SIGN_KEY_VERSION, params, tmpKey.X.Bytes(), tmpKey.Y.Bytes())
+	priv := util.NewEcdsaPrivateKey(ECDSA_SIGN_KEY_VERSION, pub, keyValue)
+	return priv, nil
 }
 
 // NewKeyData creates a new KeyData according to specification in  the given
 // serialized EcdsaKeyFormat. It should be used solely by the key management API.
 func (km *EcdsaSignKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
-  key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
-  if err != nil {
-    return nil, err
-  }
-  serializedKey, err := proto.Marshal(key)
-  if err != nil {
-    return nil, errInvalidEcdsaSignKeyFormat
-  }
-  return &tinkpb.KeyData{
-    TypeUrl: ECDSA_SIGN_TYPE_URL,
-    Value: serializedKey,
-    KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PRIVATE,
-  }, nil
+	key, err := km.NewKeyFromSerializedKeyFormat(serializedKeyFormat)
+	if err != nil {
+		return nil, err
+	}
+	serializedKey, err := proto.Marshal(key)
+	if err != nil {
+		return nil, errInvalidEcdsaSignKeyFormat
+	}
+	return &tinkpb.KeyData{
+		TypeUrl:         ECDSA_SIGN_TYPE_URL,
+		Value:           serializedKey,
+		KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PRIVATE,
+	}, nil
 }
 
 // GetPublicKeyData extracts the public key data from the private key.
 func (km *EcdsaSignKeyManager) GetPublicKeyData(serializedPrivKey []byte) (*tinkpb.KeyData, error) {
-  privKey := new(ecdsapb.EcdsaPrivateKey)
-  if err := proto.Unmarshal(serializedPrivKey, privKey); err != nil {
-    return nil, errInvalidEcdsaSignKey
-  }
-  serializedPubKey, err := proto.Marshal(privKey.PublicKey)
-  if err != nil {
-    return nil, errInvalidEcdsaSignKey
-  }
-  return &tinkpb.KeyData{
-    TypeUrl: ECDSA_VERIFY_TYPE_URL,
-    Value: serializedPubKey,
-    KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PUBLIC,
-  }, nil
+	privKey := new(ecdsapb.EcdsaPrivateKey)
+	if err := proto.Unmarshal(serializedPrivKey, privKey); err != nil {
+		return nil, errInvalidEcdsaSignKey
+	}
+	serializedPubKey, err := proto.Marshal(privKey.PublicKey)
+	if err != nil {
+		return nil, errInvalidEcdsaSignKey
+	}
+	return &tinkpb.KeyData{
+		TypeUrl:         ECDSA_VERIFY_TYPE_URL,
+		Value:           serializedPubKey,
+		KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PUBLIC,
+	}, nil
 }
 
 // DoesSupport indicates if this key manager supports the given key type.
 func (_ *EcdsaSignKeyManager) DoesSupport(typeUrl string) bool {
-  return typeUrl == ECDSA_SIGN_TYPE_URL
+	return typeUrl == ECDSA_SIGN_TYPE_URL
 }
 
 // GetKeyType returns the key type of keys managed by this key manager.
 func (_ *EcdsaSignKeyManager) GetKeyType() string {
-  return ECDSA_SIGN_TYPE_URL
+	return ECDSA_SIGN_TYPE_URL
 }
 
 // validateKey validates the given EcdsaPrivateKey.
 func (_ *EcdsaSignKeyManager) validateKey(key *ecdsapb.EcdsaPrivateKey) error {
-  if err := util.ValidateVersion(key.Version, ECDSA_SIGN_KEY_VERSION); err != nil {
-    return fmt.Errorf("ecdsa_sign_key_manager: %s", err)
-  }
-  hash, curve, encoding := util.GetEcdsaParamNames(key.PublicKey.Params)
-  return subtleEcdsa.ValidateParams(hash, curve, encoding)
+	if err := util.ValidateVersion(key.Version, ECDSA_SIGN_KEY_VERSION); err != nil {
+		return fmt.Errorf("ecdsa_sign_key_manager: %s", err)
+	}
+	hash, curve, encoding := util.GetEcdsaParamNames(key.PublicKey.Params)
+	return subtleEcdsa.ValidateParams(hash, curve, encoding)
 }
 
 // validateKeyFormat validates the given EcdsaKeyFormat.
 func (_ *EcdsaSignKeyManager) validateKeyFormat(format *ecdsapb.EcdsaKeyFormat) error {
-  hash, curve, encoding := util.GetEcdsaParamNames(format.Params)
-  return subtleEcdsa.ValidateParams(hash, curve, encoding)
+	hash, curve, encoding := util.GetEcdsaParamNames(format.Params)
+	return subtleEcdsa.ValidateParams(hash, curve, encoding)
 }

--- a/go/signature/ecdsa_sign_key_manager_test.go
+++ b/go/signature/ecdsa_sign_key_manager_test.go
@@ -16,378 +16,378 @@
 package signature_test
 
 import (
-  "fmt"
-  "testing"
-  "math/big"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/golang/protobuf/proto"
-  ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"math/big"
+	"testing"
 )
 
 type ecdsaParams struct {
-  hashType commonpb.HashType
-  curve commonpb.EllipticCurveType
+	hashType commonpb.HashType
+	curve    commonpb.EllipticCurveType
 }
 
 func TestNewEcdsaSignKeyManager(t *testing.T) {
-  var km *signature.EcdsaSignKeyManager = signature.NewEcdsaSignKeyManager()
-  if km == nil {
-    t.Errorf("NewEcdsaSignKeyManager returns nil")
-  }
+	var km *signature.EcdsaSignKeyManager = signature.NewEcdsaSignKeyManager()
+	if km == nil {
+		t.Errorf("NewEcdsaSignKeyManager returns nil")
+	}
 }
 
 func TestEcdsaSignGetPrimitiveBasic(t *testing.T) {
-  testParams := genValidEcdsaParams()
-  km := signature.NewEcdsaSignKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
-    tmp, err := km.GetPrimitiveFromKey(key)
-    if err != nil {
-      t.Errorf("unexpect error in test case %d: %s ", i, err)
-    }
-    var _ *ecdsa.EcdsaSign = tmp.(*ecdsa.EcdsaSign)
+	testParams := genValidEcdsaParams()
+	km := signature.NewEcdsaSignKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
+		tmp, err := km.GetPrimitiveFromKey(key)
+		if err != nil {
+			t.Errorf("unexpect error in test case %d: %s ", i, err)
+		}
+		var _ *ecdsa.EcdsaSign = tmp.(*ecdsa.EcdsaSign)
 
-    serializedKey, _ := proto.Marshal(key)
-    tmp, err = km.GetPrimitiveFromSerializedKey(serializedKey)
-    if err != nil {
-      t.Errorf("unexpect error in test case %d: %s ", i, err)
-    }
-    var _ *ecdsa.EcdsaSign = tmp.(*ecdsa.EcdsaSign)
-  }
+		serializedKey, _ := proto.Marshal(key)
+		tmp, err = km.GetPrimitiveFromSerializedKey(serializedKey)
+		if err != nil {
+			t.Errorf("unexpect error in test case %d: %s ", i, err)
+		}
+		var _ *ecdsa.EcdsaSign = tmp.(*ecdsa.EcdsaSign)
+	}
 }
 
 func TestEcdsaSignGetPrimitiveWithInvalidInput(t *testing.T) {
-  // invalid params
-  testParams := genInvalidEcdsaParams()
-  km := signature.NewEcdsaSignKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
-    if _, err := km.GetPrimitiveFromKey(key); err == nil {
-      t.Errorf("expect an error in test case %d")
-    }
-    serializedKey, _ := proto.Marshal(key)
-    if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
-      t.Errorf("expect an error in test case %d")
-    }
-  }
-  // invalid version
-  key := testutil.NewEcdsaPrivateKey(commonpb.HashType_SHA256,
-                                      commonpb.EllipticCurveType_NIST_P256)
-  key.Version = signature.ECDSA_SIGN_KEY_VERSION + 1
-  if _, err := km.GetPrimitiveFromKey(key); err == nil {
-    t.Errorf("expect an error when version is invalid")
-  }
-  // nil input
-  if _, err := km.GetPrimitiveFromKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty slice")
-  }
+	// invalid params
+	testParams := genInvalidEcdsaParams()
+	km := signature.NewEcdsaSignKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
+		if _, err := km.GetPrimitiveFromKey(key); err == nil {
+			t.Errorf("expect an error in test case %d")
+		}
+		serializedKey, _ := proto.Marshal(key)
+		if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
+			t.Errorf("expect an error in test case %d")
+		}
+	}
+	// invalid version
+	key := testutil.NewEcdsaPrivateKey(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256)
+	key.Version = signature.ECDSA_SIGN_KEY_VERSION + 1
+	if _, err := km.GetPrimitiveFromKey(key); err == nil {
+		t.Errorf("expect an error when version is invalid")
+	}
+	// nil input
+	if _, err := km.GetPrimitiveFromKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty slice")
+	}
 }
 
 func TestEcdsaSignNewKeyBasic(t *testing.T) {
-  testParams := genValidEcdsaParams()
-  km := signature.NewEcdsaSignKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_DER)
-    format := util.NewEcdsaKeyFormat(params)
-    tmp, err := km.NewKeyFromKeyFormat(format)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    var key *ecdsapb.EcdsaPrivateKey = tmp.(*ecdsapb.EcdsaPrivateKey)
-    if err := validateEcdsaPrivateKey(key, params); err != nil {
-      t.Errorf("invalid private key in test case %d: %s", i, err)
-    }
+	testParams := genValidEcdsaParams()
+	km := signature.NewEcdsaSignKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_DER)
+		format := util.NewEcdsaKeyFormat(params)
+		tmp, err := km.NewKeyFromKeyFormat(format)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		var key *ecdsapb.EcdsaPrivateKey = tmp.(*ecdsapb.EcdsaPrivateKey)
+		if err := validateEcdsaPrivateKey(key, params); err != nil {
+			t.Errorf("invalid private key in test case %d: %s", i, err)
+		}
 
-    serializedFormat, _ := proto.Marshal(format)
-    tmp, err = km.NewKeyFromSerializedKeyFormat(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error: %s", err)
-    }
-    key = tmp.(*ecdsapb.EcdsaPrivateKey)
-    if err := validateEcdsaPrivateKey(key, params); err != nil {
-      t.Errorf("invalid private key in test case %d: %s", i, err)
-    }
-  }
+		serializedFormat, _ := proto.Marshal(format)
+		tmp, err = km.NewKeyFromSerializedKeyFormat(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		key = tmp.(*ecdsapb.EcdsaPrivateKey)
+		if err := validateEcdsaPrivateKey(key, params); err != nil {
+			t.Errorf("invalid private key in test case %d: %s", i, err)
+		}
+	}
 }
 
 func TestEcdsaSignNewKeyWithInvalidInput(t *testing.T) {
-  km := signature.NewEcdsaSignKeyManager()
-  // invalid hash and curve type
-  testParams := genInvalidEcdsaParams()
-  for i := 0; i < len(testParams); i++ {
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_DER)
-    format := util.NewEcdsaKeyFormat(params)
-    if _, err := km.NewKeyFromKeyFormat(format); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-    serializedFormat, _ := proto.Marshal(format)
-    if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // invalid encoding
-  testParams = genValidEcdsaParams()
-  for i := 0; i < len(testParams); i++ {
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_UNKNOWN_ENCODING)
-    format := util.NewEcdsaKeyFormat(params)
-    if _, err := km.NewKeyFromKeyFormat(format); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-    serializedFormat, _ := proto.Marshal(format)
-    if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case %d", i)
-    }
-  }
-  // nil input
-  if _, err := km.NewKeyFromKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.NewKeyFromSerializedKeyFormat(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty slice")
-  }
+	km := signature.NewEcdsaSignKeyManager()
+	// invalid hash and curve type
+	testParams := genInvalidEcdsaParams()
+	for i := 0; i < len(testParams); i++ {
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_DER)
+		format := util.NewEcdsaKeyFormat(params)
+		if _, err := km.NewKeyFromKeyFormat(format); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+		serializedFormat, _ := proto.Marshal(format)
+		if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// invalid encoding
+	testParams = genValidEcdsaParams()
+	for i := 0; i < len(testParams); i++ {
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_UNKNOWN_ENCODING)
+		format := util.NewEcdsaKeyFormat(params)
+		if _, err := km.NewKeyFromKeyFormat(format); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+		serializedFormat, _ := proto.Marshal(format)
+		if _, err := km.NewKeyFromSerializedKeyFormat(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case %d", i)
+		}
+	}
+	// nil input
+	if _, err := km.NewKeyFromKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.NewKeyFromSerializedKeyFormat(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.NewKeyFromSerializedKeyFormat([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty slice")
+	}
 }
 
 func TestEcdsaSignNewKeyMultipleTimes(t *testing.T) {
-  km := signature.NewEcdsaSignKeyManager()
-  testParams := genValidEcdsaParams()
-  nTest := 27
-  for i := 0; i < len(testParams); i++ {
-    keys := make(map[string]bool)
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_DER)
-    format := util.NewEcdsaKeyFormat(params)
-    serializedFormat, _ := proto.Marshal(format)
-    for j := 0; j < nTest; j++ {
-      key, _ := km.NewKeyFromKeyFormat(format)
-      serializedKey, _ := proto.Marshal(key)
-      keys[string(serializedKey)] = true
+	km := signature.NewEcdsaSignKeyManager()
+	testParams := genValidEcdsaParams()
+	nTest := 27
+	for i := 0; i < len(testParams); i++ {
+		keys := make(map[string]bool)
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_DER)
+		format := util.NewEcdsaKeyFormat(params)
+		serializedFormat, _ := proto.Marshal(format)
+		for j := 0; j < nTest; j++ {
+			key, _ := km.NewKeyFromKeyFormat(format)
+			serializedKey, _ := proto.Marshal(key)
+			keys[string(serializedKey)] = true
 
-      key, _ = km.NewKeyFromSerializedKeyFormat(serializedFormat)
-      serializedKey, _ = proto.Marshal(key)
-      keys[string(serializedKey)] = true
+			key, _ = km.NewKeyFromSerializedKeyFormat(serializedFormat)
+			serializedKey, _ = proto.Marshal(key)
+			keys[string(serializedKey)] = true
 
-      keyData, _ := km.NewKeyData(serializedFormat)
-      serializedKey = keyData.Value
-      keys[string(serializedKey)] = true
-    }
-    if len(keys) != nTest*3 {
-      t.Errorf("key is repeated with params: %s", params)
-    }
-  }
+			keyData, _ := km.NewKeyData(serializedFormat)
+			serializedKey = keyData.Value
+			keys[string(serializedKey)] = true
+		}
+		if len(keys) != nTest*3 {
+			t.Errorf("key is repeated with params: %s", params)
+		}
+	}
 }
 
 func TestEcdsaSignNewKeyDataBasic(t *testing.T) {
-  km := signature.NewEcdsaSignKeyManager()
-  testParams := genValidEcdsaParams()
-  for i := 0; i < len(testParams); i++ {
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_DER)
-    format := util.NewEcdsaKeyFormat(params)
-    serializedFormat, _ := proto.Marshal(format)
+	km := signature.NewEcdsaSignKeyManager()
+	testParams := genValidEcdsaParams()
+	for i := 0; i < len(testParams); i++ {
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_DER)
+		format := util.NewEcdsaKeyFormat(params)
+		serializedFormat, _ := proto.Marshal(format)
 
-    keyData, err := km.NewKeyData(serializedFormat)
-    if err != nil {
-      t.Errorf("unexpected error in test case  %d: %s", i, err)
-    }
-    if keyData.TypeUrl != signature.ECDSA_SIGN_TYPE_URL {
-      t.Errorf("incorrect type url in test case  %d: expect %s, got %s",
-                i, signature.ECDSA_SIGN_TYPE_URL, keyData.TypeUrl)
-    }
-    if keyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PRIVATE {
-      t.Errorf("incorrect key material type in test case  %d: expect %s, got %s",
-                i, tinkpb.KeyData_ASYMMETRIC_PRIVATE, keyData.KeyMaterialType)
-    }
-    key := new(ecdsapb.EcdsaPrivateKey)
-    if err := proto.Unmarshal(keyData.Value, key); err != nil {
-      t.Errorf("unexpect error in test case %d: %s", i, err)
-    }
-    if err := validateEcdsaPrivateKey(key, params); err != nil {
-      t.Errorf("invalid private key in test case %d: %s", i, err)
-    }
-  }
+		keyData, err := km.NewKeyData(serializedFormat)
+		if err != nil {
+			t.Errorf("unexpected error in test case  %d: %s", i, err)
+		}
+		if keyData.TypeUrl != signature.ECDSA_SIGN_TYPE_URL {
+			t.Errorf("incorrect type url in test case  %d: expect %s, got %s",
+				i, signature.ECDSA_SIGN_TYPE_URL, keyData.TypeUrl)
+		}
+		if keyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PRIVATE {
+			t.Errorf("incorrect key material type in test case  %d: expect %s, got %s",
+				i, tinkpb.KeyData_ASYMMETRIC_PRIVATE, keyData.KeyMaterialType)
+		}
+		key := new(ecdsapb.EcdsaPrivateKey)
+		if err := proto.Unmarshal(keyData.Value, key); err != nil {
+			t.Errorf("unexpect error in test case %d: %s", i, err)
+		}
+		if err := validateEcdsaPrivateKey(key, params); err != nil {
+			t.Errorf("invalid private key in test case %d: %s", i, err)
+		}
+	}
 }
 
 func TestEcdsaSignNewKeyDataWithInvalidInput(t *testing.T) {
-  km := signature.NewEcdsaSignKeyManager()
-  testParams := genInvalidEcdsaParams()
-  for i := 0; i < len(testParams); i++ {
-    params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
-                                  ecdsapb.EcdsaSignatureEncoding_DER)
-    format := util.NewEcdsaKeyFormat(params)
-    serializedFormat, _ := proto.Marshal(format)
+	km := signature.NewEcdsaSignKeyManager()
+	testParams := genInvalidEcdsaParams()
+	for i := 0; i < len(testParams); i++ {
+		params := util.NewEcdsaParams(testParams[i].hashType, testParams[i].curve,
+			ecdsapb.EcdsaSignatureEncoding_DER)
+		format := util.NewEcdsaKeyFormat(params)
+		serializedFormat, _ := proto.Marshal(format)
 
-    if _, err := km.NewKeyData(serializedFormat); err == nil {
-      t.Errorf("expect an error in test case  %d", i)
-    }
-  }
-  // nil input
-  if _, err := km.NewKeyData(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
+		if _, err := km.NewKeyData(serializedFormat); err == nil {
+			t.Errorf("expect an error in test case  %d", i)
+		}
+	}
+	// nil input
+	if _, err := km.NewKeyData(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
 }
 
 func TestGetPublicKeyDataBasic(t *testing.T) {
-  testParams := genValidEcdsaParams()
-  km := signature.NewEcdsaSignKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
-    serializedKey, _ := proto.Marshal(key)
+	testParams := genValidEcdsaParams()
+	km := signature.NewEcdsaSignKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
+		serializedKey, _ := proto.Marshal(key)
 
-    pubKeyData, err := km.GetPublicKeyData(serializedKey)
-    if err != nil {
-      t.Errorf("unexpect error in test case %d: %s ", i, err)
-    }
-    if pubKeyData.TypeUrl != signature.ECDSA_VERIFY_TYPE_URL {
-      t.Errorf("incorrect type url: %s", pubKeyData.TypeUrl)
-    }
-    if pubKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PUBLIC {
-      t.Errorf("incorrect key material type: %d", pubKeyData.KeyMaterialType)
-    }
-    pubKey := new(ecdsapb.EcdsaPublicKey)
-    if err = proto.Unmarshal(pubKeyData.Value, pubKey); err != nil {
-      t.Errorf("invalid public key: %s", err)
-    }
-  }
+		pubKeyData, err := km.GetPublicKeyData(serializedKey)
+		if err != nil {
+			t.Errorf("unexpect error in test case %d: %s ", i, err)
+		}
+		if pubKeyData.TypeUrl != signature.ECDSA_VERIFY_TYPE_URL {
+			t.Errorf("incorrect type url: %s", pubKeyData.TypeUrl)
+		}
+		if pubKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PUBLIC {
+			t.Errorf("incorrect key material type: %d", pubKeyData.KeyMaterialType)
+		}
+		pubKey := new(ecdsapb.EcdsaPublicKey)
+		if err = proto.Unmarshal(pubKeyData.Value, pubKey); err != nil {
+			t.Errorf("invalid public key: %s", err)
+		}
+	}
 }
 
 func TestGetPublicKeyDataWithInvalidInput(t *testing.T) {
-  km := signature.NewEcdsaSignKeyManager()
-  // modified key
-  key := testutil.NewEcdsaPrivateKey(commonpb.HashType_SHA256,
-                                    commonpb.EllipticCurveType_NIST_P256)
-  serializedKey, _ := proto.Marshal(key)
-  serializedKey[0] = 0
-  if _, err := km.GetPublicKeyData(serializedKey); err == nil {
-    t.Errorf("expect an error when input is a modified serialized key")
-  }
-  // nil
-  if _, err := km.GetPublicKeyData(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  // empty slice
-  if _, err := km.GetPublicKeyData([]byte{}); err == nil {
-    t.Errorf("expect an error when input is an empty slice")
-  }
+	km := signature.NewEcdsaSignKeyManager()
+	// modified key
+	key := testutil.NewEcdsaPrivateKey(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256)
+	serializedKey, _ := proto.Marshal(key)
+	serializedKey[0] = 0
+	if _, err := km.GetPublicKeyData(serializedKey); err == nil {
+		t.Errorf("expect an error when input is a modified serialized key")
+	}
+	// nil
+	if _, err := km.GetPublicKeyData(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	// empty slice
+	if _, err := km.GetPublicKeyData([]byte{}); err == nil {
+		t.Errorf("expect an error when input is an empty slice")
+	}
 }
 
 var errSmallKey = fmt.Errorf("private key doesn't have adequate size")
 
 func validateEcdsaPrivateKey(key *ecdsapb.EcdsaPrivateKey, params *ecdsapb.EcdsaParams) error {
-  if key.Version != signature.ECDSA_SIGN_KEY_VERSION {
-    return fmt.Errorf("incorrect private key's version: expect %d, got %d",
-                      signature.ECDSA_SIGN_KEY_VERSION, key.Version)
-  }
-  publicKey := key.PublicKey
-  if publicKey.Version != signature.ECDSA_SIGN_KEY_VERSION {
-    return fmt.Errorf("incorrect public key's version: expect %d, got %d",
-                      signature.ECDSA_SIGN_KEY_VERSION, key.Version)
-  }
-  if params.HashType != publicKey.Params.HashType ||
-      params.Curve != publicKey.Params.Curve ||
-      params.Encoding != publicKey.Params.Encoding {
-    return fmt.Errorf("incorrect params: expect %s, got %s", params, publicKey.Params)
-  }
-  if len(publicKey.X) == 0 || len(publicKey.Y) == 0 {
-    return fmt.Errorf("public points are not initialized")
-  }
-  // check private key's size
-  d := new(big.Int).SetBytes(key.KeyValue)
-  keySize := len(d.Bytes())
-  switch params.Curve {
-    case commonpb.EllipticCurveType_NIST_P256:
-      if keySize < 256/8-8 || keySize > 256/8+1 {
-        return errSmallKey
-      }
-    case commonpb.EllipticCurveType_NIST_P384:
-      if keySize < 384/8-8 || keySize > 384/8+1 {
-        return errSmallKey
-      }
-    case commonpb.EllipticCurveType_NIST_P521:
-      if keySize < 521/8-8 || keySize > 521/8+1 {
-        return errSmallKey
-      }
-  }
-  // try to sign and verify with the key
-  hash, curve, encoding := util.GetEcdsaParamNames(publicKey.Params)
-  signer, err := ecdsa.NewEcdsaSign(hash, curve, encoding, key.KeyValue)
-  if err != nil {
-    return fmt.Errorf("unexpected error when creating EcdsaSign: %s", err)
-  }
-  verifier, err := ecdsa.NewEcdsaVerify(hash, curve, encoding, publicKey.X, publicKey.Y)
-  if err != nil {
-    return fmt.Errorf("unexpected error when creating EcdsaVerify: %s", err)
-  }
-  data := random.GetRandomBytes(1281)
-  signature, err := signer.Sign(data)
-  if err != nil {
-    return fmt.Errorf("unexpected error when signing: %s", err)
-  }
-  if err := verifier.Verify(signature, data); err != nil {
-    return fmt.Errorf("unexpected error when verifying signature: %s", err)
-  }
-  return nil
+	if key.Version != signature.ECDSA_SIGN_KEY_VERSION {
+		return fmt.Errorf("incorrect private key's version: expect %d, got %d",
+			signature.ECDSA_SIGN_KEY_VERSION, key.Version)
+	}
+	publicKey := key.PublicKey
+	if publicKey.Version != signature.ECDSA_SIGN_KEY_VERSION {
+		return fmt.Errorf("incorrect public key's version: expect %d, got %d",
+			signature.ECDSA_SIGN_KEY_VERSION, key.Version)
+	}
+	if params.HashType != publicKey.Params.HashType ||
+		params.Curve != publicKey.Params.Curve ||
+		params.Encoding != publicKey.Params.Encoding {
+		return fmt.Errorf("incorrect params: expect %s, got %s", params, publicKey.Params)
+	}
+	if len(publicKey.X) == 0 || len(publicKey.Y) == 0 {
+		return fmt.Errorf("public points are not initialized")
+	}
+	// check private key's size
+	d := new(big.Int).SetBytes(key.KeyValue)
+	keySize := len(d.Bytes())
+	switch params.Curve {
+	case commonpb.EllipticCurveType_NIST_P256:
+		if keySize < 256/8-8 || keySize > 256/8+1 {
+			return errSmallKey
+		}
+	case commonpb.EllipticCurveType_NIST_P384:
+		if keySize < 384/8-8 || keySize > 384/8+1 {
+			return errSmallKey
+		}
+	case commonpb.EllipticCurveType_NIST_P521:
+		if keySize < 521/8-8 || keySize > 521/8+1 {
+			return errSmallKey
+		}
+	}
+	// try to sign and verify with the key
+	hash, curve, encoding := util.GetEcdsaParamNames(publicKey.Params)
+	signer, err := ecdsa.NewEcdsaSign(hash, curve, encoding, key.KeyValue)
+	if err != nil {
+		return fmt.Errorf("unexpected error when creating EcdsaSign: %s", err)
+	}
+	verifier, err := ecdsa.NewEcdsaVerify(hash, curve, encoding, publicKey.X, publicKey.Y)
+	if err != nil {
+		return fmt.Errorf("unexpected error when creating EcdsaVerify: %s", err)
+	}
+	data := random.GetRandomBytes(1281)
+	signature, err := signer.Sign(data)
+	if err != nil {
+		return fmt.Errorf("unexpected error when signing: %s", err)
+	}
+	if err := verifier.Verify(signature, data); err != nil {
+		return fmt.Errorf("unexpected error when verifying signature: %s", err)
+	}
+	return nil
 }
 
 func genValidEcdsaParams() []ecdsaParams {
-  return []ecdsaParams{
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA256,
-      curve: commonpb.EllipticCurveType_NIST_P256,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA512,
-      curve: commonpb.EllipticCurveType_NIST_P384,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA512,
-      curve: commonpb.EllipticCurveType_NIST_P521,
-    },
-  }
+	return []ecdsaParams{
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA256,
+			curve:    commonpb.EllipticCurveType_NIST_P256,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA512,
+			curve:    commonpb.EllipticCurveType_NIST_P384,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA512,
+			curve:    commonpb.EllipticCurveType_NIST_P521,
+		},
+	}
 }
 
 func genInvalidEcdsaParams() []ecdsaParams {
-  return []ecdsaParams{
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA1,
-      curve: commonpb.EllipticCurveType_NIST_P256,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA1,
-      curve: commonpb.EllipticCurveType_NIST_P384,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA1,
-      curve: commonpb.EllipticCurveType_NIST_P521,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA256,
-      curve: commonpb.EllipticCurveType_NIST_P384,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA256,
-      curve: commonpb.EllipticCurveType_NIST_P521,
-    },
-    ecdsaParams{
-      hashType: commonpb.HashType_SHA512,
-      curve: commonpb.EllipticCurveType_NIST_P256,
-    },
-  }
+	return []ecdsaParams{
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA1,
+			curve:    commonpb.EllipticCurveType_NIST_P256,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA1,
+			curve:    commonpb.EllipticCurveType_NIST_P384,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA1,
+			curve:    commonpb.EllipticCurveType_NIST_P521,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA256,
+			curve:    commonpb.EllipticCurveType_NIST_P384,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA256,
+			curve:    commonpb.EllipticCurveType_NIST_P521,
+		},
+		ecdsaParams{
+			hashType: commonpb.HashType_SHA512,
+			curve:    commonpb.EllipticCurveType_NIST_P256,
+		},
+	}
 }

--- a/go/signature/ecdsa_verify_key_manager.go
+++ b/go/signature/ecdsa_verify_key_manager.go
@@ -16,21 +16,21 @@
 package signature
 
 import (
-  "fmt"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/golang/protobuf/proto"
-  ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/util"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 const (
-  // Supported version
-  ECDSA_VERIFY_KEY_VERSION = 0
+	// Supported version
+	ECDSA_VERIFY_KEY_VERSION = 0
 
-  // Supported type url
-  ECDSA_VERIFY_TYPE_URL = "type.googleapis.com/google.crypto.tink.EcdsaPublicKey"
+	// Supported type url
+	ECDSA_VERIFY_TYPE_URL = "type.googleapis.com/google.crypto.tink.EcdsaPublicKey"
 )
 
 // common errors
@@ -40,77 +40,77 @@ var errEcdsaVerifyNotImplemented = fmt.Errorf("ecdsa_verify_key_manager: not imp
 
 // EcdsaVerifyKeyManager is an implementation of KeyManager interface.
 // It doesn't support key generation.
-type EcdsaVerifyKeyManager struct {}
+type EcdsaVerifyKeyManager struct{}
 
 // Assert that EcdsaVerifyKeyManager implements the KeyManager interface.
 var _ tink.KeyManager = (*EcdsaVerifyKeyManager)(nil)
 
 // NewEcdsaVerifyKeyManager creates a new EcdsaVerifyKeyManager.
 func NewEcdsaVerifyKeyManager() *EcdsaVerifyKeyManager {
-  return new(EcdsaVerifyKeyManager)
+	return new(EcdsaVerifyKeyManager)
 }
 
 // GetPrimitiveFromSerializedKey creates an EcdsaVerify subtle for the given
 // serialized EcdsaPublicKey proto.
 func (km *EcdsaVerifyKeyManager) GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error) {
-  if len(serializedKey) == 0 {
-    return nil, errInvalidEcdsaVerifyKey
-  }
-  key := new(ecdsapb.EcdsaPublicKey)
-  if err := proto.Unmarshal(serializedKey, key); err != nil {
-    return nil, errInvalidEcdsaVerifyKey
-  }
-  return km.GetPrimitiveFromKey(key)
+	if len(serializedKey) == 0 {
+		return nil, errInvalidEcdsaVerifyKey
+	}
+	key := new(ecdsapb.EcdsaPublicKey)
+	if err := proto.Unmarshal(serializedKey, key); err != nil {
+		return nil, errInvalidEcdsaVerifyKey
+	}
+	return km.GetPrimitiveFromKey(key)
 }
 
 // GetPrimitiveFromKey creates an EcdsaVerify subtle for the given EcdsaPublicKey proto.
 func (km *EcdsaVerifyKeyManager) GetPrimitiveFromKey(m proto.Message) (interface{}, error) {
-  key, ok := m.(*ecdsapb.EcdsaPublicKey)
-  if !ok {
-    return nil, errInvalidEcdsaVerifyKey
-  }
-  if err := km.validateKey(key); err != nil {
-    return nil, fmt.Errorf("ecdsa_verify_key_manager: %s", err)
-  }
-  hash, curve, encoding := util.GetEcdsaParamNames(key.Params)
-  ret, err := subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, key.X, key.Y)
-  if err != nil {
-    return nil, fmt.Errorf("ecdsa_verify_key_manager: invalid key: %s", err)
-  }
-  return ret, nil
+	key, ok := m.(*ecdsapb.EcdsaPublicKey)
+	if !ok {
+		return nil, errInvalidEcdsaVerifyKey
+	}
+	if err := km.validateKey(key); err != nil {
+		return nil, fmt.Errorf("ecdsa_verify_key_manager: %s", err)
+	}
+	hash, curve, encoding := util.GetEcdsaParamNames(key.Params)
+	ret, err := subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, key.X, key.Y)
+	if err != nil {
+		return nil, fmt.Errorf("ecdsa_verify_key_manager: invalid key: %s", err)
+	}
+	return ret, nil
 }
 
 // NewKeyFromSerializedKeyFormat is not implemented
 func (km *EcdsaVerifyKeyManager) NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error) {
-  return nil, errEcdsaVerifyNotImplemented
+	return nil, errEcdsaVerifyNotImplemented
 }
 
 // NewKeyFromKeyFormat is not implemented
 func (km *EcdsaVerifyKeyManager) NewKeyFromKeyFormat(m proto.Message) (proto.Message, error) {
-  return nil, errEcdsaVerifyNotImplemented
+	return nil, errEcdsaVerifyNotImplemented
 }
 
 // NewKeyData creates a new KeyData according to specification in  the given
 // serialized EcdsaKeyFormat. It should be used solely by the key management API.
 func (km *EcdsaVerifyKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
-  return nil, errEcdsaVerifyNotImplemented
+	return nil, errEcdsaVerifyNotImplemented
 }
 
 // DoesSupport indicates if this key manager supports the given key type.
 func (_ *EcdsaVerifyKeyManager) DoesSupport(typeUrl string) bool {
-  return typeUrl == ECDSA_VERIFY_TYPE_URL
+	return typeUrl == ECDSA_VERIFY_TYPE_URL
 }
 
 // GetKeyType returns the key type of keys managed by this key manager.
 func (_ *EcdsaVerifyKeyManager) GetKeyType() string {
-  return ECDSA_VERIFY_TYPE_URL
+	return ECDSA_VERIFY_TYPE_URL
 }
 
 // validateKey validates the given EcdsaPublicKey.
 func (_ *EcdsaVerifyKeyManager) validateKey(key *ecdsapb.EcdsaPublicKey) error {
-  if err := util.ValidateVersion(key.Version, ECDSA_VERIFY_KEY_VERSION); err != nil {
-    return fmt.Errorf("ecdsa_verify_key_manager: %s", err)
-  }
-  hash, curve, encoding := util.GetEcdsaParamNames(key.Params)
-  return subtleEcdsa.ValidateParams(hash, curve, encoding)
+	if err := util.ValidateVersion(key.Version, ECDSA_VERIFY_KEY_VERSION); err != nil {
+		return fmt.Errorf("ecdsa_verify_key_manager: %s", err)
+	}
+	hash, curve, encoding := util.GetEcdsaParamNames(key.Params)
+	return subtleEcdsa.ValidateParams(hash, curve, encoding)
 }

--- a/go/signature/ecdsa_verify_key_manager_test.go
+++ b/go/signature/ecdsa_verify_key_manager_test.go
@@ -16,69 +16,69 @@
 package signature_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/golang/protobuf/proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/util/testutil"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	"testing"
 )
 
 func TestNewEcdsaVerifyKeyManager(t *testing.T) {
-  var km *signature.EcdsaVerifyKeyManager = signature.NewEcdsaVerifyKeyManager()
-  if km == nil {
-    t.Errorf("NewEcdsaVerifyKeyManager returns nil")
-  }
+	var km *signature.EcdsaVerifyKeyManager = signature.NewEcdsaVerifyKeyManager()
+	if km == nil {
+		t.Errorf("NewEcdsaVerifyKeyManager returns nil")
+	}
 }
 
 func TestEcdsaVerifyGetPrimitiveBasic(t *testing.T) {
-  testParams := genValidEcdsaParams()
-  km := signature.NewEcdsaVerifyKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    key := testutil.NewEcdsaPublicKey(testParams[i].hashType, testParams[i].curve)
-    tmp, err := km.GetPrimitiveFromKey(key)
-    if err != nil {
-      t.Errorf("unexpect error in test case %d: %s ", i, err)
-    }
-    var _ *ecdsa.EcdsaVerify = tmp.(*ecdsa.EcdsaVerify)
+	testParams := genValidEcdsaParams()
+	km := signature.NewEcdsaVerifyKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		key := testutil.NewEcdsaPublicKey(testParams[i].hashType, testParams[i].curve)
+		tmp, err := km.GetPrimitiveFromKey(key)
+		if err != nil {
+			t.Errorf("unexpect error in test case %d: %s ", i, err)
+		}
+		var _ *ecdsa.EcdsaVerify = tmp.(*ecdsa.EcdsaVerify)
 
-    serializedKey, _ := proto.Marshal(key)
-    tmp, err = km.GetPrimitiveFromSerializedKey(serializedKey)
-    if err != nil {
-      t.Errorf("unexpect error in test case %d: %s ", i, err)
-    }
-    var _ *ecdsa.EcdsaVerify = tmp.(*ecdsa.EcdsaVerify)
-  }
+		serializedKey, _ := proto.Marshal(key)
+		tmp, err = km.GetPrimitiveFromSerializedKey(serializedKey)
+		if err != nil {
+			t.Errorf("unexpect error in test case %d: %s ", i, err)
+		}
+		var _ *ecdsa.EcdsaVerify = tmp.(*ecdsa.EcdsaVerify)
+	}
 }
 
 func TestEcdsaVerifyGetPrimitiveWithInvalidInput(t *testing.T) {
-  testParams := genInvalidEcdsaParams()
-  km := signature.NewEcdsaVerifyKeyManager()
-  for i := 0; i < len(testParams); i++ {
-    key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
-    if _, err := km.GetPrimitiveFromKey(key); err == nil {
-      t.Errorf("expect an error in test case %d")
-    }
-    serializedKey, _ := proto.Marshal(key)
-    if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
-      t.Errorf("expect an error in test case %d")
-    }
-  }
-  // invalid version
-  key := testutil.NewEcdsaPublicKey(commonpb.HashType_SHA256,
-                                      commonpb.EllipticCurveType_NIST_P256)
-  key.Version = signature.ECDSA_VERIFY_KEY_VERSION + 1
-  if _, err := km.GetPrimitiveFromKey(key); err == nil {
-    t.Errorf("expect an error when version is invalid")
-  }
-  // nil input
-  if _, err := km.GetPrimitiveFromKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
-    t.Errorf("expect an error when input is empty slice")
-  }
+	testParams := genInvalidEcdsaParams()
+	km := signature.NewEcdsaVerifyKeyManager()
+	for i := 0; i < len(testParams); i++ {
+		key := testutil.NewEcdsaPrivateKey(testParams[i].hashType, testParams[i].curve)
+		if _, err := km.GetPrimitiveFromKey(key); err == nil {
+			t.Errorf("expect an error in test case %d")
+		}
+		serializedKey, _ := proto.Marshal(key)
+		if _, err := km.GetPrimitiveFromSerializedKey(serializedKey); err == nil {
+			t.Errorf("expect an error in test case %d")
+		}
+	}
+	// invalid version
+	key := testutil.NewEcdsaPublicKey(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256)
+	key.Version = signature.ECDSA_VERIFY_KEY_VERSION + 1
+	if _, err := km.GetPrimitiveFromKey(key); err == nil {
+		t.Errorf("expect an error when version is invalid")
+	}
+	// nil input
+	if _, err := km.GetPrimitiveFromKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.GetPrimitiveFromSerializedKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	if _, err := km.GetPrimitiveFromSerializedKey([]byte{}); err == nil {
+		t.Errorf("expect an error when input is empty slice")
+	}
 }

--- a/go/signature/public_key_sign_config.go
+++ b/go/signature/public_key_sign_config.go
@@ -16,8 +16,8 @@
 package signature
 
 import (
-  "sync"
-  "github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // PublicKeySignConfig contains convenience methods for initializing the Registry with native
@@ -34,32 +34,32 @@ import (
 var publicKeySignConfigInstance *publicKeySignConfig
 var publicKeySignConfigOnce sync.Once
 
-type publicKeySignConfig struct {}
+type publicKeySignConfig struct{}
 
 // PublicKeySignConfig creates an instance of publicKeySignConfig if there isn't
 // and returns the instance.
 func PublicKeySignConfig() *publicKeySignConfig {
-  publicKeySignConfigOnce.Do(func() {
-    publicKeySignConfigInstance = new(publicKeySignConfig)
-  })
-  return publicKeySignConfigInstance
+	publicKeySignConfigOnce.Do(func() {
+		publicKeySignConfigInstance = new(publicKeySignConfig)
+	})
+	return publicKeySignConfigInstance
 }
 
 // RegisterStandardKeyTypes registers standard Aead key types and their managers
 // with the Registry.
 func (c *publicKeySignConfig) RegisterStandardKeyTypes() (bool, error) {
-  return c.RegisterKeyManager(NewEcdsaSignKeyManager())
+	return c.RegisterKeyManager(NewEcdsaSignKeyManager())
 }
 
 // RegisterLegacyKeyTypes registers legacy Aead key types and their managers
 // with the Registry.
 func (c *publicKeySignConfig) RegisterLegacyKeyTypes() (bool, error) {
-  return false, nil
+	return false, nil
 }
 
 // RegisterKeyManager registers the given keyManager for the key type given in
 // keyManager.KeyType(). It returns true if registration was successful, false if
 // there already exisits a key manager for the key type.
 func (c *publicKeySignConfig) RegisterKeyManager(keyManager tink.KeyManager) (bool, error) {
-  return tink.Registry().RegisterKeyManager(keyManager)
+	return tink.Registry().RegisterKeyManager(keyManager)
 }

--- a/go/signature/public_key_sign_config_test.go
+++ b/go/signature/public_key_sign_config_test.go
@@ -16,27 +16,27 @@
 package signature_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/tink/tink"
+	"testing"
 )
 
 func TestPublicKeySignConfigInstance(t *testing.T) {
-  config := signature.PublicKeySignConfig()
-  if config == nil {
-    t.Errorf("instance of publicKeySignConfig is nil")
-  }
+	config := signature.PublicKeySignConfig()
+	if config == nil {
+		t.Errorf("instance of publicKeySignConfig is nil")
+	}
 }
 
 func TestPublicKeySignConfigRegistration(t *testing.T) {
-  _, err := signature.PublicKeySignConfig().RegisterStandardKeyTypes()
-  if err != nil {
-    t.Errorf("cannot register standard key types")
-  }
-  // check for EcdsaSignKeyManager
-  keyManager, err := tink.Registry().GetKeyManager(signature.ECDSA_SIGN_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ = keyManager.(*signature.EcdsaSignKeyManager)
+	_, err := signature.PublicKeySignConfig().RegisterStandardKeyTypes()
+	if err != nil {
+		t.Errorf("cannot register standard key types")
+	}
+	// check for EcdsaSignKeyManager
+	keyManager, err := tink.Registry().GetKeyManager(signature.ECDSA_SIGN_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ = keyManager.(*signature.EcdsaSignKeyManager)
 }

--- a/go/signature/public_key_sign_factory.go
+++ b/go/signature/public_key_sign_factory.go
@@ -16,48 +16,49 @@
 package signature
 
 import (
-  "fmt"
-  "sync"
-  "github.com/google/tink/go/tink/tink"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/tink/tink"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
 )
 
 // PublicKeySignFactory allows obtaining a PublicKeySign primitive from a
 // KeysetHandle.
 var publicKeySignFactoryInstance *publicKeySignFactory
 var publicKeySignFactoryOnce sync.Once
-type publicKeySignFactory struct {}
+
+type publicKeySignFactory struct{}
 
 // publicKeySignFactory creates an instance of publicKeySignFactory if there isn't
 // and returns the instance.
 func PublicKeySignFactory() *publicKeySignFactory {
-  publicKeySignFactoryOnce.Do(func() {
-    publicKeySignFactoryInstance = new(publicKeySignFactory)
-  })
-  return publicKeySignFactoryInstance
+	publicKeySignFactoryOnce.Do(func() {
+		publicKeySignFactoryInstance = new(publicKeySignFactory)
+	})
+	return publicKeySignFactoryInstance
 }
 
 // GetPrimitive returns a PublicKeySign primitive from the given keyset handle.
 func (f *publicKeySignFactory) GetPrimitive(handle *tink.KeysetHandle) (tink.PublicKeySign, error) {
-  return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
+	return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
 }
 
 // GetPrimitiveWithCustomerManager returns a PublicKeySign primitive from the given
 // keyset handle and custom key manager.
 func (f *publicKeySignFactory) GetPrimitiveWithCustomerManager(
-    handle *tink.KeysetHandle, manager tink.KeyManager) (tink.PublicKeySign, error) {
-  ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
-  if err != nil {
-    return nil, fmt.Errorf("public_key_sign_factory: cannot obtain primitive set: %s", err)
-  }
-  var ret tink.PublicKeySign = newPrimitiveSetPublicKeySign(ps)
-  return ret, nil
+	handle *tink.KeysetHandle, manager tink.KeyManager) (tink.PublicKeySign, error) {
+	ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
+	if err != nil {
+		return nil, fmt.Errorf("public_key_sign_factory: cannot obtain primitive set: %s", err)
+	}
+	var ret tink.PublicKeySign = newPrimitiveSetPublicKeySign(ps)
+	return ret, nil
 }
 
 // primitiveSetPublicKeySign is an PublicKeySign implementation that uses the
 // underlying primitive set for signing.
 type primitiveSetPublicKeySign struct {
-  ps *tink.PrimitiveSet
+	ps *tink.PrimitiveSet
 }
 
 // Asserts that primitiveSetPublicKeySign implements the PublicKeySign interface.
@@ -65,29 +66,29 @@ var _ tink.PublicKeySign = (*primitiveSetPublicKeySign)(nil)
 
 // newPrimitiveSetPublicKeySign creates a new instance of primitiveSetPublicKeySign
 func newPrimitiveSetPublicKeySign(ps *tink.PrimitiveSet) *primitiveSetPublicKeySign {
-  ret := new(primitiveSetPublicKeySign)
-  ret.ps = ps
-  return ret
+	ret := new(primitiveSetPublicKeySign)
+	ret.ps = ps
+	return ret
 }
 
 // Sign signs the given data and returns the signature concatenated with
 // the identifier of the primary primitive.
 func (s *primitiveSetPublicKeySign) Sign(data []byte) ([]byte, error) {
-  primary := s.ps.Primary()
-  var signer tink.PublicKeySign = (primary.Primitive()).(tink.PublicKeySign)
-  var signedData []byte
-  if primary.OutputPrefixType() == tinkpb.OutputPrefixType_LEGACY {
-    signedData = append(signedData, data...)
-    signedData = append(signedData, tink.LEGACY_START_BYTE)
-  } else {
-    signedData = data
-  }
-  signature, err := signer.Sign(signedData)
-  if err != nil {
-    return nil, err
-  }
-  var ret []byte
-  ret = append(ret, primary.Identifier()...)
-  ret = append(ret, signature...)
-  return ret, nil
+	primary := s.ps.Primary()
+	var signer tink.PublicKeySign = (primary.Primitive()).(tink.PublicKeySign)
+	var signedData []byte
+	if primary.OutputPrefixType() == tinkpb.OutputPrefixType_LEGACY {
+		signedData = append(signedData, data...)
+		signedData = append(signedData, tink.LEGACY_START_BYTE)
+	} else {
+		signedData = data
+	}
+	signature, err := signer.Sign(signedData)
+	if err != nil {
+		return nil, err
+	}
+	var ret []byte
+	ret = append(ret, primary.Identifier()...)
+	ret = append(ret, signature...)
+	return ret, nil
 }

--- a/go/signature/public_key_sign_verify_factory_test.go
+++ b/go/signature/public_key_sign_verify_factory_test.go
@@ -16,100 +16,100 @@
 package signature_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestPublicKeySignFactoryInstance(t *testing.T) {
-  f := signature.PublicKeySignFactory()
-  if f == nil {
-    t.Errorf("PublicKeySignFactory() returns nil")
-  }
+	f := signature.PublicKeySignFactory()
+	if f == nil {
+		t.Errorf("PublicKeySignFactory() returns nil")
+	}
 }
 
 func TestPublicKeySignVerifyFactory(t *testing.T) {
-  signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
-  signature.PublicKeySignConfig().RegisterStandardKeyTypes()
-  tinkPriv, tinkPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
-                                        commonpb.EllipticCurveType_NIST_P521,
-                                        tinkpb.OutputPrefixType_TINK,
-                                        1)
-  legacyPriv, legacyPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA256,
-                                        commonpb.EllipticCurveType_NIST_P256,
-                                        tinkpb.OutputPrefixType_LEGACY,
-                                        2)
-  rawPriv, rawPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
-                                        commonpb.EllipticCurveType_NIST_P384,
-                                        tinkpb.OutputPrefixType_RAW,
-                                        3)
-  crunchyPriv, crunchyPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
-                                        commonpb.EllipticCurveType_NIST_P384,
-                                        tinkpb.OutputPrefixType_CRUNCHY,
-                                        4)
-  privKeys := []*tinkpb.Keyset_Key{tinkPriv, legacyPriv, rawPriv, crunchyPriv}
-  privKeyset := util.NewKeyset(privKeys[0].KeyId, privKeys)
-  privKeysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(privKeyset)
-  pubKeys := []*tinkpb.Keyset_Key{tinkPub, legacyPub, rawPub, crunchyPub}
-  pubKeyset := util.NewKeyset(pubKeys[0].KeyId, pubKeys)
-  pubKeysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(pubKeyset)
+	signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
+	signature.PublicKeySignConfig().RegisterStandardKeyTypes()
+	tinkPriv, tinkPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P521,
+		tinkpb.OutputPrefixType_TINK,
+		1)
+	legacyPriv, legacyPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256,
+		tinkpb.OutputPrefixType_LEGACY,
+		2)
+	rawPriv, rawPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P384,
+		tinkpb.OutputPrefixType_RAW,
+		3)
+	crunchyPriv, crunchyPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P384,
+		tinkpb.OutputPrefixType_CRUNCHY,
+		4)
+	privKeys := []*tinkpb.Keyset_Key{tinkPriv, legacyPriv, rawPriv, crunchyPriv}
+	privKeyset := util.NewKeyset(privKeys[0].KeyId, privKeys)
+	privKeysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(privKeyset)
+	pubKeys := []*tinkpb.Keyset_Key{tinkPub, legacyPub, rawPub, crunchyPub}
+	pubKeyset := util.NewKeyset(pubKeys[0].KeyId, pubKeys)
+	pubKeysetHandle, _ := tink.CleartextKeysetHandle().ParseKeyset(pubKeyset)
 
-  // sign some random data
-  signer, err := signature.PublicKeySignFactory().GetPrimitive(privKeysetHandle)
-  if err != nil {
-    t.Errorf("getting sign primitive failed: %s", err)
-  }
-  data := random.GetRandomBytes(1211)
-  sig, err := signer.Sign(data)
-  if err != nil {
-    t.Errorf("signing failed: %s", err)
-  }
-  // verify with the same set of public keys should work
-  verifier, err := signature.PublicKeyVerifyFactory().GetPrimitive(pubKeysetHandle)
-  if err != nil {
-    t.Errorf("getting verify primitive failed: %s", err)
-  }
-  if err := verifier.Verify(sig, data); err != nil {
-    t.Errorf("verification failed: %s", err)
-  }
-  // verify with random key should fail
-  _, randomPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
-                                        commonpb.EllipticCurveType_NIST_P521,
-                                        tinkpb.OutputPrefixType_TINK,
-                                        1)
-  pubKeys = []*tinkpb.Keyset_Key{randomPub}
-  pubKeyset = util.NewKeyset(pubKeys[0].KeyId, pubKeys)
-  pubKeysetHandle, _ = tink.CleartextKeysetHandle().ParseKeyset(pubKeyset)
-  verifier, err = signature.PublicKeyVerifyFactory().GetPrimitive(pubKeysetHandle)
-  if err != nil {
-    t.Errorf("getting verify primitive failed: %s", err)
-  }
-  if err := verifier.Verify(sig, data); err == nil {
-    t.Errorf("verification with random key should fail: %s", err)
-  }
+	// sign some random data
+	signer, err := signature.PublicKeySignFactory().GetPrimitive(privKeysetHandle)
+	if err != nil {
+		t.Errorf("getting sign primitive failed: %s", err)
+	}
+	data := random.GetRandomBytes(1211)
+	sig, err := signer.Sign(data)
+	if err != nil {
+		t.Errorf("signing failed: %s", err)
+	}
+	// verify with the same set of public keys should work
+	verifier, err := signature.PublicKeyVerifyFactory().GetPrimitive(pubKeysetHandle)
+	if err != nil {
+		t.Errorf("getting verify primitive failed: %s", err)
+	}
+	if err := verifier.Verify(sig, data); err != nil {
+		t.Errorf("verification failed: %s", err)
+	}
+	// verify with random key should fail
+	_, randomPub := newEcdsaKeysetKeypair(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P521,
+		tinkpb.OutputPrefixType_TINK,
+		1)
+	pubKeys = []*tinkpb.Keyset_Key{randomPub}
+	pubKeyset = util.NewKeyset(pubKeys[0].KeyId, pubKeys)
+	pubKeysetHandle, _ = tink.CleartextKeysetHandle().ParseKeyset(pubKeyset)
+	verifier, err = signature.PublicKeyVerifyFactory().GetPrimitive(pubKeysetHandle)
+	if err != nil {
+		t.Errorf("getting verify primitive failed: %s", err)
+	}
+	if err := verifier.Verify(sig, data); err == nil {
+		t.Errorf("verification with random key should fail: %s", err)
+	}
 }
 
 func newEcdsaKeysetKeypair(hashType commonpb.HashType,
-                      curve commonpb.EllipticCurveType,
-                      outputPrefixType tinkpb.OutputPrefixType,
-                      keyId uint32) (*tinkpb.Keyset_Key, *tinkpb.Keyset_Key) {
-  key := testutil.NewEcdsaPrivateKey(hashType, curve)
-  serializedKey, _ := proto.Marshal(key)
-  keyData := util.NewKeyData(signature.ECDSA_SIGN_TYPE_URL,
-                              serializedKey,
-                              tinkpb.KeyData_ASYMMETRIC_PRIVATE)
-  privKey := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyId, outputPrefixType)
+	curve commonpb.EllipticCurveType,
+	outputPrefixType tinkpb.OutputPrefixType,
+	keyId uint32) (*tinkpb.Keyset_Key, *tinkpb.Keyset_Key) {
+	key := testutil.NewEcdsaPrivateKey(hashType, curve)
+	serializedKey, _ := proto.Marshal(key)
+	keyData := util.NewKeyData(signature.ECDSA_SIGN_TYPE_URL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PRIVATE)
+	privKey := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyId, outputPrefixType)
 
-  serializedKey, _ = proto.Marshal(key.PublicKey)
-  keyData = util.NewKeyData(signature.ECDSA_VERIFY_TYPE_URL,
-                              serializedKey,
-                              tinkpb.KeyData_ASYMMETRIC_PUBLIC)
-  pubKey := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyId, outputPrefixType)
-  return privKey, pubKey
+	serializedKey, _ = proto.Marshal(key.PublicKey)
+	keyData = util.NewKeyData(signature.ECDSA_VERIFY_TYPE_URL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PUBLIC)
+	pubKey := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyId, outputPrefixType)
+	return privKey, pubKey
 }

--- a/go/signature/public_key_verify_config.go
+++ b/go/signature/public_key_verify_config.go
@@ -16,8 +16,8 @@
 package signature
 
 import (
-  "sync"
-  "github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/tink/tink"
+	"sync"
 )
 
 // PublicKeySignConfig contains convenience methods for initializing the Registry with native
@@ -34,32 +34,32 @@ import (
 var publicKeyVerifyConfigInstance *publicKeyVerifyConfig
 var publicKeyVerifyConfigOnce sync.Once
 
-type publicKeyVerifyConfig struct {}
+type publicKeyVerifyConfig struct{}
 
 // PublicKeyVerifyConfig creates an instance of publicKeyVerifyConfig if there isn't
 // and returns the instance.
 func PublicKeyVerifyConfig() *publicKeyVerifyConfig {
-  publicKeyVerifyConfigOnce.Do(func() {
-    publicKeyVerifyConfigInstance = new(publicKeyVerifyConfig)
-  })
-  return publicKeyVerifyConfigInstance
+	publicKeyVerifyConfigOnce.Do(func() {
+		publicKeyVerifyConfigInstance = new(publicKeyVerifyConfig)
+	})
+	return publicKeyVerifyConfigInstance
 }
 
 // RegisterStandardKeyTypes registers standard Aead key types and their managers
 // with the Registry.
 func (c *publicKeyVerifyConfig) RegisterStandardKeyTypes() (bool, error) {
-  return c.RegisterKeyManager(NewEcdsaVerifyKeyManager())
+	return c.RegisterKeyManager(NewEcdsaVerifyKeyManager())
 }
 
 // RegisterLegacyKeyTypes registers legacy Aead key types and their managers
 // with the Registry.
 func (c *publicKeyVerifyConfig) RegisterLegacyKeyTypes() (bool, error) {
-  return false, nil
+	return false, nil
 }
 
 // RegisterKeyManager registers the given keyManager for the key type given in
 // keyManager.KeyType(). It returns true if registration was successful, false if
 // there already exisits a key manager for the key type.
 func (c *publicKeyVerifyConfig) RegisterKeyManager(keyManager tink.KeyManager) (bool, error) {
-  return tink.Registry().RegisterKeyManager(keyManager)
+	return tink.Registry().RegisterKeyManager(keyManager)
 }

--- a/go/signature/public_key_verify_config_test.go
+++ b/go/signature/public_key_verify_config_test.go
@@ -16,27 +16,27 @@
 package signature_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/tink/tink"
+	"testing"
 )
 
 func TestPublicKeyVerifyConfigInstance(t *testing.T) {
-  config := signature.PublicKeyVerifyConfig()
-  if config == nil {
-    t.Errorf("instance of publicKeyVerifyConfig is nil")
-  }
+	config := signature.PublicKeyVerifyConfig()
+	if config == nil {
+		t.Errorf("instance of publicKeyVerifyConfig is nil")
+	}
 }
 
 func TestPublicKeyVerifyConfigRegistration(t *testing.T) {
-  _, err := signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
-  if err != nil {
-    t.Errorf("cannot register standard key types")
-  }
-  // check for EcdsaVerifyKeyManager
-  keyManager, err := tink.Registry().GetKeyManager(signature.ECDSA_VERIFY_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ = keyManager.(*signature.EcdsaVerifyKeyManager)
+	_, err := signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
+	if err != nil {
+		t.Errorf("cannot register standard key types")
+	}
+	// check for EcdsaVerifyKeyManager
+	keyManager, err := tink.Registry().GetKeyManager(signature.ECDSA_VERIFY_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ = keyManager.(*signature.EcdsaVerifyKeyManager)
 }

--- a/go/signature/public_key_verify_factory.go
+++ b/go/signature/public_key_verify_factory.go
@@ -16,48 +16,49 @@
 package signature
 
 import (
-  "fmt"
-  "sync"
-  "github.com/google/tink/go/tink/tink"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/tink/tink"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
 )
 
 // publicKeyVerifyFactory allows obtaining a PublicKeySign primitive from a
 // KeysetHandle.
 var publicKeyVerifyFactoryInstance *publicKeyVerifyFactory
 var publicKeyVerifyFactoryOnce sync.Once
-type publicKeyVerifyFactory struct {}
+
+type publicKeyVerifyFactory struct{}
 
 // PublicKeyVerifyFactory creates an instance of publicKeyVerifyFactory if there isn't
 // and returns the instance.
 func PublicKeyVerifyFactory() *publicKeyVerifyFactory {
-  publicKeyVerifyFactoryOnce.Do(func() {
-    publicKeyVerifyFactoryInstance = new(publicKeyVerifyFactory)
-  })
-  return publicKeyVerifyFactoryInstance
+	publicKeyVerifyFactoryOnce.Do(func() {
+		publicKeyVerifyFactoryInstance = new(publicKeyVerifyFactory)
+	})
+	return publicKeyVerifyFactoryInstance
 }
 
 // GetPrimitive returns a PublicKeyVerify primitive from the given keyset handle.
 func (f *publicKeyVerifyFactory) GetPrimitive(handle *tink.KeysetHandle) (tink.PublicKeyVerify, error) {
-  return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
+	return f.GetPrimitiveWithCustomerManager(handle, nil /*keyManager*/)
 }
 
 // GetPrimitiveWithCustomerManager returns a PublicKeyVerify primitive from the given
 // keyset handle and custom key manager.
 func (f *publicKeyVerifyFactory) GetPrimitiveWithCustomerManager(
-    handle *tink.KeysetHandle, manager tink.KeyManager) (tink.PublicKeyVerify, error) {
-  ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
-  if err != nil {
-    return nil, fmt.Errorf("public_key_verify_factory: cannot obtain primitive set: %s", err)
-  }
-  var ret = newprimitiveSetPublicKeyVerify(ps)
-  return ret, nil
+	handle *tink.KeysetHandle, manager tink.KeyManager) (tink.PublicKeyVerify, error) {
+	ps, err := tink.Registry().GetPrimitivesWithCustomManager(handle, manager)
+	if err != nil {
+		return nil, fmt.Errorf("public_key_verify_factory: cannot obtain primitive set: %s", err)
+	}
+	var ret = newprimitiveSetPublicKeyVerify(ps)
+	return ret, nil
 }
 
 // primitiveSetPublicKeyVerify is an PublicKeySign implementation that uses the
 // underlying primitive set for signing.
 type primitiveSetPublicKeyVerify struct {
-  ps *tink.PrimitiveSet
+	ps *tink.PrimitiveSet
 }
 
 // Asserts that primitiveSetPublicKeyVerify implements the PublicKeyVerify interface.
@@ -65,45 +66,46 @@ var _ tink.PublicKeyVerify = (*primitiveSetPublicKeyVerify)(nil)
 
 // newprimitiveSetPublicKeyVerify creates a new instance of primitiveSetPublicKeyVerify
 func newprimitiveSetPublicKeyVerify(ps *tink.PrimitiveSet) *primitiveSetPublicKeyVerify {
-  ret := new(primitiveSetPublicKeyVerify)
-  ret.ps = ps
-  return ret
+	ret := new(primitiveSetPublicKeyVerify)
+	ret.ps = ps
+	return ret
 }
 
 var errInvalidSignature = fmt.Errorf("public_key_verify_factory: invalid signature")
+
 // Verify checks whether the given signature is a valid signature of the given data.
 func (v *primitiveSetPublicKeyVerify) Verify(signature []byte, data []byte) error {
-  if len(signature) < tink.NON_RAW_PREFIX_SIZE {
-    return errInvalidSignature
-  }
-  // try non-raw keys
-  prefix := signature[:tink.NON_RAW_PREFIX_SIZE]
-  signatureNoPrefix := signature[tink.NON_RAW_PREFIX_SIZE:]
-  entries, err := v.ps.GetPrimitivesWithByteIdentifier(prefix)
-  if err == nil {
-    for i := 0; i < len(entries); i++ {
-      var signedData []byte
-      if entries[i].OutputPrefixType() == tinkpb.OutputPrefixType_LEGACY {
-        signedData = append(signedData, data...)
-        signedData = append(signedData, tink.LEGACY_START_BYTE)
-      } else {
-        signedData = data
-      }
-      var verifier = (entries[i].Primitive()).(tink.PublicKeyVerify)
-      if err := verifier.Verify(signatureNoPrefix, signedData); err == nil {
-        return nil
-      }
-    }
-  }
-  // try raw keys
-  entries, err = v.ps.GetRawPrimitives()
-  if err == nil {
-    for i := 0; i < len(entries); i++ {
-      var verifier = (entries[i].Primitive()).(tink.PublicKeyVerify)
-      if err := verifier.Verify(signature, data); err == nil {
-        return nil
-      }
-    }
-  }
-  return errInvalidSignature
+	if len(signature) < tink.NON_RAW_PREFIX_SIZE {
+		return errInvalidSignature
+	}
+	// try non-raw keys
+	prefix := signature[:tink.NON_RAW_PREFIX_SIZE]
+	signatureNoPrefix := signature[tink.NON_RAW_PREFIX_SIZE:]
+	entries, err := v.ps.GetPrimitivesWithByteIdentifier(prefix)
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			var signedData []byte
+			if entries[i].OutputPrefixType() == tinkpb.OutputPrefixType_LEGACY {
+				signedData = append(signedData, data...)
+				signedData = append(signedData, tink.LEGACY_START_BYTE)
+			} else {
+				signedData = data
+			}
+			var verifier = (entries[i].Primitive()).(tink.PublicKeyVerify)
+			if err := verifier.Verify(signatureNoPrefix, signedData); err == nil {
+				return nil
+			}
+		}
+	}
+	// try raw keys
+	entries, err = v.ps.GetRawPrimitives()
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			var verifier = (entries[i].Primitive()).(tink.PublicKeyVerify)
+			if err := verifier.Verify(signature, data); err == nil {
+				return nil
+			}
+		}
+	}
+	return errInvalidSignature
 }

--- a/go/signature/signature_key_templates.go
+++ b/go/signature/signature_key_templates.go
@@ -16,11 +16,11 @@
 package signature
 
 import (
-  "github.com/google/tink/go/util/util"
-  "github.com/golang/protobuf/proto"
-  ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/util/util"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // This file contains pre-generated KeyTemplate for PublicKeySign and PublicKeyVerify.
@@ -32,9 +32,9 @@ import (
 //   - Curve: NIST P-256
 //   - Signature encoding: DER
 func EcdsaP256KeyTemplate() *tinkpb.KeyTemplate {
-  return createEcdsaKeyTemplate(commonpb.HashType_SHA256,
-                                commonpb.EllipticCurveType_NIST_P256,
-                                ecdsapb.EcdsaSignatureEncoding_DER)
+	return createEcdsaKeyTemplate(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256,
+		ecdsapb.EcdsaSignatureEncoding_DER)
 }
 
 // EcdsaP384KeyTemplate is a KeyTemplate of EcdsaPrivateKey with the following parameters:
@@ -42,9 +42,9 @@ func EcdsaP256KeyTemplate() *tinkpb.KeyTemplate {
 //   - Curve: NIST P-384
 //   - Signature encoding: DER
 func EcdsaP384KeyTemplate() *tinkpb.KeyTemplate {
-  return createEcdsaKeyTemplate(commonpb.HashType_SHA512,
-                                commonpb.EllipticCurveType_NIST_P384,
-                                ecdsapb.EcdsaSignatureEncoding_DER)
+	return createEcdsaKeyTemplate(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P384,
+		ecdsapb.EcdsaSignatureEncoding_DER)
 }
 
 // EcdsaP521KeyTemplate is a KeyTemplate of EcdsaPrivateKey with the following parameters:
@@ -52,21 +52,21 @@ func EcdsaP384KeyTemplate() *tinkpb.KeyTemplate {
 //   - Curve: NIST P-521
 //   - Signature encoding: DER
 func EcdsaP521KeyTemplate() *tinkpb.KeyTemplate {
-  return createEcdsaKeyTemplate(commonpb.HashType_SHA512,
-                                commonpb.EllipticCurveType_NIST_P521,
-                                ecdsapb.EcdsaSignatureEncoding_DER)
+	return createEcdsaKeyTemplate(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P521,
+		ecdsapb.EcdsaSignatureEncoding_DER)
 }
 
 // createEcdsaKeyTemplate creates a KeyTemplate containing a EcdasKeyFormat
 // with the given parameters.
 func createEcdsaKeyTemplate(hashType commonpb.HashType,
-                            curve commonpb.EllipticCurveType,
-                            encoding ecdsapb.EcdsaSignatureEncoding) *tinkpb.KeyTemplate {
-  params := util.NewEcdsaParams(hashType, curve, encoding)
-  format := util.NewEcdsaKeyFormat(params)
-  serializedFormat, _ := proto.Marshal(format)
-  return &tinkpb.KeyTemplate{
-    TypeUrl: ECDSA_SIGN_TYPE_URL,
-    Value: serializedFormat,
-  }
+	curve commonpb.EllipticCurveType,
+	encoding ecdsapb.EcdsaSignatureEncoding) *tinkpb.KeyTemplate {
+	params := util.NewEcdsaParams(hashType, curve, encoding)
+	format := util.NewEcdsaKeyFormat(params)
+	serializedFormat, _ := proto.Marshal(format)
+	return &tinkpb.KeyTemplate{
+		TypeUrl: ECDSA_SIGN_TYPE_URL,
+		Value:   serializedFormat,
+	}
 }

--- a/go/signature/signature_key_templates_test.go
+++ b/go/signature/signature_key_templates_test.go
@@ -16,67 +16,67 @@
 package signature_test
 
 import (
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/golang/protobuf/proto"
-  ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/signature/signature"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestEcdsaKeyTemplates(t *testing.T) {
-  var template *tinkpb.KeyTemplate
-  var err error
-  // ECDSA P-256
-  template = signature.EcdsaP256KeyTemplate()
-  err = checkEcdsaKeyTemplate(template,
-                              commonpb.HashType_SHA256,
-                              commonpb.EllipticCurveType_NIST_P256,
-                              ecdsapb.EcdsaSignatureEncoding_DER)
-  if err != nil {
-    t.Errorf("invalid ECDSA P-256 key template: %s", err)
-  }
-  // ECDSA P-384
-  template = signature.EcdsaP384KeyTemplate()
-  err = checkEcdsaKeyTemplate(template,
-                              commonpb.HashType_SHA512,
-                              commonpb.EllipticCurveType_NIST_P384,
-                              ecdsapb.EcdsaSignatureEncoding_DER)
-  if err != nil {
-    t.Errorf("invalid ECDSA P-384 key template: %s", err)
-  }
-  // ECDSA P-521
-  template = signature.EcdsaP521KeyTemplate()
-  err = checkEcdsaKeyTemplate(template,
-                              commonpb.HashType_SHA512,
-                              commonpb.EllipticCurveType_NIST_P521,
-                              ecdsapb.EcdsaSignatureEncoding_DER)
-  if err != nil {
-    t.Errorf("invalid ECDSA P-521 key template: %s", err)
-  }
+	var template *tinkpb.KeyTemplate
+	var err error
+	// ECDSA P-256
+	template = signature.EcdsaP256KeyTemplate()
+	err = checkEcdsaKeyTemplate(template,
+		commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256,
+		ecdsapb.EcdsaSignatureEncoding_DER)
+	if err != nil {
+		t.Errorf("invalid ECDSA P-256 key template: %s", err)
+	}
+	// ECDSA P-384
+	template = signature.EcdsaP384KeyTemplate()
+	err = checkEcdsaKeyTemplate(template,
+		commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P384,
+		ecdsapb.EcdsaSignatureEncoding_DER)
+	if err != nil {
+		t.Errorf("invalid ECDSA P-384 key template: %s", err)
+	}
+	// ECDSA P-521
+	template = signature.EcdsaP521KeyTemplate()
+	err = checkEcdsaKeyTemplate(template,
+		commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P521,
+		ecdsapb.EcdsaSignatureEncoding_DER)
+	if err != nil {
+		t.Errorf("invalid ECDSA P-521 key template: %s", err)
+	}
 }
 
 func checkEcdsaKeyTemplate(template *tinkpb.KeyTemplate,
-                            hashType commonpb.HashType,
-                            curve commonpb.EllipticCurveType,
-                            encoding ecdsapb.EcdsaSignatureEncoding) error {
-  if template.TypeUrl != signature.ECDSA_SIGN_TYPE_URL {
-    return fmt.Errorf("incorrect typeurl: expect %s, got %s", signature.ECDSA_SIGN_TYPE_URL, template.TypeUrl)
-  }
-  format := new(ecdsapb.EcdsaKeyFormat)
-  if err := proto.Unmarshal(template.Value, format); err != nil {
-    return fmt.Errorf("cannot unmarshak key format: %s", err)
-  }
-  params := format.Params
-  if params.HashType != hashType {
-    return fmt.Errorf("incorrect hash type: expect %d, got %d", hashType, params.HashType)
-  }
-  if params.Curve != curve {
-    return fmt.Errorf("incorrect curve: expect %d, got %d", curve, params.Curve)
-  }
-  if params.Encoding != encoding {
-    return fmt.Errorf("incorrect encoding: expect %d, got %d", encoding, params.Encoding)
-  }
-  return nil
+	hashType commonpb.HashType,
+	curve commonpb.EllipticCurveType,
+	encoding ecdsapb.EcdsaSignatureEncoding) error {
+	if template.TypeUrl != signature.ECDSA_SIGN_TYPE_URL {
+		return fmt.Errorf("incorrect typeurl: expect %s, got %s", signature.ECDSA_SIGN_TYPE_URL, template.TypeUrl)
+	}
+	format := new(ecdsapb.EcdsaKeyFormat)
+	if err := proto.Unmarshal(template.Value, format); err != nil {
+		return fmt.Errorf("cannot unmarshak key format: %s", err)
+	}
+	params := format.Params
+	if params.HashType != hashType {
+		return fmt.Errorf("incorrect hash type: expect %d, got %d", hashType, params.HashType)
+	}
+	if params.Curve != curve {
+		return fmt.Errorf("incorrect curve: expect %d, got %d", curve, params.Curve)
+	}
+	if params.Encoding != encoding {
+		return fmt.Errorf("incorrect encoding: expect %d, got %d", encoding, params.Encoding)
+	}
+	return nil
 }

--- a/go/subtle/aes/aes_gcm.go
+++ b/go/subtle/aes/aes_gcm.go
@@ -15,22 +15,22 @@
 package aes
 
 import (
-  "fmt"
-  "crypto/aes"
-  "crypto/cipher"
-  "github.com/google/tink/go/tink/primitives"
-  "github.com/google/tink/go/subtle/random"
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink/primitives"
 )
 
 const (
-  // All instances of this class use a 12 byte IV and 16 byte tag
-  AES_GCM_IV_SIZE = 12
-  AES_GCM_TAG_SIZE = 16
+	// All instances of this class use a 12 byte IV and 16 byte tag
+	AES_GCM_IV_SIZE  = 12
+	AES_GCM_TAG_SIZE = 16
 )
 
 // AesGcm is an implementation of Aead interface.
 type AesGcm struct {
-  Key []byte
+	Key []byte
 }
 
 // Assert that AesGcm implements the Aead interface.
@@ -40,21 +40,21 @@ var _ tink.Aead = (*AesGcm)(nil)
 // The key argument should be the AES key, either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256.
 func NewAesGcm(key []byte) (*AesGcm, error) {
-  keySize := uint32(len(key))
-  if err := ValidateAesKeySize(keySize); err != nil {
-    return nil, fmt.Errorf("aes_gcm: %s", err)
-  }
-  return &AesGcm{Key: key}, nil
+	keySize := uint32(len(key))
+	if err := ValidateAesKeySize(keySize); err != nil {
+		return nil, fmt.Errorf("aes_gcm: %s", err)
+	}
+	return &AesGcm{Key: key}, nil
 }
 
 // ValidateAesKeySize checks if the given key size is a valid AES key size.
 func ValidateAesKeySize(sizeInBytes uint32) error {
-  switch sizeInBytes {
-    case 16, 24, 32:
-      return nil
-    default:
-      return fmt.Errorf("invalid AES key size %d", sizeInBytes)
-  }
+	switch sizeInBytes {
+	case 16, 24, 32:
+		return nil
+	default:
+		return fmt.Errorf("invalid AES key size %d", sizeInBytes)
+	}
 }
 
 // Encrypt encrypts {@code pt} with {@code aad} as additional
@@ -64,56 +64,56 @@ func ValidateAesKeySize(sizeInBytes uint32) error {
 // Note: AES-GCM implementation of crypto library always returns ciphertext with
 // 128-bit tag.
 func (a *AesGcm) Encrypt(pt []byte, aad []byte) ([]byte, error) {
-  // Although Seal() function already checks for plaintext length,
-  // this check is repeated here to avoid panic.
-  if uint64(len(pt)) > (1<<36)-32 {
-    return nil, fmt.Errorf("aes_gcm: plaintext too long")
-  }
-  cipher, err := a.newCipher(a.Key)
-  if err != nil {
-    return nil, err
-  }
-  iv := a.newIV()
-  ct := cipher.Seal(nil, iv, pt, aad)
-  var ret []byte
-  ret = append(ret, iv...)
-  ret = append(ret, ct...)
-  return ret, nil
+	// Although Seal() function already checks for plaintext length,
+	// this check is repeated here to avoid panic.
+	if uint64(len(pt)) > (1<<36)-32 {
+		return nil, fmt.Errorf("aes_gcm: plaintext too long")
+	}
+	cipher, err := a.newCipher(a.Key)
+	if err != nil {
+		return nil, err
+	}
+	iv := a.newIV()
+	ct := cipher.Seal(nil, iv, pt, aad)
+	var ret []byte
+	ret = append(ret, iv...)
+	ret = append(ret, ct...)
+	return ret, nil
 }
 
 // Decrypt decrypts {@code ct} with {@code aad} as the additionalauthenticated data.
 func (a *AesGcm) Decrypt(ct []byte, aad []byte) ([]byte, error) {
-  if len(ct) < AES_GCM_IV_SIZE + AES_GCM_TAG_SIZE {
-    return nil, fmt.Errorf("aes_gcm: ciphertext too short")
-  }
-  cipher, err := a.newCipher(a.Key)
-  if err != nil {
-    return nil, err
-  }
-  iv := ct[:AES_GCM_IV_SIZE]
-  pt, err := cipher.Open(nil, iv, ct[AES_GCM_IV_SIZE:], aad)
-  if err != nil {
-    return nil, fmt.Errorf("aes_gcm: %s", err)
-  }
-  return pt, nil
+	if len(ct) < AES_GCM_IV_SIZE+AES_GCM_TAG_SIZE {
+		return nil, fmt.Errorf("aes_gcm: ciphertext too short")
+	}
+	cipher, err := a.newCipher(a.Key)
+	if err != nil {
+		return nil, err
+	}
+	iv := ct[:AES_GCM_IV_SIZE]
+	pt, err := cipher.Open(nil, iv, ct[AES_GCM_IV_SIZE:], aad)
+	if err != nil {
+		return nil, fmt.Errorf("aes_gcm: %s", err)
+	}
+	return pt, nil
 }
 
 // newIV creates a new IV for encryption.
 func (a *AesGcm) newIV() []byte {
-  return random.GetRandomBytes(AES_GCM_IV_SIZE)
+	return random.GetRandomBytes(AES_GCM_IV_SIZE)
 }
 
 var errCipher = fmt.Errorf("aes_gcm: initializing cipher failed")
 
 // newCipher creates a new AES-GCM cipher using the given key and the crypto library.
 func (a *AesGcm) newCipher(key []byte) (cipher.AEAD, error) {
-  aesCipher, err := aes.NewCipher(key)
-  if err != nil {
-    return nil, errCipher
-  }
-  ret, err := cipher.NewGCM(aesCipher)
-  if err != nil {
-    return nil, errCipher
-  }
-  return ret, nil
+	aesCipher, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errCipher
+	}
+	ret, err := cipher.NewGCM(aesCipher)
+	if err != nil {
+		return nil, errCipher
+	}
+	return ret, nil
 }

--- a/go/subtle/aes/aes_gcm_test.go
+++ b/go/subtle/aes/aes_gcm_test.go
@@ -15,13 +15,13 @@
 package aes_test
 
 import (
-  "bytes"
-  "encoding/hex"
-  "encoding/json"
-  "os"
-  "testing"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/subtle/aes"
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/google/tink/go/subtle/aes"
+	"github.com/google/tink/go/subtle/random"
+	"os"
+	"testing"
 )
 
 var keySizes = []int{16, 24, 32}
@@ -29,107 +29,107 @@ var keySizes = []int{16, 24, 32}
 // Since the tag size depends on the Seal() function of crypto library,
 // this test checks that the tag size is always 128 bit.
 func TestAesGcmTagLength(t *testing.T) {
-  for _, keySize := range keySizes {
-    key := random.GetRandomBytes(uint32(keySize))
-    a, _ := aes.NewAesGcm(key)
-    ad := random.GetRandomBytes(32)
-    pt := random.GetRandomBytes(32)
-    ct, _ := a.Encrypt(pt, ad)
-    actualTagSize := len(ct) - aes.AES_GCM_IV_SIZE - len(pt)
-    if actualTagSize != aes.AES_GCM_TAG_SIZE {
-      t.Errorf("tag size is not 128 bit, it is %d bit", actualTagSize*8)
-    }
-  }
+	for _, keySize := range keySizes {
+		key := random.GetRandomBytes(uint32(keySize))
+		a, _ := aes.NewAesGcm(key)
+		ad := random.GetRandomBytes(32)
+		pt := random.GetRandomBytes(32)
+		ct, _ := a.Encrypt(pt, ad)
+		actualTagSize := len(ct) - aes.AES_GCM_IV_SIZE - len(pt)
+		if actualTagSize != aes.AES_GCM_TAG_SIZE {
+			t.Errorf("tag size is not 128 bit, it is %d bit", actualTagSize*8)
+		}
+	}
 }
 
 func TestAesGcmKeySize(t *testing.T) {
-  for _, keySize := range keySizes {
-    if _, err := aes.NewAesGcm(make([]byte, keySize)); err != nil {
-      t.Errorf("unexpected error when key size is %d btyes", keySize)
-    }
-    if _, err := aes.NewAesGcm(make([]byte, keySize+1)); err == nil {
-      t.Errorf("expect an error when key size is not supported %d", keySize)
-    }
-  }
+	for _, keySize := range keySizes {
+		if _, err := aes.NewAesGcm(make([]byte, keySize)); err != nil {
+			t.Errorf("unexpected error when key size is %d btyes", keySize)
+		}
+		if _, err := aes.NewAesGcm(make([]byte, keySize+1)); err == nil {
+			t.Errorf("expect an error when key size is not supported %d", keySize)
+		}
+	}
 }
 
 func TestAesGcmEncryptDecrypt(t *testing.T) {
-  for _, keySize := range keySizes {
-    key := random.GetRandomBytes(uint32(keySize))
-    a, err := aes.NewAesGcm(key)
-    if err != nil {
-      t.Errorf("unexpected error when creating new cipher: %s", err)
-    }
-    ad := random.GetRandomBytes(5)
-    for ptSize := 0; ptSize < 75; ptSize++ {
-      pt := random.GetRandomBytes(uint32(ptSize))
-      ct, err := a.Encrypt(pt, ad)
-      if err != nil {
-        t.Errorf("unexpected error in encryption: keySize %v, ptSize %v", keySize, ptSize)
-      }
-      decrypted, err := a.Decrypt(ct, ad)
-      if err != nil {
-        t.Errorf("unexpected error in decryption: keySize %v, ptSize %v", keySize, ptSize)
-      }
-      if !bytes.Equal(pt, decrypted) {
-        t.Errorf("decrypted text and plaintext don't match: keySize %v, ptSize %v", keySize, ptSize)
-      }
-    }
-  }
+	for _, keySize := range keySizes {
+		key := random.GetRandomBytes(uint32(keySize))
+		a, err := aes.NewAesGcm(key)
+		if err != nil {
+			t.Errorf("unexpected error when creating new cipher: %s", err)
+		}
+		ad := random.GetRandomBytes(5)
+		for ptSize := 0; ptSize < 75; ptSize++ {
+			pt := random.GetRandomBytes(uint32(ptSize))
+			ct, err := a.Encrypt(pt, ad)
+			if err != nil {
+				t.Errorf("unexpected error in encryption: keySize %v, ptSize %v", keySize, ptSize)
+			}
+			decrypted, err := a.Decrypt(ct, ad)
+			if err != nil {
+				t.Errorf("unexpected error in decryption: keySize %v, ptSize %v", keySize, ptSize)
+			}
+			if !bytes.Equal(pt, decrypted) {
+				t.Errorf("decrypted text and plaintext don't match: keySize %v, ptSize %v", keySize, ptSize)
+			}
+		}
+	}
 }
 
 func TestAesGcmLongMessages(t *testing.T) {
-  ptSize := 16
-  for ptSize <= 1<<24 {
-    pt := random.GetRandomBytes(uint32(ptSize))
-    ad := random.GetRandomBytes(uint32(ptSize/3))
-    for _, keySize := range keySizes {
-      key := random.GetRandomBytes(uint32(keySize))
-      a, _ := aes.NewAesGcm(key)
-      ct, _ := a.Encrypt(pt, ad)
-      decrypted, _ := a.Decrypt(ct, ad)
-      if !bytes.Equal(pt, decrypted) {
-        t.Errorf("decrypted text and plaintext don't match: keySize %v, ptSize %v", keySize, ptSize)
-      }
-    }
-    ptSize += 5*ptSize/11
-  }
+	ptSize := 16
+	for ptSize <= 1<<24 {
+		pt := random.GetRandomBytes(uint32(ptSize))
+		ad := random.GetRandomBytes(uint32(ptSize / 3))
+		for _, keySize := range keySizes {
+			key := random.GetRandomBytes(uint32(keySize))
+			a, _ := aes.NewAesGcm(key)
+			ct, _ := a.Encrypt(pt, ad)
+			decrypted, _ := a.Decrypt(ct, ad)
+			if !bytes.Equal(pt, decrypted) {
+				t.Errorf("decrypted text and plaintext don't match: keySize %v, ptSize %v", keySize, ptSize)
+			}
+		}
+		ptSize += 5 * ptSize / 11
+	}
 }
 
 func TestAesGcmModifyCiphertext(t *testing.T) {
-  ad := random.GetRandomBytes(33)
-  key := random.GetRandomBytes(16)
-  pt := random.GetRandomBytes(32)
-  a, _ := aes.NewAesGcm(key)
-  ct, _ := a.Encrypt(pt, ad)
-  // flipping bits
-  for i := 0; i < len(ct); i++ {
-    tmp := ct[i]
-    for j := 0; j < 8; j++ {
-      ct[i] ^= 1 << uint8(j)
-      if _, err := a.Decrypt(ct, ad); err == nil {
-        t.Errorf("expect an error when flipping bit of ciphertext: byte %d, bit %d", i, j)
-      }
-      ct[i] = tmp
-    }
-  }
-  // truncated ciphertext
-  for i := 1; i < len(ct); i++ {
-    if _, err := a.Decrypt(ct[:i], ad); err == nil {
-      t.Errorf("expect an error ciphertext is truncated until byte %s", i)
-    }
-  }
-  // modify additinal authenticated data
-  for i := 0; i < len(ad); i++ {
-    tmp := ad[i]
-    for j := 0; j < 8; j++ {
-      ad[i] ^= 1 << uint8(j)
-      if _, err := a.Decrypt(ct, ad); err == nil {
-        t.Errorf("expect an error when flipping bit of ad: byte %d, bit %d", i, j)
-      }
-      ad[i] = tmp
-    }
-  }
+	ad := random.GetRandomBytes(33)
+	key := random.GetRandomBytes(16)
+	pt := random.GetRandomBytes(32)
+	a, _ := aes.NewAesGcm(key)
+	ct, _ := a.Encrypt(pt, ad)
+	// flipping bits
+	for i := 0; i < len(ct); i++ {
+		tmp := ct[i]
+		for j := 0; j < 8; j++ {
+			ct[i] ^= 1 << uint8(j)
+			if _, err := a.Decrypt(ct, ad); err == nil {
+				t.Errorf("expect an error when flipping bit of ciphertext: byte %d, bit %d", i, j)
+			}
+			ct[i] = tmp
+		}
+	}
+	// truncated ciphertext
+	for i := 1; i < len(ct); i++ {
+		if _, err := a.Decrypt(ct[:i], ad); err == nil {
+			t.Errorf("expect an error ciphertext is truncated until byte %s", i)
+		}
+	}
+	// modify additinal authenticated data
+	for i := 0; i < len(ad); i++ {
+		tmp := ad[i]
+		for j := 0; j < 8; j++ {
+			ad[i] ^= 1 << uint8(j)
+			if _, err := a.Decrypt(ct, ad); err == nil {
+				t.Errorf("expect an error when flipping bit of ad: byte %d, bit %d", i, j)
+			}
+			ad[i] = tmp
+		}
+	}
 }
 
 /**
@@ -138,110 +138,110 @@ func TestAesGcmModifyCiphertext(t *testing.T) {
  * message are distinct.
  */
 func TestAesGcmRandomNonce(t *testing.T) {
-  nSample := 1 << 17
-  key := random.GetRandomBytes(16)
-  pt := []byte{}
-  ad := []byte{}
-  a, _ := aes.NewAesGcm(key)
-  ctSet := make(map[string]bool)
-  for i := 0; i < nSample; i++ {
-    ct, _ := a.Encrypt(pt, ad)
-    ctHex := hex.EncodeToString(ct)
-    _, existed := ctSet[ctHex]
-    if existed {
-      t.Errorf("nonce is repeated after %d samples", i)
-    }
-    ctSet[ctHex] = true
-  }
+	nSample := 1 << 17
+	key := random.GetRandomBytes(16)
+	pt := []byte{}
+	ad := []byte{}
+	a, _ := aes.NewAesGcm(key)
+	ctSet := make(map[string]bool)
+	for i := 0; i < nSample; i++ {
+		ct, _ := a.Encrypt(pt, ad)
+		ctHex := hex.EncodeToString(ct)
+		_, existed := ctSet[ctHex]
+		if existed {
+			t.Errorf("nonce is repeated after %d samples", i)
+		}
+		ctSet[ctHex] = true
+	}
 }
 
 type testdata struct {
-  Algorithm string
-  GeneratorVersion string
-  NumberOfTests uint32
-  TestGroups []*testgroup
+	Algorithm        string
+	GeneratorVersion string
+	NumberOfTests    uint32
+	TestGroups       []*testgroup
 }
 
 type testgroup struct {
-  IvSize uint32
-  KeySize uint32
-  TagSize uint32
-  Type string
-  Tests []*testcase
+	IvSize  uint32
+	KeySize uint32
+	TagSize uint32
+	Type    string
+	Tests   []*testcase
 }
 
 type testcase struct {
-  Aad string
-  Comment string
-  Ct string
-  Iv string
-  Key string
-  Msg string
-  Result string
-  Tag string
-  TcId uint32
+	Aad     string
+	Comment string
+	Ct      string
+	Iv      string
+	Key     string
+	Msg     string
+	Result  string
+	Tag     string
+	TcId    uint32
 }
 
 func TestVectors(t *testing.T) {
-  f, err := os.Open("../../../wycheproof/testvectors/aes_gcm_test.json")
-  if err != nil {
-    t.Fatal("cannot open file: %s", err)
-  }
-  parser := json.NewDecoder(f)
-  data := new(testdata)
-  if err := parser.Decode(data); err != nil {
-    t.Fatal("cannot decode test data: %s", err)
-  }
+	f, err := os.Open("../../../wycheproof/testvectors/aes_gcm_test.json")
+	if err != nil {
+		t.Fatal("cannot open file: %s", err)
+	}
+	parser := json.NewDecoder(f)
+	data := new(testdata)
+	if err := parser.Decode(data); err != nil {
+		t.Fatal("cannot decode test data: %s", err)
+	}
 
-  for _, g := range data.TestGroups {
-    if err := aes.ValidateAesKeySize(g.KeySize/8); err != nil {
-      continue
-    }
-    if g.IvSize != aes.AES_GCM_IV_SIZE*8 {
-      continue
-    }
-    for _, tc := range g.Tests {
-      key, err := hex.DecodeString(tc.Key)
-      if err != nil {
-        t.Errorf("cannot decode key in test case %d: %s", tc.TcId, err)
-      }
-      aad, err := hex.DecodeString(tc.Aad)
-      if err != nil {
-        t.Errorf("cannot decode aad in test case %d: %s", tc.TcId, err)
-      }
-      msg, err := hex.DecodeString(tc.Msg)
-      if err != nil {
-        t.Errorf("cannot decode msg in test case %d: %s", tc.TcId, err)
-      }
-      ct, err := hex.DecodeString(tc.Ct)
-      if err != nil {
-        t.Errorf("cannot decode ct in test case %d: %s", tc.TcId, err)
-      }
-      iv, err := hex.DecodeString(tc.Iv)
-      if err != nil {
-        t.Errorf("cannot decode iv in test case %d: %s", tc.TcId, err)
-      }
-      tag, err := hex.DecodeString(tc.Tag)
-      if err != nil {
-        t.Errorf("cannot decode tag in test case %d: %s", tc.TcId, err)
-      }
-      var combinedCt []byte
-      combinedCt = append(combinedCt, iv...)
-      combinedCt = append(combinedCt, ct...)
-      combinedCt = append(combinedCt, tag...)
-      // create cipher and do encryption
-      cipher, err := aes.NewAesGcm(key)
-      if err != nil {
-        t.Errorf("cannot create new instance of AesGcm in test case %d: %s", tc.TcId, err)
-        continue
-      }
-      decrypted, err := cipher.Decrypt(combinedCt, aad)
-      if err != nil {
-        t.Errorf("unexpected error in test case %d: %s", tc.TcId, err)
-      }
-      if bytes.Compare(decrypted, msg) != 0 {
-        t.Errorf("failed in test case %d", tc.TcId)
-      }
-    }
-  }
+	for _, g := range data.TestGroups {
+		if err := aes.ValidateAesKeySize(g.KeySize / 8); err != nil {
+			continue
+		}
+		if g.IvSize != aes.AES_GCM_IV_SIZE*8 {
+			continue
+		}
+		for _, tc := range g.Tests {
+			key, err := hex.DecodeString(tc.Key)
+			if err != nil {
+				t.Errorf("cannot decode key in test case %d: %s", tc.TcId, err)
+			}
+			aad, err := hex.DecodeString(tc.Aad)
+			if err != nil {
+				t.Errorf("cannot decode aad in test case %d: %s", tc.TcId, err)
+			}
+			msg, err := hex.DecodeString(tc.Msg)
+			if err != nil {
+				t.Errorf("cannot decode msg in test case %d: %s", tc.TcId, err)
+			}
+			ct, err := hex.DecodeString(tc.Ct)
+			if err != nil {
+				t.Errorf("cannot decode ct in test case %d: %s", tc.TcId, err)
+			}
+			iv, err := hex.DecodeString(tc.Iv)
+			if err != nil {
+				t.Errorf("cannot decode iv in test case %d: %s", tc.TcId, err)
+			}
+			tag, err := hex.DecodeString(tc.Tag)
+			if err != nil {
+				t.Errorf("cannot decode tag in test case %d: %s", tc.TcId, err)
+			}
+			var combinedCt []byte
+			combinedCt = append(combinedCt, iv...)
+			combinedCt = append(combinedCt, ct...)
+			combinedCt = append(combinedCt, tag...)
+			// create cipher and do encryption
+			cipher, err := aes.NewAesGcm(key)
+			if err != nil {
+				t.Errorf("cannot create new instance of AesGcm in test case %d: %s", tc.TcId, err)
+				continue
+			}
+			decrypted, err := cipher.Decrypt(combinedCt, aad)
+			if err != nil {
+				t.Errorf("unexpected error in test case %d: %s", tc.TcId, err)
+			}
+			if bytes.Compare(decrypted, msg) != 0 {
+				t.Errorf("failed in test case %d", tc.TcId)
+			}
+		}
+	}
 }

--- a/go/subtle/ecdsa/ecdsa.go
+++ b/go/subtle/ecdsa/ecdsa.go
@@ -15,67 +15,67 @@
 package ecdsa
 
 import (
-  "fmt"
-  "math/big"
+	"fmt"
+	"math/big"
 )
 
 var errUnsupportedEncoding = fmt.Errorf("ecdsa: unsupported encoding")
 
 // ecdsaSignature is a struct holding r and s values of an ECDSA signature.
 type EcdsaSignature struct {
-  R, S *big.Int
+	R, S *big.Int
 }
 
 // newSignature creates a new ecdsaSignature object.
 func NewSignature(r, s *big.Int) *EcdsaSignature {
-  return &EcdsaSignature{R: r, S: s}
+	return &EcdsaSignature{R: r, S: s}
 }
 
 // Encode converts the signature to the given encoding format.
 // Only DER encoding is supported now.
 func (sig *EcdsaSignature) Encode(encoding string) ([]byte, error) {
-  switch encoding {
-    case "DER":
-      return asn1encode(sig)
-    default:
-      return nil, errUnsupportedEncoding
-  }
+	switch encoding {
+	case "DER":
+		return asn1encode(sig)
+	default:
+		return nil, errUnsupportedEncoding
+	}
 }
 
 // DecodeSignature creates a new ECDSA signature using the given byte slice.
 // The function assumes that the byte slice is the concatenation of the BigEndian
 // representation of two big integer r and s.
 func DecodeSignature(encodedBytes []byte,
-                      encoding string) (*EcdsaSignature, error) {
-  switch encoding {
-    case "DER":
-      return asn1decode(encodedBytes)
-    default:
-      return nil, errUnsupportedEncoding
-  }
+	encoding string) (*EcdsaSignature, error) {
+	switch encoding {
+	case "DER":
+		return asn1decode(encodedBytes)
+	default:
+		return nil, errUnsupportedEncoding
+	}
 }
 
 // ValidateEcdsaParams validates ECDSA parameters.
 // The hash's strength must not be weaker than the curve's strength.
 // Only DER encoding is supported now.
 func ValidateParams(hashAlg string, curve string, encoding string) error {
-  switch encoding {
-    case "DER":
-      break
-    default:
-      return errUnsupportedEncoding
-  }
-  switch curve {
-    case "NIST_P256":
-      if hashAlg != "SHA256" {
-        return fmt.Errorf("invalid hash type, expect SHA-256")
-      }
-    case "NIST_P384", "NIST_P521":
-      if hashAlg != "SHA512" {
-        return fmt.Errorf("invalid hash type, expect SHA-512")
-      }
-    default:
-      return fmt.Errorf("unsupported curve: %d", curve)
-  }
-  return nil
+	switch encoding {
+	case "DER":
+		break
+	default:
+		return errUnsupportedEncoding
+	}
+	switch curve {
+	case "NIST_P256":
+		if hashAlg != "SHA256" {
+			return fmt.Errorf("invalid hash type, expect SHA-256")
+		}
+	case "NIST_P384", "NIST_P521":
+		if hashAlg != "SHA512" {
+			return fmt.Errorf("invalid hash type, expect SHA-512")
+		}
+	default:
+		return fmt.Errorf("unsupported curve: %d", curve)
+	}
+	return nil
 }

--- a/go/subtle/ecdsa/ecdsa_sign.go
+++ b/go/subtle/ecdsa/ecdsa_sign.go
@@ -15,21 +15,21 @@
 package ecdsa
 
 import (
-  "fmt"
-  "hash"
-  "math/big"
-  "crypto/ecdsa"
-  "crypto/rand"
-  "github.com/google/tink/go/tink/primitives"
-  "github.com/google/tink/go/subtle/subtleutil"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/primitives"
+	"hash"
+	"math/big"
 )
 
 // ecdsaSign is an implementation of PublicKeySign for ECDSA.
 // At the moment, the implementation only accepts DER encoding.
 type EcdsaSign struct {
-  privateKey *ecdsa.PrivateKey
-  hashFunc func() hash.Hash
-  encoding string
+	privateKey *ecdsa.PrivateKey
+	hashFunc   func() hash.Hash
+	encoding   string
 }
 
 // Assert that ecdsaSign implements the PublicKeySign interface.
@@ -37,46 +37,46 @@ var _ tink.PublicKeySign = (*EcdsaSign)(nil)
 
 // NewEcdsaSign creates a new instance of EcdsaSign.
 func NewEcdsaSign(hashAlg string,
-                curve string,
-                encoding string,
-                keyValue []byte) (*EcdsaSign, error) {
-  publicKey := ecdsa.PublicKey{Curve: subtleutil.GetCurve(curve), X: nil, Y: nil}
-  d := new(big.Int).SetBytes(keyValue)
-  privateKey := &ecdsa.PrivateKey{PublicKey: publicKey, D: d}
-  return NewEcdsaSignFromPrivateKey(hashAlg, encoding, privateKey)
+	curve string,
+	encoding string,
+	keyValue []byte) (*EcdsaSign, error) {
+	publicKey := ecdsa.PublicKey{Curve: subtleutil.GetCurve(curve), X: nil, Y: nil}
+	d := new(big.Int).SetBytes(keyValue)
+	privateKey := &ecdsa.PrivateKey{PublicKey: publicKey, D: d}
+	return NewEcdsaSignFromPrivateKey(hashAlg, encoding, privateKey)
 }
 
 // NewEcdsaSignFromPrivateKey creates a new instance of EcdsaSign
 func NewEcdsaSignFromPrivateKey(hashAlg string,
-                              encoding string,
-                              privateKey *ecdsa.PrivateKey) (*EcdsaSign, error) {
-  if privateKey.Curve == nil {
-    return nil, fmt.Errorf("ecdsa_sign: invalid curve")
-  }
-  curve := subtleutil.ConvertCurveName(privateKey.Curve.Params().Name)
-  if err := ValidateParams(hashAlg, curve, encoding); err != nil {
-    return nil, fmt.Errorf("ecdsa_sign: %s", err)
-  }
-  hashFunc := subtleutil.GetHashFunc(hashAlg)
-  return &EcdsaSign{
-    privateKey: privateKey,
-    hashFunc: hashFunc,
-    encoding: encoding,
-  }, nil
+	encoding string,
+	privateKey *ecdsa.PrivateKey) (*EcdsaSign, error) {
+	if privateKey.Curve == nil {
+		return nil, fmt.Errorf("ecdsa_sign: invalid curve")
+	}
+	curve := subtleutil.ConvertCurveName(privateKey.Curve.Params().Name)
+	if err := ValidateParams(hashAlg, curve, encoding); err != nil {
+		return nil, fmt.Errorf("ecdsa_sign: %s", err)
+	}
+	hashFunc := subtleutil.GetHashFunc(hashAlg)
+	return &EcdsaSign{
+		privateKey: privateKey,
+		hashFunc:   hashFunc,
+		encoding:   encoding,
+	}, nil
 }
 
 // Sign computes a signature for the given data.
 func (e *EcdsaSign) Sign(data []byte) ([]byte, error) {
-  hashed := subtleutil.ComputeHash(e.hashFunc, data)
-  r, s, err := ecdsa.Sign(rand.Reader, e.privateKey, hashed)
-  if err != nil {
-    return nil, fmt.Errorf("ecdsa_sign: signing failed: %s", err)
-  }
-  // format the signature
-  sig := NewSignature(r, s)
-  ret, err := sig.Encode(e.encoding)
-  if err != nil {
-    return nil, fmt.Errorf("ecdsa_sign: signing failed: %s", err)
-  }
-  return ret, nil
+	hashed := subtleutil.ComputeHash(e.hashFunc, data)
+	r, s, err := ecdsa.Sign(rand.Reader, e.privateKey, hashed)
+	if err != nil {
+		return nil, fmt.Errorf("ecdsa_sign: signing failed: %s", err)
+	}
+	// format the signature
+	sig := NewSignature(r, s)
+	ret, err := sig.Encode(e.encoding)
+	if err != nil {
+		return nil, fmt.Errorf("ecdsa_sign: signing failed: %s", err)
+	}
+	return ret, nil
 }

--- a/go/subtle/ecdsa/ecdsa_sign_verify_test.go
+++ b/go/subtle/ecdsa/ecdsa_sign_verify_test.go
@@ -15,135 +15,135 @@
 package ecdsa_test
 
 import (
-  "fmt"
-  "testing"
-  "os"
-  "encoding/json"
-  "encoding/hex"
-  "crypto/ecdsa"
-  "crypto/rand"
-  "github.com/google/tink/go/subtle/random"
-  subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/google/tink/go/subtle/subtleutil"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	subtleEcdsa "github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"os"
+	"testing"
 )
 
 func TestSignVerify(t *testing.T) {
-  data := random.GetRandomBytes(20)
-  hash := "SHA256"
-  curve := "NIST_P256"
-  encoding := "DER"
-  priv, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curve), rand.Reader)
-  // Use the private key and public key directly to create new instances
-  signer, err := subtleEcdsa.NewEcdsaSignFromPrivateKey(hash, encoding, priv)
-  if err != nil {
-    t.Errorf("unexpected error when creating EcdsaSign: %s", err)
-  }
-  verifier, err := subtleEcdsa.NewEcdsaVerifyFromPublicKey(hash, encoding, &priv.PublicKey)
-  if err != nil {
-    t.Errorf("unexpected error when creating EcdsaVerify: %s", err)
-  }
-  signature, err := signer.Sign(data)
-  if err != nil {
-    t.Errorf("unexpected error when signing: %s", err)
-  }
-  err = verifier.Verify(signature, data)
-  if err != nil {
-    t.Errorf("unexpected error when verifying: %s", err)
-  }
+	data := random.GetRandomBytes(20)
+	hash := "SHA256"
+	curve := "NIST_P256"
+	encoding := "DER"
+	priv, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curve), rand.Reader)
+	// Use the private key and public key directly to create new instances
+	signer, err := subtleEcdsa.NewEcdsaSignFromPrivateKey(hash, encoding, priv)
+	if err != nil {
+		t.Errorf("unexpected error when creating EcdsaSign: %s", err)
+	}
+	verifier, err := subtleEcdsa.NewEcdsaVerifyFromPublicKey(hash, encoding, &priv.PublicKey)
+	if err != nil {
+		t.Errorf("unexpected error when creating EcdsaVerify: %s", err)
+	}
+	signature, err := signer.Sign(data)
+	if err != nil {
+		t.Errorf("unexpected error when signing: %s", err)
+	}
+	err = verifier.Verify(signature, data)
+	if err != nil {
+		t.Errorf("unexpected error when verifying: %s", err)
+	}
 
-  // Use byte slices to create new instances
-  signer, err = subtleEcdsa.NewEcdsaSign(hash, curve, encoding, priv.D.Bytes())
-  if err != nil {
-    t.Errorf("unexpected error when creating EcdsaSign: %s", err)
-  }
-  verifier, err = subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, priv.X.Bytes(), priv.Y.Bytes())
-  if err != nil {
-    t.Errorf("unexpected error when creating EcdsaVerify: %s", err)
-  }
-  signature, err = signer.Sign(data)
-  if err != nil {
-    t.Errorf("unexpected error when signing: %s", err)
-  }
-  err = verifier.Verify(signature, data)
-  if err != nil {
-    t.Errorf("unexpected error when verifying: %s", err)
-  }
+	// Use byte slices to create new instances
+	signer, err = subtleEcdsa.NewEcdsaSign(hash, curve, encoding, priv.D.Bytes())
+	if err != nil {
+		t.Errorf("unexpected error when creating EcdsaSign: %s", err)
+	}
+	verifier, err = subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, priv.X.Bytes(), priv.Y.Bytes())
+	if err != nil {
+		t.Errorf("unexpected error when creating EcdsaVerify: %s", err)
+	}
+	signature, err = signer.Sign(data)
+	if err != nil {
+		t.Errorf("unexpected error when signing: %s", err)
+	}
+	err = verifier.Verify(signature, data)
+	if err != nil {
+		t.Errorf("unexpected error when verifying: %s", err)
+	}
 }
 
 type testData struct {
-  Algorithm string
-  GeneratorVersion string
-  NumberOfTests uint32
-  TestGroups []*testGroup
+	Algorithm        string
+	GeneratorVersion string
+	NumberOfTests    uint32
+	TestGroups       []*testGroup
 }
 
 type testGroup struct {
-  KeyDer string
-  KeyPem string
-  Sha string
-  Type string
-  Key *testKey
-  Tests []*testcase
+	KeyDer string
+	KeyPem string
+	Sha    string
+	Type   string
+	Key    *testKey
+	Tests  []*testcase
 }
 
 type testKey struct {
-  Curve string
-  Type string
-  Wx string
-  Wy string
+	Curve string
+	Type  string
+	Wx    string
+	Wy    string
 }
 
 type testcase struct {
-  Comment string
-  Message string
-  Result string
-  Sig string
-  TcId uint32
+	Comment string
+	Message string
+	Result  string
+	Sig     string
+	TcId    uint32
 }
 
 func TestVectors(t *testing.T) {
-  f, err := os.Open("../../../wycheproof/testvectors/ecdsa_test.json")
-  if err != nil {
-    t.Errorf("cannot open file: %s", err)
-  }
-  parser := json.NewDecoder(f)
-  content := new(testData)
-  if err := parser.Decode(content); err != nil {
-    t.Errorf("cannot decode content of file: %s", err)
-  }
-  for _, g := range content.TestGroups {
-    hash := subtleutil.ConvertHashName(g.Sha)
-    curve := subtleutil.ConvertCurveName(g.Key.Curve)
-    if hash == "" || curve == "" {
-      continue
-    }
-    encoding := "DER"
-    x, err := subtleutil.NewBigIntFromHex(g.Key.Wx)
-    if err != nil {
-      t.Errorf("cannot decode wx: %s", err)
-    }
-    y, err := subtleutil.NewBigIntFromHex(g.Key.Wy)
-    if err != nil {
-      t.Errorf("cannot decode wy: %s", err)
-    }
-    verifier, err := subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, x.Bytes(), y.Bytes())
-    if err != nil {
-      continue
-    }
-    for _, tc := range g.Tests {
-      message, err := hex.DecodeString(tc.Message)
-      if err != nil {
-        t.Errorf("cannot decode message in test case %d: %s", tc.TcId, err)
-      }
-      sig, err := hex.DecodeString(tc.Sig)
-      if err != nil {
-        t.Errorf("cannot decode signature in test case %d: %s", tc.TcId, err)
-      }
-      err = verifier.Verify(sig, message)
-      if (tc.Result == "valid" && err != nil) ||
-          (tc.Result == "invalid" && err == nil) {
-        fmt.Println("failed in test case ", tc.TcId, err)
-      }
-    }
-  }
+	f, err := os.Open("../../../wycheproof/testvectors/ecdsa_test.json")
+	if err != nil {
+		t.Errorf("cannot open file: %s", err)
+	}
+	parser := json.NewDecoder(f)
+	content := new(testData)
+	if err := parser.Decode(content); err != nil {
+		t.Errorf("cannot decode content of file: %s", err)
+	}
+	for _, g := range content.TestGroups {
+		hash := subtleutil.ConvertHashName(g.Sha)
+		curve := subtleutil.ConvertCurveName(g.Key.Curve)
+		if hash == "" || curve == "" {
+			continue
+		}
+		encoding := "DER"
+		x, err := subtleutil.NewBigIntFromHex(g.Key.Wx)
+		if err != nil {
+			t.Errorf("cannot decode wx: %s", err)
+		}
+		y, err := subtleutil.NewBigIntFromHex(g.Key.Wy)
+		if err != nil {
+			t.Errorf("cannot decode wy: %s", err)
+		}
+		verifier, err := subtleEcdsa.NewEcdsaVerify(hash, curve, encoding, x.Bytes(), y.Bytes())
+		if err != nil {
+			continue
+		}
+		for _, tc := range g.Tests {
+			message, err := hex.DecodeString(tc.Message)
+			if err != nil {
+				t.Errorf("cannot decode message in test case %d: %s", tc.TcId, err)
+			}
+			sig, err := hex.DecodeString(tc.Sig)
+			if err != nil {
+				t.Errorf("cannot decode signature in test case %d: %s", tc.TcId, err)
+			}
+			err = verifier.Verify(sig, message)
+			if (tc.Result == "valid" && err != nil) ||
+				(tc.Result == "invalid" && err == nil) {
+				fmt.Println("failed in test case ", tc.TcId, err)
+			}
+		}
+	}
 }

--- a/go/subtle/ecdsa/ecdsa_test.go
+++ b/go/subtle/ecdsa/ecdsa_test.go
@@ -15,147 +15,147 @@
 package ecdsa_test
 
 import (
-  "fmt"
-  "testing"
-  "math/big"
-  "encoding/asn1"
-  . "github.com/google/tink/go/subtle/ecdsa"
-  "github.com/google/tink/go/subtle/random"
+	"encoding/asn1"
+	"fmt"
+	. "github.com/google/tink/go/subtle/ecdsa"
+	"github.com/google/tink/go/subtle/random"
+	"math/big"
+	"testing"
 )
 
 type paramsTest struct {
-  hash string
-  curve string
-  encoding string
+	hash     string
+	curve    string
+	encoding string
 }
 
 var _ = fmt.Println
 
 func TestEncodeDecode(t *testing.T) {
-  nTest := 1000
-  for i := 0; i < nTest; i++ {
-    sig := newRandomSignature()
-    encoding := "DER"
-    encoded, err := sig.Encode(encoding)
-    if err != nil {
-      t.Errorf("unexpected error during encoding: %s", err)
-    }
-    // first byte is 0x30
-    if encoded[0] != byte(0x30) {
-      t.Errorf("first byte is incorrect, expected 48, got %v", encoded[0])
-    }
-    // tag is 2
-    if encoded[2] != byte(2) || encoded[4+encoded[3]] != byte(2) {
-      t.Errorf("expect tag to be 2 (integer), got %d and %d", encoded[2], encoded[4+encoded[3]])
-    }
-    // length
-    if len(encoded) != int(encoded[1])+2 {
-      t.Errorf("incorrect length, expected %d, got %d", len(encoded), encoded[1]+2)
-    }
-    decodedSig, err := DecodeSignature(encoded, encoding)
-    if err != nil {
-      t.Errorf("unexpected error during decoding: %s", err)
-    }
-    if decodedSig.R.Cmp(sig.R) != 0 || decodedSig.S.Cmp(sig.S) != 0 {
-      t.Errorf("decoded signature doesn't match original value")
-    }
-  }
+	nTest := 1000
+	for i := 0; i < nTest; i++ {
+		sig := newRandomSignature()
+		encoding := "DER"
+		encoded, err := sig.Encode(encoding)
+		if err != nil {
+			t.Errorf("unexpected error during encoding: %s", err)
+		}
+		// first byte is 0x30
+		if encoded[0] != byte(0x30) {
+			t.Errorf("first byte is incorrect, expected 48, got %v", encoded[0])
+		}
+		// tag is 2
+		if encoded[2] != byte(2) || encoded[4+encoded[3]] != byte(2) {
+			t.Errorf("expect tag to be 2 (integer), got %d and %d", encoded[2], encoded[4+encoded[3]])
+		}
+		// length
+		if len(encoded) != int(encoded[1])+2 {
+			t.Errorf("incorrect length, expected %d, got %d", len(encoded), encoded[1]+2)
+		}
+		decodedSig, err := DecodeSignature(encoded, encoding)
+		if err != nil {
+			t.Errorf("unexpected error during decoding: %s", err)
+		}
+		if decodedSig.R.Cmp(sig.R) != 0 || decodedSig.S.Cmp(sig.S) != 0 {
+			t.Errorf("decoded signature doesn't match original value")
+		}
+	}
 }
 
 func TestEncodeWithInvalidInput(t *testing.T) {
-  sig := newRandomSignature()
-  _, err := sig.Encode("UNKNOWN_ENCODING")
-  if err == nil {
-    t.Errorf("expect an error when encoding is invalid")
-  }
+	sig := newRandomSignature()
+	_, err := sig.Encode("UNKNOWN_ENCODING")
+	if err == nil {
+		t.Errorf("expect an error when encoding is invalid")
+	}
 }
 
 func TestDecodeWithInvalidInput(t *testing.T) {
-  var sig *EcdsaSignature
-  var encoded []byte
-  encoding := "DER"
+	var sig *EcdsaSignature
+	var encoded []byte
+	encoding := "DER"
 
-  // modified first byte
-  sig = newRandomSignature()
-  encoded, _ = sig.Encode(encoding)
-  encoded[0] = 0x31
-  if _, err := DecodeSignature(encoded, encoding); err == nil {
-    t.Errorf("expect an error when first byte is not 0x30")
-  }
-  // modified tag
-  sig = newRandomSignature()
-  encoded, _ = sig.Encode(encoding)
-  encoded[2] = encoded[2] + 1
-  if _, err := DecodeSignature(encoded, encoding); err == nil {
-    t.Errorf("expect an error when tag is modified")
-  }
-  // modified length
-  sig = newRandomSignature()
-  encoded, _ = sig.Encode(encoding)
-  encoded[1] = encoded[1] + 1
-  if _, err := DecodeSignature(encoded, encoding); err == nil {
-    t.Errorf("expect an error when length is modified")
-  }
-  // append unused 0s
-  sig = newRandomSignature()
-  encoded, _ = sig.Encode(encoding)
-  tmp := make([]byte, len(encoded)+4)
-  copy(tmp, encoded)
-  if _, err := DecodeSignature(tmp, encoding); err == nil {
-    t.Errorf("expect an error when unused 0s are appended to signature")
-  }
-  // a struct with three numbers
-  randomStruct := struct{X, Y, Z *big.Int}{
-    X: new(big.Int).SetBytes(random.GetRandomBytes(32)),
-    Y: new(big.Int).SetBytes(random.GetRandomBytes(32)),
-    Z: new(big.Int).SetBytes(random.GetRandomBytes(32)),
-  }
-  encoded, _ = asn1.Marshal(randomStruct)
-  if _, err := DecodeSignature(encoded, encoding); err == nil {
-    t.Errorf("expect an error when input is not an EcdsaSignature")
-  }
+	// modified first byte
+	sig = newRandomSignature()
+	encoded, _ = sig.Encode(encoding)
+	encoded[0] = 0x31
+	if _, err := DecodeSignature(encoded, encoding); err == nil {
+		t.Errorf("expect an error when first byte is not 0x30")
+	}
+	// modified tag
+	sig = newRandomSignature()
+	encoded, _ = sig.Encode(encoding)
+	encoded[2] = encoded[2] + 1
+	if _, err := DecodeSignature(encoded, encoding); err == nil {
+		t.Errorf("expect an error when tag is modified")
+	}
+	// modified length
+	sig = newRandomSignature()
+	encoded, _ = sig.Encode(encoding)
+	encoded[1] = encoded[1] + 1
+	if _, err := DecodeSignature(encoded, encoding); err == nil {
+		t.Errorf("expect an error when length is modified")
+	}
+	// append unused 0s
+	sig = newRandomSignature()
+	encoded, _ = sig.Encode(encoding)
+	tmp := make([]byte, len(encoded)+4)
+	copy(tmp, encoded)
+	if _, err := DecodeSignature(tmp, encoding); err == nil {
+		t.Errorf("expect an error when unused 0s are appended to signature")
+	}
+	// a struct with three numbers
+	randomStruct := struct{ X, Y, Z *big.Int }{
+		X: new(big.Int).SetBytes(random.GetRandomBytes(32)),
+		Y: new(big.Int).SetBytes(random.GetRandomBytes(32)),
+		Z: new(big.Int).SetBytes(random.GetRandomBytes(32)),
+	}
+	encoded, _ = asn1.Marshal(randomStruct)
+	if _, err := DecodeSignature(encoded, encoding); err == nil {
+		t.Errorf("expect an error when input is not an EcdsaSignature")
+	}
 }
 
 func TestValidateParams(t *testing.T) {
-  params := genValidParams()
-  for i := 0; i < len(params); i++ {
-    if err := ValidateParams(params[i].hash, params[i].curve, params[i].encoding); err != nil {
-      t.Errorf("unexpected error for valid params: %s, i = %d", err, i)
-    }
-  }
-  params = genInvalidParams()
-  for i := 0; i < len(params); i++ {
-    if err := ValidateParams(params[i].hash, params[i].curve, params[i].encoding); err == nil {
-      t.Errorf("expect an error when params are invalid, i = %d", i)
-    }
-  }
+	params := genValidParams()
+	for i := 0; i < len(params); i++ {
+		if err := ValidateParams(params[i].hash, params[i].curve, params[i].encoding); err != nil {
+			t.Errorf("unexpected error for valid params: %s, i = %d", err, i)
+		}
+	}
+	params = genInvalidParams()
+	for i := 0; i < len(params); i++ {
+		if err := ValidateParams(params[i].hash, params[i].curve, params[i].encoding); err == nil {
+			t.Errorf("expect an error when params are invalid, i = %d", i)
+		}
+	}
 }
 
 func genInvalidParams() []paramsTest {
-  return []paramsTest{
-    // invalid encoding
-    paramsTest{hash: "SHA256", curve: "NIST_P256", encoding: "UNKNOWN_ENCODING"},
-    // invalid curve
-    paramsTest{hash: "SHA256", curve: "UNKNOWN_CURVE", encoding: "DER"},
-    // invalid hash: P256 and SHA-512
-    paramsTest{hash: "SHA512", curve: "NIST_P256", encoding: "DER"},
-    // invalid hash: P521 and SHA-256
-    paramsTest{hash: "SHA256", curve: "NIST_P521", encoding: "DER"},
-    // invalid hash: P384 and SHA-256
-    paramsTest{hash: "SHA256", curve: "NIST_P384", encoding: "DER"},
-  }
+	return []paramsTest{
+		// invalid encoding
+		paramsTest{hash: "SHA256", curve: "NIST_P256", encoding: "UNKNOWN_ENCODING"},
+		// invalid curve
+		paramsTest{hash: "SHA256", curve: "UNKNOWN_CURVE", encoding: "DER"},
+		// invalid hash: P256 and SHA-512
+		paramsTest{hash: "SHA512", curve: "NIST_P256", encoding: "DER"},
+		// invalid hash: P521 and SHA-256
+		paramsTest{hash: "SHA256", curve: "NIST_P521", encoding: "DER"},
+		// invalid hash: P384 and SHA-256
+		paramsTest{hash: "SHA256", curve: "NIST_P384", encoding: "DER"},
+	}
 }
 
 func genValidParams() []paramsTest {
-  return []paramsTest{
-    paramsTest{hash: "SHA256", curve: "NIST_P256", encoding: "DER"},
-    paramsTest{hash: "SHA512", curve: "NIST_P384", encoding: "DER"},
-    paramsTest{hash: "SHA512", curve: "NIST_P521", encoding: "DER"},
-  }
+	return []paramsTest{
+		paramsTest{hash: "SHA256", curve: "NIST_P256", encoding: "DER"},
+		paramsTest{hash: "SHA512", curve: "NIST_P384", encoding: "DER"},
+		paramsTest{hash: "SHA512", curve: "NIST_P521", encoding: "DER"},
+	}
 }
 
 func newRandomSignature() *EcdsaSignature {
-  r := new(big.Int).SetBytes(random.GetRandomBytes(32))
-  s := new(big.Int).SetBytes(random.GetRandomBytes(32))
-  return NewSignature(r, s)
+	r := new(big.Int).SetBytes(random.GetRandomBytes(32))
+	s := new(big.Int).SetBytes(random.GetRandomBytes(32))
+	return NewSignature(r, s)
 }

--- a/go/subtle/ecdsa/ecdsa_verify.go
+++ b/go/subtle/ecdsa/ecdsa_verify.go
@@ -15,12 +15,12 @@
 package ecdsa
 
 import (
-  "fmt"
-  "hash"
-  "math/big"
-  "crypto/ecdsa"
-  "github.com/google/tink/go/tink/primitives"
-  "github.com/google/tink/go/subtle/subtleutil"
+	"crypto/ecdsa"
+	"fmt"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/primitives"
+	"hash"
+	"math/big"
 )
 
 var errInvalidSignature = fmt.Errorf("ecdsa_verify: invalid signature")
@@ -28,9 +28,9 @@ var errInvalidSignature = fmt.Errorf("ecdsa_verify: invalid signature")
 // ecdsaVerify is an implementation of PublicKeyVerify for ECDSA.
 // At the moment, the implementation only accepts signatures with strict DER encoding.
 type EcdsaVerify struct {
-  publicKey *ecdsa.PublicKey
-  hashFunc func() hash.Hash
-  encoding string
+	publicKey *ecdsa.PublicKey
+	hashFunc  func() hash.Hash
+	encoding  string
 }
 
 // Assert that EcdsaVerify implements the PublicKeyVerify interface.
@@ -38,48 +38,47 @@ var _ tink.PublicKeyVerify = (*EcdsaVerify)(nil)
 
 // NewEcdsaVerify creates a new instance of EcdsaVerify.
 func NewEcdsaVerify(hashAlg string,
-                  curve string,
-                  encoding string,
-                  x []byte,
-                  y []byte) (*EcdsaVerify, error) {
-  publicKey := &ecdsa.PublicKey{
-    Curve: subtleutil.GetCurve(curve),
-    X: new(big.Int).SetBytes(x),
-    Y: new(big.Int).SetBytes(y),
-  }
-  return NewEcdsaVerifyFromPublicKey(hashAlg, encoding, publicKey)
+	curve string,
+	encoding string,
+	x []byte,
+	y []byte) (*EcdsaVerify, error) {
+	publicKey := &ecdsa.PublicKey{
+		Curve: subtleutil.GetCurve(curve),
+		X:     new(big.Int).SetBytes(x),
+		Y:     new(big.Int).SetBytes(y),
+	}
+	return NewEcdsaVerifyFromPublicKey(hashAlg, encoding, publicKey)
 }
 
 // NewEcdsaVerifyFromPublicKey creates a new instance of EcdsaVerify.
 func NewEcdsaVerifyFromPublicKey(hashAlg string, encoding string,
-                                publicKey *ecdsa.PublicKey) (*EcdsaVerify, error) {
-  if publicKey.Curve == nil {
-    return nil, fmt.Errorf("ecdsa_verify: invalid curve")
-  }
-  curve := subtleutil.ConvertCurveName(publicKey.Curve.Params().Name)
-  if err := ValidateParams(hashAlg, curve, encoding); err != nil {
-    return nil, fmt.Errorf("ecdsa_verify: %s", err)
-  }
-  hashFunc := subtleutil.GetHashFunc(hashAlg)
-  return &EcdsaVerify{
-    publicKey: publicKey,
-    hashFunc: hashFunc,
-    encoding: encoding,
-  }, nil
+	publicKey *ecdsa.PublicKey) (*EcdsaVerify, error) {
+	if publicKey.Curve == nil {
+		return nil, fmt.Errorf("ecdsa_verify: invalid curve")
+	}
+	curve := subtleutil.ConvertCurveName(publicKey.Curve.Params().Name)
+	if err := ValidateParams(hashAlg, curve, encoding); err != nil {
+		return nil, fmt.Errorf("ecdsa_verify: %s", err)
+	}
+	hashFunc := subtleutil.GetHashFunc(hashAlg)
+	return &EcdsaVerify{
+		publicKey: publicKey,
+		hashFunc:  hashFunc,
+		encoding:  encoding,
+	}, nil
 }
 
 // Verify verifies whether the given signature is valid for the given data.
 // It returns an error if the signature is not valid; nil otherwise.
 func (e *EcdsaVerify) Verify(signatureBytes []byte, data []byte) error {
-  signature, err := DecodeSignature(signatureBytes, e.encoding)
-  if err != nil {
-    return errInvalidSignature
-  }
-  hashed := subtleutil.ComputeHash(e.hashFunc, data)
-  valid := ecdsa.Verify(e.publicKey, hashed, signature.R, signature.S)
-  if valid {
-    return nil
-  }
-  return errInvalidSignature
+	signature, err := DecodeSignature(signatureBytes, e.encoding)
+	if err != nil {
+		return errInvalidSignature
+	}
+	hashed := subtleutil.ComputeHash(e.hashFunc, data)
+	valid := ecdsa.Verify(e.publicKey, hashed, signature.R, signature.S)
+	if valid {
+		return nil
+	}
+	return errInvalidSignature
 }
-

--- a/go/subtle/ecdsa/encoding.go
+++ b/go/subtle/ecdsa/encoding.go
@@ -15,20 +15,20 @@
 package ecdsa
 
 import (
-  "bytes"
-  "encoding/asn1"
-  "fmt"
+	"bytes"
+	"encoding/asn1"
+	"fmt"
 )
 
 var errInvalidLength = fmt.Errorf("invalid length")
 
 // asn1encode encodes the given ECDSA signature using ASN.1 encoding.
 func asn1encode(sig *EcdsaSignature) ([]byte, error) {
-  ret, err := asn1.Marshal(*sig)
-  if err != nil {
-    return nil, fmt.Errorf("asn.1 encoding failed")
-  }
-  return ret, nil
+	ret, err := asn1.Marshal(*sig)
+	if err != nil {
+		return nil, fmt.Errorf("asn.1 encoding failed")
+	}
+	return ret, nil
 }
 
 var errAsn1Decoding = fmt.Errorf("asn.1 decoding failed")
@@ -40,19 +40,19 @@ var errAsn1Decoding = fmt.Errorf("asn.1 decoding failed")
 // we marshal the obtained signature object again. Since DER encoding is deterministic,
 // we expect that the obtained bytes would be equal to the input.
 func asn1decode(b []byte) (*EcdsaSignature, error) {
-  // parse the signature
-  sig := new(EcdsaSignature)
-  _, err := asn1.Unmarshal(b, sig)
-  if err != nil {
-    return nil, errAsn1Decoding
-  }
-  // encode the signature again
-  encoded, err := asn1.Marshal(*sig)
-  if err != nil {
-    return nil, errAsn1Decoding
-  }
-  if !bytes.Equal(b, encoded) {
-    return nil, errAsn1Decoding
-  }
-  return sig, nil
+	// parse the signature
+	sig := new(EcdsaSignature)
+	_, err := asn1.Unmarshal(b, sig)
+	if err != nil {
+		return nil, errAsn1Decoding
+	}
+	// encode the signature again
+	encoded, err := asn1.Marshal(*sig)
+	if err != nil {
+		return nil, errAsn1Decoding
+	}
+	if !bytes.Equal(b, encoded) {
+		return nil, errAsn1Decoding
+	}
+	return sig, nil
 }

--- a/go/subtle/hmac/hmac.go
+++ b/go/subtle/hmac/hmac.go
@@ -15,35 +15,35 @@
 package hmac
 
 import (
-  "fmt"
-  "hash"
-  "crypto/hmac"
-  "github.com/google/tink/go/subtle/subtleutil"
-  "github.com/google/tink/go/tink/primitives"
+	"crypto/hmac"
+	"fmt"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/primitives"
+	"hash"
 )
 
 const (
-  // Minimum key size in bytes.
-  minKeySizeInBytes = uint32(16)
+	// Minimum key size in bytes.
+	minKeySizeInBytes = uint32(16)
 
-  // Minimum tag size in bytes. This provides minimum 80-bit security strength.
-  minTagSizeInBytes = uint32(10)
+	// Minimum tag size in bytes. This provides minimum 80-bit security strength.
+	minTagSizeInBytes = uint32(10)
 )
 
 // Maximum tag size in bytes for each hash type
 var maxTagSizeInBytes = map[string]uint32{
-  "SHA1": uint32(20),
-  "SHA256": uint32(32),
-  "SHA512": uint32(64),
+	"SHA1":   uint32(20),
+	"SHA256": uint32(32),
+	"SHA512": uint32(64),
 }
 
 var errHmacInvalidInput = fmt.Errorf("hmac: invalid input")
 
 // Hmac implementation of interface tink.Mac
 type Hmac struct {
-  HashFunc func() hash.Hash
-  Key []byte
-  TagSize uint32
+	HashFunc func() hash.Hash
+	Key      []byte
+	TagSize  uint32
 }
 
 // This makes sure that Hmac implements the tink.Mac interface
@@ -51,61 +51,61 @@ var _ tink.Mac = (*Hmac)(nil)
 
 // New creates a new instance of Hmac
 func New(hashAlg string, key []byte, tagSize uint32) (*Hmac, error) {
-  keySize := uint32(len(key))
-  if err := ValidateParams(hashAlg, keySize, tagSize); err != nil {
-    return nil, fmt.Errorf("hmac: %s", err)
-  }
-  hashFunc := subtleutil.GetHashFunc(hashAlg)
-  if hashFunc == nil {
-    return nil, fmt.Errorf("hmac: invalid hash algorithm")
-  }
-  return &Hmac{
-    HashFunc: hashFunc,
-    Key: key,
-    TagSize: tagSize,
-  }, nil
+	keySize := uint32(len(key))
+	if err := ValidateParams(hashAlg, keySize, tagSize); err != nil {
+		return nil, fmt.Errorf("hmac: %s", err)
+	}
+	hashFunc := subtleutil.GetHashFunc(hashAlg)
+	if hashFunc == nil {
+		return nil, fmt.Errorf("hmac: invalid hash algorithm")
+	}
+	return &Hmac{
+		HashFunc: hashFunc,
+		Key:      key,
+		TagSize:  tagSize,
+	}, nil
 }
 
 // ValidateParams validates parameters of Hmac constructor.
 func ValidateParams(hash string, keySize uint32, tagSize uint32) error {
-  // validate tag size
-  maxTagSize, found := maxTagSizeInBytes[hash]
-  if !found {
-    return fmt.Errorf("invalid hash algorithm")
-  }
-  if tagSize > maxTagSize {
-    return fmt.Errorf("tag size too big")
-  }
-  if tagSize < minTagSizeInBytes {
-    return fmt.Errorf("tag size too small")
-  }
-  // validate key size
-  if keySize < minKeySizeInBytes {
-    return fmt.Errorf("key too short")
-  }
-  return nil
+	// validate tag size
+	maxTagSize, found := maxTagSizeInBytes[hash]
+	if !found {
+		return fmt.Errorf("invalid hash algorithm")
+	}
+	if tagSize > maxTagSize {
+		return fmt.Errorf("tag size too big")
+	}
+	if tagSize < minTagSizeInBytes {
+		return fmt.Errorf("tag size too small")
+	}
+	// validate key size
+	if keySize < minKeySizeInBytes {
+		return fmt.Errorf("key too short")
+	}
+	return nil
 }
 
 // ComputeMac computes message authentication code (MAC) for the given data.
 func (h *Hmac) ComputeMac(data []byte) ([]byte, error) {
-  if data == nil {
-    return nil, errHmacInvalidInput
-  }
-  mac := hmac.New(h.HashFunc, h.Key)
-  mac.Write(data)
-  tag := mac.Sum(nil)
-  return tag[:h.TagSize], nil
+	if data == nil {
+		return nil, errHmacInvalidInput
+	}
+	mac := hmac.New(h.HashFunc, h.Key)
+	mac.Write(data)
+	tag := mac.Sum(nil)
+	return tag[:h.TagSize], nil
 }
 
 // VerifyMac verifies whether the given MAC is a correct authentication code (MAC)
 // the given data.
 func (h *Hmac) VerifyMac(mac []byte, data []byte) (bool, error) {
-  if mac == nil || data == nil {
-    return false, errHmacInvalidInput
-  }
-  expectedMAC, err := h.ComputeMac(data)
-  if err != nil {
-    return false, err
-  }
-  return hmac.Equal(expectedMAC, mac), nil
+	if mac == nil || data == nil {
+		return false, errHmacInvalidInput
+	}
+	expectedMAC, err := h.ComputeMac(data)
+	if err != nil {
+		return false, err
+	}
+	return hmac.Equal(expectedMAC, mac), nil
 }

--- a/go/subtle/hmac/hmac_test.go
+++ b/go/subtle/hmac/hmac_test.go
@@ -15,156 +15,156 @@
 package hmac_test
 
 import (
-  "testing"
-  "strings"
-  "encoding/hex"
-  "github.com/google/tink/go/subtle/hmac"
-  "github.com/google/tink/go/subtle/random"
+	"encoding/hex"
+	"github.com/google/tink/go/subtle/hmac"
+	"github.com/google/tink/go/subtle/random"
+	"strings"
+	"testing"
 )
 
 var key, _ = hex.DecodeString("000102030405060708090a0b0c0d0e0f")
 var data = []byte("Hello")
 var hmacTests = []struct {
-  hashAlg string
-  tagSize uint32
-  key []byte
-  data []byte
-  expectedMac string
+	hashAlg     string
+	tagSize     uint32
+	key         []byte
+	data        []byte
+	expectedMac string
 }{
-  {
-    hashAlg: "SHA256",
-    tagSize: 32,
-    data: data,
-    key: key,
-    expectedMac: "e0ff02553d9a619661026c7aa1ddf59b7b44eac06a9908ff9e19961d481935d4",
-  },
-  {
-    hashAlg: "SHA512",
-    tagSize: 64,
-    data: data,
-    key: key,
-    expectedMac: "481e10d823ba64c15b94537a3de3f253c16642451ac45124dd4dde120bf1e5c15" +
-        "e55487d55ba72b43039f235226e7954cd5854b30abc4b5b53171a4177047c9b",
-  },
-  // empty data
-  {
-    hashAlg: "SHA256",
-    tagSize: 32,
-    data: []byte{},
-    key: key,
-    expectedMac: "07eff8b326b7798c9ccfcbdbe579489ac785a7995a04618b1a2813c26744777d",
-  },
+	{
+		hashAlg:     "SHA256",
+		tagSize:     32,
+		data:        data,
+		key:         key,
+		expectedMac: "e0ff02553d9a619661026c7aa1ddf59b7b44eac06a9908ff9e19961d481935d4",
+	},
+	{
+		hashAlg: "SHA512",
+		tagSize: 64,
+		data:    data,
+		key:     key,
+		expectedMac: "481e10d823ba64c15b94537a3de3f253c16642451ac45124dd4dde120bf1e5c15" +
+			"e55487d55ba72b43039f235226e7954cd5854b30abc4b5b53171a4177047c9b",
+	},
+	// empty data
+	{
+		hashAlg:     "SHA256",
+		tagSize:     32,
+		data:        []byte{},
+		key:         key,
+		expectedMac: "07eff8b326b7798c9ccfcbdbe579489ac785a7995a04618b1a2813c26744777d",
+	},
 }
 
 func TestHmacBasic(t *testing.T) {
-  for i, test := range hmacTests {
-    cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
-    if err != nil {
-      t.Errorf("cannot create new mac in test case %d: %s", i, err)
-    }
-    mac, err := cipher.ComputeMac(test.data)
-    if err != nil {
-      t.Errorf("mac computation failed in test case %d: %s", i, err)
-    }
-    if hex.EncodeToString(mac) != test.expectedMac[:(test.tagSize*2)] {
-      t.Errorf("incorrect mac in test case %d: expect %s, got %s",
-                i, test.expectedMac[:(test.tagSize*2)], hex.EncodeToString(mac))
-    }
-    valid, err := cipher.VerifyMac(mac, test.data)
-    if !valid || err != nil {
-      t.Errorf("mac verification failed in test case %d: %s", i, err)
-    }
-  }
+	for i, test := range hmacTests {
+		cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
+		if err != nil {
+			t.Errorf("cannot create new mac in test case %d: %s", i, err)
+		}
+		mac, err := cipher.ComputeMac(test.data)
+		if err != nil {
+			t.Errorf("mac computation failed in test case %d: %s", i, err)
+		}
+		if hex.EncodeToString(mac) != test.expectedMac[:(test.tagSize*2)] {
+			t.Errorf("incorrect mac in test case %d: expect %s, got %s",
+				i, test.expectedMac[:(test.tagSize*2)], hex.EncodeToString(mac))
+		}
+		valid, err := cipher.VerifyMac(mac, test.data)
+		if !valid || err != nil {
+			t.Errorf("mac verification failed in test case %d: %s", i, err)
+		}
+	}
 }
 
 func TestNewHmacWithInvalidInput(t *testing.T) {
-  // invalid hash algorithm
-  _, err := hmac.New("SHA224", random.GetRandomBytes(16), 32)
-  if err == nil || !strings.Contains(err.Error(), "invalid hash algorithm") {
-    t.Errorf("expect an error when hash algorithm is invalid")
-  }
-  // key too short
-  _, err = hmac.New("SHA256", random.GetRandomBytes(1), 32)
-  if err == nil || !strings.Contains(err.Error(), "key too short") {
-    t.Errorf("expect an error when key is too short")
-  }
-  // tag too short
-  _, err = hmac.New("SHA256", random.GetRandomBytes(16), 9)
-  if err == nil || !strings.Contains(err.Error(), "tag size too small") {
-    t.Errorf("expect an error when tag size is too small")
-  }
-  // tag too big
-  _, err = hmac.New("SHA1", random.GetRandomBytes(16), 21)
-  if err == nil || !strings.Contains(err.Error(), "tag size too big") {
-    t.Errorf("expect an error when tag size is too big")
-  }
-  _, err = hmac.New("SHA256", random.GetRandomBytes(16), 33)
-  if err == nil || !strings.Contains(err.Error(), "tag size too big") {
-    t.Errorf("expect an error when tag size is too big")
-  }
-  _, err = hmac.New("SHA512", random.GetRandomBytes(16), 65)
-  if err == nil || !strings.Contains(err.Error(), "tag size too big") {
-    t.Errorf("expect an error when tag size is too big")
-  }
+	// invalid hash algorithm
+	_, err := hmac.New("SHA224", random.GetRandomBytes(16), 32)
+	if err == nil || !strings.Contains(err.Error(), "invalid hash algorithm") {
+		t.Errorf("expect an error when hash algorithm is invalid")
+	}
+	// key too short
+	_, err = hmac.New("SHA256", random.GetRandomBytes(1), 32)
+	if err == nil || !strings.Contains(err.Error(), "key too short") {
+		t.Errorf("expect an error when key is too short")
+	}
+	// tag too short
+	_, err = hmac.New("SHA256", random.GetRandomBytes(16), 9)
+	if err == nil || !strings.Contains(err.Error(), "tag size too small") {
+		t.Errorf("expect an error when tag size is too small")
+	}
+	// tag too big
+	_, err = hmac.New("SHA1", random.GetRandomBytes(16), 21)
+	if err == nil || !strings.Contains(err.Error(), "tag size too big") {
+		t.Errorf("expect an error when tag size is too big")
+	}
+	_, err = hmac.New("SHA256", random.GetRandomBytes(16), 33)
+	if err == nil || !strings.Contains(err.Error(), "tag size too big") {
+		t.Errorf("expect an error when tag size is too big")
+	}
+	_, err = hmac.New("SHA512", random.GetRandomBytes(16), 65)
+	if err == nil || !strings.Contains(err.Error(), "tag size too big") {
+		t.Errorf("expect an error when tag size is too big")
+	}
 }
 
 func TestComputeMacWithInvalidInput(t *testing.T) {
-  cipher, err := hmac.New("SHA256", random.GetRandomBytes(16), 32)
-  if err != nil {
-    t.Errorf("unexpected error when creating new Hmac")
-  }
-  if _, err := cipher.ComputeMac(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
+	cipher, err := hmac.New("SHA256", random.GetRandomBytes(16), 32)
+	if err != nil {
+		t.Errorf("unexpected error when creating new Hmac")
+	}
+	if _, err := cipher.ComputeMac(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
 }
 
 func TestVerifyMacWithInvalidInput(t *testing.T) {
-  cipher, err := hmac.New("SHA256", random.GetRandomBytes(16), 32)
-  if err != nil {
-    t.Errorf("unexpected error when creating new Hmac")
-  }
-  if _, err := cipher.VerifyMac(nil, []byte{1}); err == nil {
-    t.Errorf("expect an error when mac is nil")
-  }
-  if _, err := cipher.VerifyMac([]byte{1}, nil); err == nil {
-    t.Errorf("expect an error when data is nil")
-  }
+	cipher, err := hmac.New("SHA256", random.GetRandomBytes(16), 32)
+	if err != nil {
+		t.Errorf("unexpected error when creating new Hmac")
+	}
+	if _, err := cipher.VerifyMac(nil, []byte{1}); err == nil {
+		t.Errorf("expect an error when mac is nil")
+	}
+	if _, err := cipher.VerifyMac([]byte{1}, nil); err == nil {
+		t.Errorf("expect an error when data is nil")
+	}
 }
 
 func TestHmacModification(t *testing.T) {
-  for i, test := range hmacTests {
-    cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
-    if err != nil {
-      t.Errorf("cannot create new mac in test case %d: %s", i, err)
-    }
-    mac, _ := cipher.ComputeMac(test.data)
-    for i := 0; i < len(mac); i++ {
-      tmp := mac[i]
-      for j := 0; j < 8; j++ {
-        mac[i] ^= 1 << uint8(j)
-        valid, _ := cipher.VerifyMac(mac, test.data)
-        if valid {
-          t.Errorf("test case %d: modified MAC should be invalid", i)
-        }
-        mac[i] = tmp
-      }
-    }
-  }
+	for i, test := range hmacTests {
+		cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
+		if err != nil {
+			t.Errorf("cannot create new mac in test case %d: %s", i, err)
+		}
+		mac, _ := cipher.ComputeMac(test.data)
+		for i := 0; i < len(mac); i++ {
+			tmp := mac[i]
+			for j := 0; j < 8; j++ {
+				mac[i] ^= 1 << uint8(j)
+				valid, _ := cipher.VerifyMac(mac, test.data)
+				if valid {
+					t.Errorf("test case %d: modified MAC should be invalid", i)
+				}
+				mac[i] = tmp
+			}
+		}
+	}
 }
 
 func TestHmacTruncation(t *testing.T) {
-  for i, test := range hmacTests {
-    cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
-    if err != nil {
-      t.Errorf("cannot create new mac in test case %d: %s", i, err)
-    }
-    mac, _ := cipher.ComputeMac(test.data)
-    for i := 1; i < len(mac); i++ {
-      tmp := mac[:i]
-      valid, _ := cipher.VerifyMac(tmp, test.data)
-      if valid {
-        t.Errorf("test case %d: truncated MAC should be invalid", i)
-      }
-    }
-  }
+	for i, test := range hmacTests {
+		cipher, err := hmac.New(test.hashAlg, test.key, test.tagSize)
+		if err != nil {
+			t.Errorf("cannot create new mac in test case %d: %s", i, err)
+		}
+		mac, _ := cipher.ComputeMac(test.data)
+		for i := 1; i < len(mac); i++ {
+			tmp := mac[:i]
+			valid, _ := cipher.VerifyMac(tmp, test.data)
+			if valid {
+				t.Errorf("test case %d: truncated MAC should be invalid", i)
+			}
+		}
+	}
 }

--- a/go/subtle/random/random.go
+++ b/go/subtle/random/random.go
@@ -15,23 +15,23 @@
 package random
 
 import (
-  "crypto/rand"
-  "encoding/binary"
+	"crypto/rand"
+	"encoding/binary"
 )
 
 /**
  * Generates random bytes.
  */
 func GetRandomBytes(n uint32) []byte {
-  buf := make([]byte, n)
-  _, err := rand.Read(buf)
-  if err != nil {
-    panic(err)  // out of randomness, should never happen
-  }
-  return buf
+	buf := make([]byte, n)
+	_, err := rand.Read(buf)
+	if err != nil {
+		panic(err) // out of randomness, should never happen
+	}
+	return buf
 }
 
 func GetRandomUint32() uint32 {
-  b := GetRandomBytes(4)
-  return binary.BigEndian.Uint32(b)
+	b := GetRandomBytes(4)
+	return binary.BigEndian.Uint32(b)
 }

--- a/go/subtle/random/random_test.go
+++ b/go/subtle/random/random_test.go
@@ -15,15 +15,15 @@
 package random_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/subtle/random"
+	"testing"
 )
 
 func TestGetRandomBytes(t *testing.T) {
-  for i := 0; i <= 32; i++ {
-    buf := random.GetRandomBytes(uint32(i))
-    if len(buf) != i {
-      t.Errorf("length of the output doesn't match the input")
-    }
-  }
+	for i := 0; i <= 32; i++ {
+		buf := random.GetRandomBytes(uint32(i))
+		if len(buf) != i {
+			t.Errorf("length of the output doesn't match the input")
+		}
+	}
 }

--- a/go/subtle/subtleutil/subtleutil.go
+++ b/go/subtle/subtleutil/subtleutil.go
@@ -16,93 +16,93 @@
 package subtleutil
 
 import (
-  "hash"
-  "math/big"
-  "encoding/hex"
-  "crypto/sha1"
-  "crypto/sha256"
-  "crypto/sha512"
-  "crypto/elliptic"
+	"crypto/elliptic"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"hash"
+	"math/big"
 )
 
 // ConvertTestVectorHashName converts different forms of a hash name to the
 // hash name that tink recognizes
 func ConvertHashName(name string) string {
-  switch name {
-    case "SHA-256":
-      return "SHA256"
-    case "SHA-512":
-      return "SHA512"
-    case "SHA-1":
-      return "SHA1"
-    default:
-      return ""
-  }
+	switch name {
+	case "SHA-256":
+		return "SHA256"
+	case "SHA-512":
+		return "SHA512"
+	case "SHA-1":
+		return "SHA1"
+	default:
+		return ""
+	}
 }
 
 // ConvertCurveName converts different forms of a curve name to the
 // name that tink recognizes
 func ConvertCurveName(name string) string {
-  switch name {
-    case "secp256r1", "P-256":
-      return "NIST_P256"
-    case "secp384r1", "P-384":
-      return "NIST_P384"
-    case "secp521r1", "P-521":
-      return "NIST_P521"
-    default:
-      return ""
-  }
+	switch name {
+	case "secp256r1", "P-256":
+		return "NIST_P256"
+	case "secp384r1", "P-384":
+		return "NIST_P384"
+	case "secp521r1", "P-521":
+		return "NIST_P521"
+	default:
+		return ""
+	}
 }
 
 // GetHashFunc returns the corresponding hash function of the given hash name.
 func GetHashFunc(hash string) func() hash.Hash {
-  switch hash {
-    case "SHA1":
-      return sha1.New
-    case "SHA256":
-      return sha256.New
-    case "SHA512":
-      return sha512.New
-    default:
-      return nil
-  }
+	switch hash {
+	case "SHA1":
+		return sha1.New
+	case "SHA256":
+		return sha256.New
+	case "SHA512":
+		return sha512.New
+	default:
+		return nil
+	}
 }
 
 // GetCurve returns the curve object that corresponds to the given curve type.
 // It returns null if the curve type is not supported.
 func GetCurve(curve string) elliptic.Curve {
-  switch curve {
-    case "NIST_P224":
-      return elliptic.P224()
-    case "NIST_P256":
-      return elliptic.P256()
-    case "NIST_P384":
-      return elliptic.P384()
-    case "NIST_P521":
-      return elliptic.P521()
-    default:
-      return nil
-  }
+	switch curve {
+	case "NIST_P224":
+		return elliptic.P224()
+	case "NIST_P256":
+		return elliptic.P256()
+	case "NIST_P384":
+		return elliptic.P384()
+	case "NIST_P521":
+		return elliptic.P521()
+	default:
+		return nil
+	}
 }
 
 // ComputeHash calculates a hash of the given data using the given hash function.
 func ComputeHash(hashFunc func() hash.Hash, data []byte) []byte {
-  h := hashFunc()
-  h.Write(data)
-  ret := h.Sum(nil)
-  return ret
+	h := hashFunc()
+	h.Write(data)
+	ret := h.Sum(nil)
+	return ret
 }
 
 // NewBigIntFromHex returns a big integer from a hex string.
 func NewBigIntFromHex(s string) (*big.Int, error) {
-  if len(s)%2 == 1 {
-    s = "0" + s
-  }
-  b, err := hex.DecodeString(s)
-  if err != nil {
-    return nil, err
-  }
-  ret := new(big.Int).SetBytes(b)
-  return ret, nil
+	if len(s)%2 == 1 {
+		s = "0" + s
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	ret := new(big.Int).SetBytes(b)
+	return ret, nil
 }

--- a/go/subtle/subtleutil/subtleutil_test.go
+++ b/go/subtle/subtleutil/subtleutil_test.go
@@ -16,71 +16,70 @@
 package subtleutil_test
 
 import (
-  "encoding/hex"
-  "testing"
-  "github.com/google/tink/go/subtle/subtleutil"
+	"encoding/hex"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"testing"
 )
 
 func TestConvertHashName(t *testing.T) {
-  if subtleutil.ConvertHashName("SHA-256") != "SHA256" ||
-    subtleutil.ConvertHashName("SHA-1") != "SHA1" ||
-    subtleutil.ConvertHashName("SHA-512") != "SHA512" ||
-    subtleutil.ConvertHashName("UNKNOWN_HASH") != "" {
-    t.Errorf("incorrect hash name conversion")
-  }
+	if subtleutil.ConvertHashName("SHA-256") != "SHA256" ||
+		subtleutil.ConvertHashName("SHA-1") != "SHA1" ||
+		subtleutil.ConvertHashName("SHA-512") != "SHA512" ||
+		subtleutil.ConvertHashName("UNKNOWN_HASH") != "" {
+		t.Errorf("incorrect hash name conversion")
+	}
 }
 
 func TestConvertCurveName(t *testing.T) {
-  if subtleutil.ConvertCurveName("secp256r1") != "NIST_P256" ||
-    subtleutil.ConvertCurveName("secp384r1") != "NIST_P384" ||
-    subtleutil.ConvertCurveName("secp521r1") != "NIST_P521" ||
-    subtleutil.ConvertCurveName("UNKNOWN_CURVE") != "" {
-    t.Errorf("incorrect curve name conversion")
-  }
+	if subtleutil.ConvertCurveName("secp256r1") != "NIST_P256" ||
+		subtleutil.ConvertCurveName("secp384r1") != "NIST_P384" ||
+		subtleutil.ConvertCurveName("secp521r1") != "NIST_P521" ||
+		subtleutil.ConvertCurveName("UNKNOWN_CURVE") != "" {
+		t.Errorf("incorrect curve name conversion")
+	}
 }
 
-
 func TestComputeHash(t *testing.T) {
-  data := []byte("Hello")
-  // SHA1
-  expectedMac := "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0"
-  hashFunc := subtleutil.GetHashFunc("SHA1")
-  if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
-    t.Errorf("invalid hash function for SHA1")
-  }
-  // SHA256
-  expectedMac = "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969"
-  hashFunc = subtleutil.GetHashFunc("SHA256")
-  if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
-    t.Errorf("invalid hash function for SHA256")
-  }
-  // SHA512
-  expectedMac = "3615f80c9d293ed7402687f94b22d58e529b8cc7916f8fac7fddf7fbd5af4cf" +
-                "777d3d795a7a00a16bf7e7f3fb9561ee9baae480da9fe7a18769e71886b03f315"
-  hashFunc = subtleutil.GetHashFunc("SHA512")
-  if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
-    t.Errorf("invalid hash function for SHA512")
-  }
-  // unknown
-  if subtleutil.GetHashFunc("UNKNOWN_HASH") != nil {
-    t.Errorf("unexpected result for invalid hash types")
-  }
+	data := []byte("Hello")
+	// SHA1
+	expectedMac := "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0"
+	hashFunc := subtleutil.GetHashFunc("SHA1")
+	if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
+		t.Errorf("invalid hash function for SHA1")
+	}
+	// SHA256
+	expectedMac = "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969"
+	hashFunc = subtleutil.GetHashFunc("SHA256")
+	if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
+		t.Errorf("invalid hash function for SHA256")
+	}
+	// SHA512
+	expectedMac = "3615f80c9d293ed7402687f94b22d58e529b8cc7916f8fac7fddf7fbd5af4cf" +
+		"777d3d795a7a00a16bf7e7f3fb9561ee9baae480da9fe7a18769e71886b03f315"
+	hashFunc = subtleutil.GetHashFunc("SHA512")
+	if hashFunc == nil || hex.EncodeToString(subtleutil.ComputeHash(hashFunc, data)) != expectedMac {
+		t.Errorf("invalid hash function for SHA512")
+	}
+	// unknown
+	if subtleutil.GetHashFunc("UNKNOWN_HASH") != nil {
+		t.Errorf("unexpected result for invalid hash types")
+	}
 }
 
 func TestGetCurve(t *testing.T) {
-  if subtleutil.GetCurve("NIST_P224").Params().Name != "P-224" {
-    t.Errorf("incorrect result for NIST_P224")
-  }
-  if subtleutil.GetCurve("NIST_P256").Params().Name != "P-256" {
-    t.Errorf("incorrect result for NIST_P256")
-  }
-  if subtleutil.GetCurve("NIST_P384").Params().Name != "P-384" {
-    t.Errorf("incorrect result for NIST_P384")
-  }
-  if subtleutil.GetCurve("NIST_P521").Params().Name != "P-521" {
-    t.Errorf("incorrect result for NIST_P521")
-  }
-  if subtleutil.GetCurve("UNKNOWN_CURVE") != nil {
-    t.Errorf("expect nil when curve is unknown")
-  }
+	if subtleutil.GetCurve("NIST_P224").Params().Name != "P-224" {
+		t.Errorf("incorrect result for NIST_P224")
+	}
+	if subtleutil.GetCurve("NIST_P256").Params().Name != "P-256" {
+		t.Errorf("incorrect result for NIST_P256")
+	}
+	if subtleutil.GetCurve("NIST_P384").Params().Name != "P-384" {
+		t.Errorf("incorrect result for NIST_P384")
+	}
+	if subtleutil.GetCurve("NIST_P521").Params().Name != "P-521" {
+		t.Errorf("incorrect result for NIST_P521")
+	}
+	if subtleutil.GetCurve("UNKNOWN_CURVE") != nil {
+		t.Errorf("expect nil when curve is unknown")
+	}
 }

--- a/go/tink/aead.go
+++ b/go/tink/aead.go
@@ -21,22 +21,22 @@ package tink
  * but not its secrecy. (see RFC 5116, https://tools.ietf.org/html/rfc5116)
  */
 type Aead interface {
-  /**
-   * Encrypts {@code plaintext} with {@code additionalData} as additional
-   * authenticated data. The resulting ciphertext allows for checking
-   * authenticity and integrity of additional data ({@code additionalData}),
-   * but does not guarantee its secrecy.
-   *
-   * @return resulting ciphertext.
-   */
-  Encrypt(plaintext []byte, additionalData []byte) ([]byte, error)
+	/**
+	 * Encrypts {@code plaintext} with {@code additionalData} as additional
+	 * authenticated data. The resulting ciphertext allows for checking
+	 * authenticity and integrity of additional data ({@code additionalData}),
+	 * but does not guarantee its secrecy.
+	 *
+	 * @return resulting ciphertext.
+	 */
+	Encrypt(plaintext []byte, additionalData []byte) ([]byte, error)
 
-  /**
-   * Decrypts {@code ciphertext} with {@code additionalData} as additional
-   * authenticated data. The decryption verifies the authenticity and integrity
-   * of the additional data, but there are no guarantees wrt. secrecy of that data.
-   *
-   * @return resulting plaintext.
-   */
-  Decrypt(ciphertext []byte, additionalData []byte) ([]byte, error)
+	/**
+	 * Decrypts {@code ciphertext} with {@code additionalData} as additional
+	 * authenticated data. The decryption verifies the authenticity and integrity
+	 * of the additional data, but there are no guarantees wrt. secrecy of that data.
+	 *
+	 * @return resulting plaintext.
+	 */
+	Decrypt(ciphertext []byte, additionalData []byte) ([]byte, error)
 }

--- a/go/tink/cleartext_keyset_handle.go
+++ b/go/tink/cleartext_keyset_handle.go
@@ -16,10 +16,10 @@
 package tink
 
 import (
-  "fmt"
-  "sync"
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
 )
 
 // cleartextKeysetHandle provides utilities to creates keyset handles from
@@ -27,46 +27,47 @@ import (
 // should be restricted.
 var ckhInstance *cleartextKeysetHandle
 var cleartextKeysetHandleOnce sync.Once
-type cleartextKeysetHandle struct {}
+
+type cleartextKeysetHandle struct{}
 
 // CleartextKeysetHandle returns the single instance of cleartextKeysetHandle.
 func CleartextKeysetHandle() *cleartextKeysetHandle {
-  cleartextKeysetHandleOnce.Do(func() {
-    ckhInstance = new(cleartextKeysetHandle)
-  })
-  return ckhInstance
+	cleartextKeysetHandleOnce.Do(func() {
+		ckhInstance = new(cleartextKeysetHandle)
+	})
+	return ckhInstance
 }
 
 var errInvalidKeyset = fmt.Errorf("cleartext_keyset_handle: invalid keyset")
 
 // ParseSerializedKeyset creates a new keyset handle from the given serialized keyset.
 func (_ *cleartextKeysetHandle) ParseSerializedKeyset(serialized []byte) (*KeysetHandle, error) {
-  if len(serialized) == 0 {
-    return nil, errInvalidKeyset
-  }
-  keyset := new(tinkpb.Keyset)
-  if err := proto.Unmarshal(serialized, keyset); err != nil {
-    return nil, errInvalidKeyset
-  }
-  return newKeysetHandle(keyset, nil)
+	if len(serialized) == 0 {
+		return nil, errInvalidKeyset
+	}
+	keyset := new(tinkpb.Keyset)
+	if err := proto.Unmarshal(serialized, keyset); err != nil {
+		return nil, errInvalidKeyset
+	}
+	return newKeysetHandle(keyset, nil)
 }
 
 // ParseKeyset creates a new keyset handle from the given keyset.
 func (_ *cleartextKeysetHandle) ParseKeyset(keyset *tinkpb.Keyset) (*KeysetHandle, error) {
-  return newKeysetHandle(keyset, nil)
+	return newKeysetHandle(keyset, nil)
 }
 
 // GenerateNew creates a keyset handle that contains a single fresh key generated
 // according to the given key template.
 func (_ *cleartextKeysetHandle) GenerateNew(template *tinkpb.KeyTemplate) (*KeysetHandle, error) {
-  manager := NewKeysetManager(template, nil, nil)
-  err := manager.Rotate()
-  if err != nil {
-    return nil, fmt.Errorf("cleartext_keyset_handle: cannot rotate keyset manager: %s", err)
-  }
-  handle, err := manager.GetKeysetHandle()
-  if err != nil {
-    return nil, fmt.Errorf("cleartext_keyset_handle: cannot get keyset handle: %s", err)
-  }
-  return handle, nil
+	manager := NewKeysetManager(template, nil, nil)
+	err := manager.Rotate()
+	if err != nil {
+		return nil, fmt.Errorf("cleartext_keyset_handle: cannot rotate keyset manager: %s", err)
+	}
+	handle, err := manager.GetKeysetHandle()
+	if err != nil {
+		return nil, fmt.Errorf("cleartext_keyset_handle: cannot get keyset handle: %s", err)
+	}
+	return handle, nil
 }

--- a/go/tink/cleartext_keyset_handle_test.go
+++ b/go/tink/cleartext_keyset_handle_test.go
@@ -16,117 +16,117 @@
 package tink_test
 
 import (
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/golang/protobuf/proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"testing"
 )
 
 func setupCleartextKeysetHandleTest() {
-  if _, err := mac.Config().RegisterStandardKeyTypes(); err != nil {
-    panic(fmt.Sprintln("cannot register mac key types: %s", err))
-  }
+	if _, err := mac.Config().RegisterStandardKeyTypes(); err != nil {
+		panic(fmt.Sprintln("cannot register mac key types: %s", err))
+	}
 }
 
 func TestCleartextKeysetHandleParseBasic(t *testing.T) {
-  setupCleartextKeysetHandleTest()
+	setupCleartextKeysetHandleTest()
 
-  // Create a keyset that contains a single HmacKey.
-  manager := testutil.NewHmacKeysetManager()
-  handle, err := manager.GetKeysetHandle()
-  if handle == nil || err != nil {
-    t.Errorf("cannot get keyset handle: %s", err)
-  }
-  serializedKeyset, err := proto.Marshal(handle.Keyset())
-  if err != nil {
-    t.Errorf("cannot serialize keyset: %s", err)
-  }
-  // create handle rom serialized keyset
-  parsedHandle, err := tink.CleartextKeysetHandle().ParseSerializedKeyset(serializedKeyset)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  if handle.Keyset().String() != parsedHandle.Keyset().String() {
-    t.Errorf("parsed keyset doesn't match the original")
-  }
-  // create handle from keyset
-  parsedHandle, err = tink.CleartextKeysetHandle().ParseKeyset(handle.Keyset())
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  if handle.Keyset().String() != parsedHandle.Keyset().String() {
-    t.Errorf("parsed keyset doesn't match the original")
-  }
+	// Create a keyset that contains a single HmacKey.
+	manager := testutil.NewHmacKeysetManager()
+	handle, err := manager.GetKeysetHandle()
+	if handle == nil || err != nil {
+		t.Errorf("cannot get keyset handle: %s", err)
+	}
+	serializedKeyset, err := proto.Marshal(handle.Keyset())
+	if err != nil {
+		t.Errorf("cannot serialize keyset: %s", err)
+	}
+	// create handle rom serialized keyset
+	parsedHandle, err := tink.CleartextKeysetHandle().ParseSerializedKeyset(serializedKeyset)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if handle.Keyset().String() != parsedHandle.Keyset().String() {
+		t.Errorf("parsed keyset doesn't match the original")
+	}
+	// create handle from keyset
+	parsedHandle, err = tink.CleartextKeysetHandle().ParseKeyset(handle.Keyset())
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if handle.Keyset().String() != parsedHandle.Keyset().String() {
+		t.Errorf("parsed keyset doesn't match the original")
+	}
 }
 
 func TestCleartextKeysetHandleParseWithInvalidInput(t *testing.T) {
-  setupCleartextKeysetHandleTest()
+	setupCleartextKeysetHandleTest()
 
-  manager := testutil.NewHmacKeysetManager()
-  handle, err := manager.GetKeysetHandle()
-  if handle == nil || err != nil {
-    t.Errorf("cannot get keyset handle: %s", err)
-  }
-  serializedKeyset, err := proto.Marshal(handle.Keyset())
-  if err != nil {
-    t.Errorf("cannot serialize keyset: %s", err)
-  }
-  serializedKeyset[0] = 0
-  _, err = tink.CleartextKeysetHandle().ParseSerializedKeyset(serializedKeyset)
-  if err == nil {
-    t.Errorf("expect an error when input is an invalid serialized keyset")
-  }
-  _, err = tink.CleartextKeysetHandle().ParseSerializedKeyset([]byte{})
-  if err == nil {
-    t.Errorf("expect an error when input is an empty slice")
-  }
-  _, err = tink.CleartextKeysetHandle().ParseSerializedKeyset(nil)
-  if err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  _, err = tink.CleartextKeysetHandle().ParseKeyset(nil)
-  if err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
+	manager := testutil.NewHmacKeysetManager()
+	handle, err := manager.GetKeysetHandle()
+	if handle == nil || err != nil {
+		t.Errorf("cannot get keyset handle: %s", err)
+	}
+	serializedKeyset, err := proto.Marshal(handle.Keyset())
+	if err != nil {
+		t.Errorf("cannot serialize keyset: %s", err)
+	}
+	serializedKeyset[0] = 0
+	_, err = tink.CleartextKeysetHandle().ParseSerializedKeyset(serializedKeyset)
+	if err == nil {
+		t.Errorf("expect an error when input is an invalid serialized keyset")
+	}
+	_, err = tink.CleartextKeysetHandle().ParseSerializedKeyset([]byte{})
+	if err == nil {
+		t.Errorf("expect an error when input is an empty slice")
+	}
+	_, err = tink.CleartextKeysetHandle().ParseSerializedKeyset(nil)
+	if err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	_, err = tink.CleartextKeysetHandle().ParseKeyset(nil)
+	if err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
 }
 
 func TestCleartextKeysetHandleGenerateNewBasic(t *testing.T) {
-  setupCleartextKeysetHandleTest()
+	setupCleartextKeysetHandleTest()
 
-  macTemplate := mac.HmacSha256Tag128KeyTemplate()
-  handle, err := tink.CleartextKeysetHandle().GenerateNew(macTemplate)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  keyset := handle.Keyset()
-  if len(keyset.Key) != 1 {
-    t.Errorf("incorrect number of keys in the keyset: %d", len(keyset.Key))
-  }
-  key := keyset.Key[0]
-  if keyset.PrimaryKeyId != key.KeyId {
-    t.Errorf("incorrect primary key id, expect %d, got %d", key.KeyId, keyset.PrimaryKeyId)
-  }
-  if key.KeyData.TypeUrl != macTemplate.TypeUrl {
-    t.Errorf("incorrect type url, expect %s, got %s", macTemplate.TypeUrl, key.KeyData.TypeUrl)
-  }
-  if _, err = mac.Factory().GetPrimitive(handle); err != nil {
-    t.Errorf("cannot get primitive from generated keyset handle: %s", err)
-  }
+	macTemplate := mac.HmacSha256Tag128KeyTemplate()
+	handle, err := tink.CleartextKeysetHandle().GenerateNew(macTemplate)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	keyset := handle.Keyset()
+	if len(keyset.Key) != 1 {
+		t.Errorf("incorrect number of keys in the keyset: %d", len(keyset.Key))
+	}
+	key := keyset.Key[0]
+	if keyset.PrimaryKeyId != key.KeyId {
+		t.Errorf("incorrect primary key id, expect %d, got %d", key.KeyId, keyset.PrimaryKeyId)
+	}
+	if key.KeyData.TypeUrl != macTemplate.TypeUrl {
+		t.Errorf("incorrect type url, expect %s, got %s", macTemplate.TypeUrl, key.KeyData.TypeUrl)
+	}
+	if _, err = mac.Factory().GetPrimitive(handle); err != nil {
+		t.Errorf("cannot get primitive from generated keyset handle: %s", err)
+	}
 }
 
 func TestCleartextKeysetHandleGenerateNewWithInvalidInput(t *testing.T) {
-  setupCleartextKeysetHandleTest()
+	setupCleartextKeysetHandleTest()
 
-  // template unregistered TypeUrl
-  template := mac.HmacSha256Tag128KeyTemplate()
-  template.TypeUrl = "some unknown TypeUrl"
-  if _, err := tink.CleartextKeysetHandle().GenerateNew(template); err == nil {
-    t.Errorf("expect an error when TypeUrl is not registered")
-  }
-  // nil
-  if _, err := tink.CleartextKeysetHandle().GenerateNew(nil); err == nil {
-    t.Errorf("expect an error when template is nil")
-  }
+	// template unregistered TypeUrl
+	template := mac.HmacSha256Tag128KeyTemplate()
+	template.TypeUrl = "some unknown TypeUrl"
+	if _, err := tink.CleartextKeysetHandle().GenerateNew(template); err == nil {
+		t.Errorf("expect an error when TypeUrl is not registered")
+	}
+	// nil
+	if _, err := tink.CleartextKeysetHandle().GenerateNew(nil); err == nil {
+		t.Errorf("expect an error when template is nil")
+	}
 }

--- a/go/tink/crypto_format.go
+++ b/go/tink/crypto_format.go
@@ -16,29 +16,29 @@
 package tink
 
 import (
-  "fmt"
-  "encoding/binary"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"encoding/binary"
+	"fmt"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 /**
  * Constants and convenience methods that deal with crypto format.
  */
 const (
-  // Prefix size of Tink and Legacy key types.
-  NON_RAW_PREFIX_SIZE = 5
+	// Prefix size of Tink and Legacy key types.
+	NON_RAW_PREFIX_SIZE = 5
 
-  // Legacy or Crunchy prefix starts with \x00 and followed by a 4-byte key id.
-  LEGACY_PREFIX_SIZE = NON_RAW_PREFIX_SIZE
-  LEGACY_START_BYTE = byte(0)
+	// Legacy or Crunchy prefix starts with \x00 and followed by a 4-byte key id.
+	LEGACY_PREFIX_SIZE = NON_RAW_PREFIX_SIZE
+	LEGACY_START_BYTE  = byte(0)
 
-  // Tink prefix starts with \x01 and followed by a 4-byte key id.
-  TINK_PREFIX_SIZE = NON_RAW_PREFIX_SIZE
-  TINK_START_BYTE = byte(1)
+	// Tink prefix starts with \x01 and followed by a 4-byte key id.
+	TINK_PREFIX_SIZE = NON_RAW_PREFIX_SIZE
+	TINK_START_BYTE  = byte(1)
 
-  // Raw prefix is empty.
-  RAW_PREFIX_SIZE = 0;
-  RAW_PREFIX = ""
+	// Raw prefix is empty.
+	RAW_PREFIX_SIZE = 0
+	RAW_PREFIX      = ""
 )
 
 /**
@@ -52,16 +52,16 @@ const (
  * @return a prefix.
  */
 func GetOutputPrefix(key *tinkpb.Keyset_Key) (string, error) {
-  switch key.OutputPrefixType {
-    case tinkpb.OutputPrefixType_LEGACY, tinkpb.OutputPrefixType_CRUNCHY:
-      return createOutputPrefix(LEGACY_PREFIX_SIZE, LEGACY_START_BYTE, key.KeyId), nil
-    case tinkpb.OutputPrefixType_TINK:
-      return createOutputPrefix(TINK_PREFIX_SIZE, TINK_START_BYTE, key.KeyId), nil
-    case tinkpb.OutputPrefixType_RAW:
-      return RAW_PREFIX, nil
-    default:
-      return "", fmt.Errorf("crypto_format: unknown output prefix type")
-  }
+	switch key.OutputPrefixType {
+	case tinkpb.OutputPrefixType_LEGACY, tinkpb.OutputPrefixType_CRUNCHY:
+		return createOutputPrefix(LEGACY_PREFIX_SIZE, LEGACY_START_BYTE, key.KeyId), nil
+	case tinkpb.OutputPrefixType_TINK:
+		return createOutputPrefix(TINK_PREFIX_SIZE, TINK_START_BYTE, key.KeyId), nil
+	case tinkpb.OutputPrefixType_RAW:
+		return RAW_PREFIX, nil
+	default:
+		return "", fmt.Errorf("crypto_format: unknown output prefix type")
+	}
 }
 
 /**
@@ -69,8 +69,8 @@ func GetOutputPrefix(key *tinkpb.Keyset_Key) (string, error) {
  * of the prefix, followed by 4 bytes of {@code keyId} in Big Endian encoding.
  */
 func createOutputPrefix(size int, startByte byte, keyId uint32) string {
-  prefix := make([]byte, size)
-  prefix[0] = startByte
-  binary.BigEndian.PutUint32(prefix[1:], keyId)
-  return string(prefix)
+	prefix := make([]byte, size)
+	prefix[0] = startByte
+	binary.BigEndian.PutUint32(prefix[1:], keyId)
+	return string(prefix)
 }

--- a/go/tink/crypto_format_test.go
+++ b/go/tink/crypto_format_test.go
@@ -16,68 +16,68 @@
 package tink_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/tink/tink"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"github.com/google/tink/go/tink/tink"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
-var tests = []struct{
-  keyId uint32
-  result string // expected prefix
+var tests = []struct {
+	keyId  uint32
+	result string // expected prefix
 }{
-  {
-    keyId: 1000000,
-    result: string([]byte{0, 15, 66, 64}),
-  },
-  {
-    keyId: 4294967295,
-    result: string([]byte{255, 255, 255, 255}),
-  },
-  {
-    keyId: 0,
-    result: string([]byte{0, 0, 0, 0}),
-  },
+	{
+		keyId:  1000000,
+		result: string([]byte{0, 15, 66, 64}),
+	},
+	{
+		keyId:  4294967295,
+		result: string([]byte{255, 255, 255, 255}),
+	},
+	{
+		keyId:  0,
+		result: string([]byte{0, 0, 0, 0}),
+	},
 }
 
 func TestGetOutputPrefix(t *testing.T) {
-  key := new(tinkpb.Keyset_Key)
-  for i, test := range tests {
-    key.KeyId = test.keyId
-    // legacy type
-    key.OutputPrefixType = tinkpb.OutputPrefixType_LEGACY
-    prefix, err := tink.GetOutputPrefix(key)
-    if err != nil || !validatePrefix(prefix, tink.LEGACY_START_BYTE, test.result){
-      t.Errorf("incorrect legacy prefix in test %d", i)
-    }
-    // crunchy type
-    key.OutputPrefixType = tinkpb.OutputPrefixType_CRUNCHY
-    prefix, err = tink.GetOutputPrefix(key)
-    if err != nil || !validatePrefix(prefix, tink.LEGACY_START_BYTE, test.result){
-      t.Errorf("incorrect legacy prefix in test %d", i)
-    }
-    // tink type
-    key.OutputPrefixType = tinkpb.OutputPrefixType_TINK
-    prefix, err = tink.GetOutputPrefix(key)
-    if err != nil || !validatePrefix(prefix, tink.TINK_START_BYTE, test.result){
-      t.Errorf("incorrect tink prefix in test %d", i)
-    }
-    // raw type
-    key.OutputPrefixType = tinkpb.OutputPrefixType_RAW
-    prefix, err = tink.GetOutputPrefix(key)
-    if err != nil || prefix != tink.RAW_PREFIX {
-      t.Errorf("incorrect raw prefix in test %d", i)
-    }
-  }
-  // unknown prefix type
-  key.OutputPrefixType = tinkpb.OutputPrefixType_UNKNOWN_PREFIX
-  if _, err := tink.GetOutputPrefix(key); err == nil {
-    t.Errorf("expect an error when prefix type is unknown")
-  }
+	key := new(tinkpb.Keyset_Key)
+	for i, test := range tests {
+		key.KeyId = test.keyId
+		// legacy type
+		key.OutputPrefixType = tinkpb.OutputPrefixType_LEGACY
+		prefix, err := tink.GetOutputPrefix(key)
+		if err != nil || !validatePrefix(prefix, tink.LEGACY_START_BYTE, test.result) {
+			t.Errorf("incorrect legacy prefix in test %d", i)
+		}
+		// crunchy type
+		key.OutputPrefixType = tinkpb.OutputPrefixType_CRUNCHY
+		prefix, err = tink.GetOutputPrefix(key)
+		if err != nil || !validatePrefix(prefix, tink.LEGACY_START_BYTE, test.result) {
+			t.Errorf("incorrect legacy prefix in test %d", i)
+		}
+		// tink type
+		key.OutputPrefixType = tinkpb.OutputPrefixType_TINK
+		prefix, err = tink.GetOutputPrefix(key)
+		if err != nil || !validatePrefix(prefix, tink.TINK_START_BYTE, test.result) {
+			t.Errorf("incorrect tink prefix in test %d", i)
+		}
+		// raw type
+		key.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+		prefix, err = tink.GetOutputPrefix(key)
+		if err != nil || prefix != tink.RAW_PREFIX {
+			t.Errorf("incorrect raw prefix in test %d", i)
+		}
+	}
+	// unknown prefix type
+	key.OutputPrefixType = tinkpb.OutputPrefixType_UNKNOWN_PREFIX
+	if _, err := tink.GetOutputPrefix(key); err == nil {
+		t.Errorf("expect an error when prefix type is unknown")
+	}
 }
 
 func validatePrefix(prefix string, startByte byte, key string) bool {
-  if prefix[0] != startByte {
-    return false
-  }
-  return prefix[1:] == key
+	if prefix[0] != startByte {
+		return false
+	}
+	return prefix[1:] == key
 }

--- a/go/tink/encrypted_keyset_handle.go
+++ b/go/tink/encrypted_keyset_handle.go
@@ -16,24 +16,25 @@
 package tink
 
 import (
-  "fmt"
-  "sync"
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
 )
 
 // encryptedKeysetHandle provides utilities to create keyset handles from keysets
 // that are encrypted with a Master key.
 var ekhInstance *encryptedKeysetHandle
 var encryptedKeysetHandleOnce sync.Once
-type encryptedKeysetHandle struct {}
+
+type encryptedKeysetHandle struct{}
 
 // EncryptedKeysetHandle returns the single instance of encryptedKeysetHandle.
 func EncryptedKeysetHandle() *encryptedKeysetHandle {
-  encryptedKeysetHandleOnce.Do(func() {
-    ekhInstance = new(encryptedKeysetHandle)
-  })
-  return ekhInstance
+	encryptedKeysetHandleOnce.Do(func() {
+		ekhInstance = new(encryptedKeysetHandle)
+	})
+	return ekhInstance
 }
 
 var errInvalidEncryptedKeyset = fmt.Errorf("encrypted_keyset_handle: invalid keyset")
@@ -42,50 +43,50 @@ var errInvalidMasterKey = fmt.Errorf("encrypted_keyset_handle: invalid master ke
 // ParseSerializedKeyset creates a new keyset handle from the given serialized
 // EncryptedKeyset. The keyset is encrypted with the given master key.
 func (handle *encryptedKeysetHandle) ParseSerializedKeyset(
-    serializedEncryptedKeyset []byte, masterKey Aead) (*KeysetHandle, error) {
-  if len(serializedEncryptedKeyset) == 0 {
-    return nil, errInvalidEncryptedKeyset
-  }
-  if masterKey == nil {
-    return nil, errInvalidMasterKey
-  }
-  encryptedKeyset := new(tinkpb.EncryptedKeyset)
-  if err := proto.Unmarshal(serializedEncryptedKeyset, encryptedKeyset); err != nil {
-    return nil, errInvalidEncryptedKeyset
-  }
-  return handle.ParseKeyset(encryptedKeyset, masterKey)
+	serializedEncryptedKeyset []byte, masterKey Aead) (*KeysetHandle, error) {
+	if len(serializedEncryptedKeyset) == 0 {
+		return nil, errInvalidEncryptedKeyset
+	}
+	if masterKey == nil {
+		return nil, errInvalidMasterKey
+	}
+	encryptedKeyset := new(tinkpb.EncryptedKeyset)
+	if err := proto.Unmarshal(serializedEncryptedKeyset, encryptedKeyset); err != nil {
+		return nil, errInvalidEncryptedKeyset
+	}
+	return handle.ParseKeyset(encryptedKeyset, masterKey)
 }
 
 // ParseKeyset creates a new keyset handle from the given EncryptedKeyset and master key.
 func (_ *encryptedKeysetHandle) ParseKeyset(
-    encryptedKeyset *tinkpb.EncryptedKeyset, masterKey Aead) (*KeysetHandle, error) {
-  if encryptedKeyset == nil || len(encryptedKeyset.EncryptedKeyset) == 0 {
-    return nil, errInvalidEncryptedKeyset
-  }
-  if masterKey == nil {
-    return nil, errInvalidMasterKey
-  }
-  keyset, err := DecryptKeyset(encryptedKeyset, masterKey)
-  if err != nil {
-    return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
-  }
-  return newKeysetHandle(keyset, encryptedKeyset)
+	encryptedKeyset *tinkpb.EncryptedKeyset, masterKey Aead) (*KeysetHandle, error) {
+	if encryptedKeyset == nil || len(encryptedKeyset.EncryptedKeyset) == 0 {
+		return nil, errInvalidEncryptedKeyset
+	}
+	if masterKey == nil {
+		return nil, errInvalidMasterKey
+	}
+	keyset, err := DecryptKeyset(encryptedKeyset, masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
+	}
+	return newKeysetHandle(keyset, encryptedKeyset)
 }
 
 // GenerateNew creates a keyset handle that contains a single fresh key generated
 // according to the given key template. The keyset is encrypted with the given master key.
 func (_ *encryptedKeysetHandle) GenerateNew(
-    template *tinkpb.KeyTemplate, masterKey Aead) (*KeysetHandle, error) {
-  if masterKey == nil {
-    return nil, errInvalidMasterKey
-  }
-  keysetManager := NewKeysetManager(template, masterKey, nil)
-  if err := keysetManager.Rotate(); err != nil {
-    return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
-  }
-  handle, err := keysetManager.GetKeysetHandle()
-  if err != nil {
-    return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
-  }
-  return handle, nil
+	template *tinkpb.KeyTemplate, masterKey Aead) (*KeysetHandle, error) {
+	if masterKey == nil {
+		return nil, errInvalidMasterKey
+	}
+	keysetManager := NewKeysetManager(template, masterKey, nil)
+	if err := keysetManager.Rotate(); err != nil {
+		return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
+	}
+	handle, err := keysetManager.GetKeysetHandle()
+	if err != nil {
+		return nil, fmt.Errorf("encrypted_keyset_handle: %s", err)
+	}
+	return handle, nil
 }

--- a/go/tink/encrypted_keyset_handle_test.go
+++ b/go/tink/encrypted_keyset_handle_test.go
@@ -16,174 +16,174 @@
 package tink_test
 
 import (
-  "fmt"
-  "testing"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func setupEncryptedKeysetHandleTest() {
-  if _, err := aead.Config().RegisterStandardKeyTypes(); err != nil {
-    panic(fmt.Sprintln("cannot register aead key types: %s", err))
-  }
-  if _, err := mac.Config().RegisterStandardKeyTypes(); err != nil {
-    panic(fmt.Sprintln("cannot register mac key types: %s", err))
-  }
+	if _, err := aead.Config().RegisterStandardKeyTypes(); err != nil {
+		panic(fmt.Sprintln("cannot register aead key types: %s", err))
+	}
+	if _, err := mac.Config().RegisterStandardKeyTypes(); err != nil {
+		panic(fmt.Sprintln("cannot register mac key types: %s", err))
+	}
 }
 
-func TestEncryptedKeysetHandleInstance(t *testing.T){
-  if handle := tink.EncryptedKeysetHandle(); handle == nil {
-    t.Errorf("EncryptedKeysetHandle() returns nil")
-  }
+func TestEncryptedKeysetHandleInstance(t *testing.T) {
+	if handle := tink.EncryptedKeysetHandle(); handle == nil {
+		t.Errorf("EncryptedKeysetHandle() returns nil")
+	}
 }
 
 func TestEncryptedKeysetHandleParseBasic(t *testing.T) {
-  setupEncryptedKeysetHandleTest()
-  masterKey := newMasterKey()
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
+	setupEncryptedKeysetHandleTest()
+	masterKey := newMasterKey()
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
 
-  // ParseKeyset
-  handle, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, masterKey)
-  if err != nil {
-    t.Errorf("unexpected error when parsing keyset: %s", err)
-  }
-  if err := validateKeysetHandle(handle, keyset, encryptedKeyset); err != nil {
-    t.Errorf("%s", err)
-  }
-  // ParseSerializedKeyset
-  serialized, _ := proto.Marshal(encryptedKeyset)
-  handle, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
-  if err != nil {
-    t.Errorf("unexpected error when parsing serialized keyset: %s", err)
-  }
-  if err := validateKeysetHandle(handle, keyset, encryptedKeyset); err != nil {
-    t.Errorf("%s", err)
-  }
+	// ParseKeyset
+	handle, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, masterKey)
+	if err != nil {
+		t.Errorf("unexpected error when parsing keyset: %s", err)
+	}
+	if err := validateKeysetHandle(handle, keyset, encryptedKeyset); err != nil {
+		t.Errorf("%s", err)
+	}
+	// ParseSerializedKeyset
+	serialized, _ := proto.Marshal(encryptedKeyset)
+	handle, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
+	if err != nil {
+		t.Errorf("unexpected error when parsing serialized keyset: %s", err)
+	}
+	if err := validateKeysetHandle(handle, keyset, encryptedKeyset); err != nil {
+		t.Errorf("%s", err)
+	}
 }
 
 func TestEncryptedKeysetHandleParseWithInvalidMasterKey(t *testing.T) {
-  setupEncryptedKeysetHandleTest()
-  masterKey := newMasterKey()
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
-  serialized, _ := proto.Marshal(encryptedKeyset)
+	setupEncryptedKeysetHandleTest()
+	masterKey := newMasterKey()
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
+	serialized, _ := proto.Marshal(encryptedKeyset)
 
-  // wrong master key
-  _, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, newMasterKey())
-  if err == nil {
-    t.Errorf("expect an error when master key is wrong")
-  }
-  _, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, newMasterKey())
-  if err == nil {
-    t.Errorf("expect an error when master key is wrong")
-  }
+	// wrong master key
+	_, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, newMasterKey())
+	if err == nil {
+		t.Errorf("expect an error when master key is wrong")
+	}
+	_, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, newMasterKey())
+	if err == nil {
+		t.Errorf("expect an error when master key is wrong")
+	}
 }
 
 func TestEncryptedKeysetHandleParseWithInvalidKeyset(t *testing.T) {
-  setupEncryptedKeysetHandleTest()
-  masterKey := newMasterKey()
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
-  serialized, _ := proto.Marshal(encryptedKeyset)
+	setupEncryptedKeysetHandleTest()
+	masterKey := newMasterKey()
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
+	serialized, _ := proto.Marshal(encryptedKeyset)
 
-  // modified
-  serialized[0] = 0
-  _, err := tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when serialized keyset is modified")
-  }
-  // encrypted keyset contains a keyset with no key
-  keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{})
-  encryptedKeyset, _ = tink.EncryptKeyset(keyset, masterKey)
-  serialized, _ = proto.Marshal(encryptedKeyset)
-  _, err = tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when keyset doesn't contain any key")
-  }
-  _, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when keyset doesn't contain any key")
-  }
+	// modified
+	serialized[0] = 0
+	_, err := tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when serialized keyset is modified")
+	}
+	// encrypted keyset contains a keyset with no key
+	keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{})
+	encryptedKeyset, _ = tink.EncryptKeyset(keyset, masterKey)
+	serialized, _ = proto.Marshal(encryptedKeyset)
+	_, err = tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when keyset doesn't contain any key")
+	}
+	_, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when keyset doesn't contain any key")
+	}
 }
 
 func TestEncryptedKeysetHandleParseWithVoidInput(t *testing.T) {
-  setupEncryptedKeysetHandleTest()
-  masterKey := newMasterKey()
-  keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
-  encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
-  serialized, _ := proto.Marshal(encryptedKeyset)
+	setupEncryptedKeysetHandleTest()
+	masterKey := newMasterKey()
+	keyset := testutil.NewTestAesGcmKeyset(tinkpb.OutputPrefixType_TINK)
+	encryptedKeyset, _ := tink.EncryptKeyset(keyset, masterKey)
+	serialized, _ := proto.Marshal(encryptedKeyset)
 
-  // master key is nil
-  _, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, nil)
-  if err == nil {
-    t.Errorf("expect an error when master key is nil")
-  }
-  _, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, nil)
-  if err == nil {
-    t.Errorf("expect an error when master key is nil")
-  }
-  // encrypted keyset is nil
-  _, err = tink.EncryptedKeysetHandle().ParseKeyset(nil, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when keyset is nil")
-  }
-  _, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(nil, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when serialized keyset is nil")
-  }
-  // encrypted keyset is empty array
-  _, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset([]byte{}, masterKey)
-  if err == nil {
-    t.Errorf("expect an error when keyset is an empty slice")
-  }
+	// master key is nil
+	_, err := tink.EncryptedKeysetHandle().ParseKeyset(encryptedKeyset, nil)
+	if err == nil {
+		t.Errorf("expect an error when master key is nil")
+	}
+	_, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(serialized, nil)
+	if err == nil {
+		t.Errorf("expect an error when master key is nil")
+	}
+	// encrypted keyset is nil
+	_, err = tink.EncryptedKeysetHandle().ParseKeyset(nil, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when keyset is nil")
+	}
+	_, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset(nil, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when serialized keyset is nil")
+	}
+	// encrypted keyset is empty array
+	_, err = tink.EncryptedKeysetHandle().ParseSerializedKeyset([]byte{}, masterKey)
+	if err == nil {
+		t.Errorf("expect an error when keyset is an empty slice")
+	}
 }
 
 func TestEncryptedKeysetHandleGenerateNewBasic(t *testing.T) {
-  setupEncryptedKeysetHandleTest()
-  keyTemplate := mac.HmacSha256Tag128KeyTemplate()
-  masterKey := newMasterKey()
+	setupEncryptedKeysetHandleTest()
+	keyTemplate := mac.HmacSha256Tag128KeyTemplate()
+	masterKey := newMasterKey()
 
-  handle, err := tink.EncryptedKeysetHandle().GenerateNew(keyTemplate, masterKey)
-  if err != nil || handle == nil {
-    t.Errorf("generating new handle failed: %s", err)
-  }
+	handle, err := tink.EncryptedKeysetHandle().GenerateNew(keyTemplate, masterKey)
+	if err != nil || handle == nil {
+		t.Errorf("generating new handle failed: %s", err)
+	}
 }
 
 func TestEncryptedKeysetHandleGenerateNewWithVoidInput(t *testing.T) {
-  keyTemplate := mac.HmacSha256Tag128KeyTemplate()
-  masterKey := newMasterKey()
+	keyTemplate := mac.HmacSha256Tag128KeyTemplate()
+	masterKey := newMasterKey()
 
-  // template is nil
-  if _, err := tink.EncryptedKeysetHandle().GenerateNew(nil, masterKey); err == nil {
-    t.Errorf("expect an error when template is nil")
-  }
-  // master key is nil
-  if _, err := tink.EncryptedKeysetHandle().GenerateNew(keyTemplate, nil); err == nil {
-    t.Errorf("expect an error when master key is nil")
-  }
+	// template is nil
+	if _, err := tink.EncryptedKeysetHandle().GenerateNew(nil, masterKey); err == nil {
+		t.Errorf("expect an error when template is nil")
+	}
+	// master key is nil
+	if _, err := tink.EncryptedKeysetHandle().GenerateNew(keyTemplate, nil); err == nil {
+		t.Errorf("expect an error when master key is nil")
+	}
 }
 
 func validateKeysetHandle(handle *tink.KeysetHandle,
-                          keyset *tinkpb.Keyset,
-                          encryptedKeyset *tinkpb.EncryptedKeyset) error {
-  if handle.Keyset().String() != keyset.String() {
-    return fmt.Errorf("incorrect keyset")
-  }
-  if handle.EncryptedKeyset().String() != encryptedKeyset.String() {
-    return fmt.Errorf("incorrect encrypted keyset")
-  }
-  return nil
+	keyset *tinkpb.Keyset,
+	encryptedKeyset *tinkpb.EncryptedKeyset) error {
+	if handle.Keyset().String() != keyset.String() {
+		return fmt.Errorf("incorrect keyset")
+	}
+	if handle.EncryptedKeyset().String() != encryptedKeyset.String() {
+		return fmt.Errorf("incorrect encrypted keyset")
+	}
+	return nil
 }
 
 func newMasterKey() tink.Aead {
-  keyTemplate := aead.Aes128GcmKeyTemplate()
-  keyData, _ := tink.Registry().NewKeyData(keyTemplate)
-  p, _ := tink.Registry().GetPrimitiveFromKeyData(keyData)
-  return p.(tink.Aead)
+	keyTemplate := aead.Aes128GcmKeyTemplate()
+	keyData, _ := tink.Registry().NewKeyData(keyTemplate)
+	p, _ := tink.Registry().GetPrimitiveFromKeyData(keyData)
+	return p.(tink.Aead)
 }

--- a/go/tink/key_manager.go
+++ b/go/tink/key_manager.go
@@ -16,8 +16,8 @@
 package tink
 
 import (
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"github.com/golang/protobuf/proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 /**
@@ -28,53 +28,53 @@ import (
  * given by type_url-field of KeyData-protocol buffer.
  */
 type KeyManager interface {
-  /**
-   * Constructs a primitive instance for the key given in {@code serializedKey},
-   * which must be a serialized key protocol buffer handled by this manager.
-   *
-   * @return the new constructed primitive instance.
-   */
-  GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error)
+	/**
+	 * Constructs a primitive instance for the key given in {@code serializedKey},
+	 * which must be a serialized key protocol buffer handled by this manager.
+	 *
+	 * @return the new constructed primitive instance.
+	 */
+	GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error)
 
-  /**
-   * Constructs a primitive instance for the key given in {@code key}.
-   *
-   * @return the new constructed primitive instance.
-   */
-  GetPrimitiveFromKey(key proto.Message) (interface{}, error)
+	/**
+	 * Constructs a primitive instance for the key given in {@code key}.
+	 *
+	 * @return the new constructed primitive instance.
+	 */
+	GetPrimitiveFromKey(key proto.Message) (interface{}, error)
 
-  /**
-   * Generates a new key according to specification in {@code serializedKeyFormat},
-   * which must be a serialized key format protocol buffer handled by this manager.
-   *
-   * @return the new generated key.
-   */
-  NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error)
+	/**
+	 * Generates a new key according to specification in {@code serializedKeyFormat},
+	 * which must be a serialized key format protocol buffer handled by this manager.
+	 *
+	 * @return the new generated key.
+	 */
+	NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error)
 
-  /**
-   * Generates a new key according to specification in {@code keyFormat}.
-   *
-   * @return the new generated key.
-   */
-  NewKeyFromKeyFormat(keyFormat proto.Message) (proto.Message, error)
+	/**
+	 * Generates a new key according to specification in {@code keyFormat}.
+	 *
+	 * @return the new generated key.
+	 */
+	NewKeyFromKeyFormat(keyFormat proto.Message) (proto.Message, error)
 
-  /**
-   * @return true iff this KeyManager supports key type identified by {@code typeUrl}.
-   */
-  DoesSupport(typeUrl string) bool
+	/**
+	 * @return true iff this KeyManager supports key type identified by {@code typeUrl}.
+	 */
+	DoesSupport(typeUrl string) bool
 
-  /**
-   * @return the type URL that identifes the key type of keys managed by this KeyManager.
-   */
-  GetKeyType() string
+	/**
+	 * @return the type URL that identifes the key type of keys managed by this KeyManager.
+	 */
+	GetKeyType() string
 
-  // APIs for Key Management
+	// APIs for Key Management
 
-  /**
-   * Generates a new {@code KeyData} according to specification in {@code serializedkeyFormat}.
-   * This should be used solely by the key management API.
-   *
-   * @return the new generated key.
-   */
-  NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error)
+	/**
+	 * Generates a new {@code KeyData} according to specification in {@code serializedkeyFormat}.
+	 * This should be used solely by the key management API.
+	 *
+	 * @return the new generated key.
+	 */
+	NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error)
 }

--- a/go/tink/keyset_handle.go
+++ b/go/tink/keyset_handle.go
@@ -16,9 +16,9 @@
 package tink
 
 import (
-  "fmt"
-  "github.com/google/tink/go/util/util"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 var errKeysetHandleInvalidKeyset = fmt.Errorf("keyset_handle: invalid keyset")
@@ -26,86 +26,86 @@ var errKeysetHandleInvalidKeyset = fmt.Errorf("keyset_handle: invalid keyset")
 // KeysetHandle provides abstracted access to Keysets, to limit the exposure
 // of actual protocol buffers that hold sensitive key material.
 type KeysetHandle struct {
-  keyset *tinkpb.Keyset
-  encryptedKeyset *tinkpb.EncryptedKeyset
+	keyset          *tinkpb.Keyset
+	encryptedKeyset *tinkpb.EncryptedKeyset
 }
 
 // NewKeysetHandle creates a new instance of KeysetHandle using the given keyset
 // and encrypted keyset. The given keyset must not be nil. Otherwise, an error will
 // be returned.
 func newKeysetHandle(keyset *tinkpb.Keyset,
-                    encryptedKeyset *tinkpb.EncryptedKeyset) (*KeysetHandle, error) {
-  if keyset == nil || len(keyset.Key) == 0 {
-    return nil, errKeysetHandleInvalidKeyset
-  }
-  return &KeysetHandle{
-    keyset: keyset,
-    encryptedKeyset: encryptedKeyset,
-  }, nil
+	encryptedKeyset *tinkpb.EncryptedKeyset) (*KeysetHandle, error) {
+	if keyset == nil || len(keyset.Key) == 0 {
+		return nil, errKeysetHandleInvalidKeyset
+	}
+	return &KeysetHandle{
+		keyset:          keyset,
+		encryptedKeyset: encryptedKeyset,
+	}, nil
 }
 
 // GetPublicKeysetHandle returns a KeysetHandle of the public keys if the managed
 // keyset contains private keys.
 func (h *KeysetHandle) GetPublicKeysetHandle() (*KeysetHandle, error) {
-  privKeys := h.keyset.Key
-  pubKeys := make([]*tinkpb.Keyset_Key, len(privKeys))
+	privKeys := h.keyset.Key
+	pubKeys := make([]*tinkpb.Keyset_Key, len(privKeys))
 
-  for i := 0; i < len(privKeys); i++ {
-    if privKeys[i] == nil || privKeys[i].KeyData == nil {
-      return nil, errKeysetHandleInvalidKeyset
-    }
-    privKeyData := privKeys[i].KeyData
-    if privKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PRIVATE {
-      return nil, fmt.Errorf("keyset_handle: keyset contains a non-private key")
-    }
-    pubKeyData, err := Registry().GetPublicKeyData(privKeyData.TypeUrl, privKeyData.Value)
-    if err != nil {
-      return nil, fmt.Errorf("keyset_handle: %s", err)
-    }
-    if err := h.validateKeyData(pubKeyData); err != nil {
-      return nil, fmt.Errorf("keyset_handle: %s", err)
-    }
-    pubKeys[i] = &tinkpb.Keyset_Key{
-      KeyData: pubKeyData,
-      Status: privKeys[i].Status,
-      KeyId: privKeys[i].KeyId,
-      OutputPrefixType: privKeys[i].OutputPrefixType,
-    }
-  }
-  pubKeyset := &tinkpb.Keyset{
-    PrimaryKeyId: h.keyset.PrimaryKeyId,
-    Key: pubKeys,
-  }
-  return newKeysetHandle(pubKeyset, nil)
+	for i := 0; i < len(privKeys); i++ {
+		if privKeys[i] == nil || privKeys[i].KeyData == nil {
+			return nil, errKeysetHandleInvalidKeyset
+		}
+		privKeyData := privKeys[i].KeyData
+		if privKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PRIVATE {
+			return nil, fmt.Errorf("keyset_handle: keyset contains a non-private key")
+		}
+		pubKeyData, err := Registry().GetPublicKeyData(privKeyData.TypeUrl, privKeyData.Value)
+		if err != nil {
+			return nil, fmt.Errorf("keyset_handle: %s", err)
+		}
+		if err := h.validateKeyData(pubKeyData); err != nil {
+			return nil, fmt.Errorf("keyset_handle: %s", err)
+		}
+		pubKeys[i] = &tinkpb.Keyset_Key{
+			KeyData:          pubKeyData,
+			Status:           privKeys[i].Status,
+			KeyId:            privKeys[i].KeyId,
+			OutputPrefixType: privKeys[i].OutputPrefixType,
+		}
+	}
+	pubKeyset := &tinkpb.Keyset{
+		PrimaryKeyId: h.keyset.PrimaryKeyId,
+		Key:          pubKeys,
+	}
+	return newKeysetHandle(pubKeyset, nil)
 }
 
 // Ketset returns the keyset component of the keyset handle.
 func (h *KeysetHandle) Keyset() *tinkpb.Keyset {
-  return h.keyset
+	return h.keyset
 }
 
 // EncryptedKeyset returns the encrypted keyset component of the keyset handle.
 func (h *KeysetHandle) EncryptedKeyset() *tinkpb.EncryptedKeyset {
-  return h.encryptedKeyset
+	return h.encryptedKeyset
 }
 
 // KeysetInfo returns a KeysetInfo object that doesn't contain actual key material.
 func (h *KeysetHandle) KeysetInfo() (*tinkpb.KeysetInfo, error) {
-  return util.GetKeysetInfo(h.keyset);
+	return util.GetKeysetInfo(h.keyset)
 }
 
 // String returns the string representation of the KeysetInfo.
 func (h *KeysetHandle) String() string {
-  info, err := h.KeysetInfo()
-  if err != nil {
-    return ""
-  }
-  return info.String()
+	info, err := h.KeysetInfo()
+	if err != nil {
+		return ""
+	}
+	return info.String()
 }
 
 func (h *KeysetHandle) validateKeyData(keyData *tinkpb.KeyData) error {
-  if _, err := Registry().GetPrimitiveFromKeyData(keyData); err != nil {
-    return err
-  }
-  return nil
+	if _, err := Registry().GetPrimitiveFromKeyData(keyData); err != nil {
+		return err
+	}
+	return nil
 }

--- a/go/tink/keyset_handle_test.go
+++ b/go/tink/keyset_handle_test.go
@@ -16,91 +16,90 @@
 package tink
 
 import (
-  "testing"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/google/tink/go/util/util"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestNewKeysetHandleBasic(t *testing.T) {
-  keyData := util.NewKeyData("some type url", []byte{0}, tinkpb.KeyData_SYMMETRIC)
-  key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
-  keyset := util.NewKeyset(1, []*tinkpb.Keyset_Key{key})
-  keysetInfo, _ := util.GetKeysetInfo(keyset)
-  encryptedKeyset := util.NewEncryptedKeyset([]byte{1}, keysetInfo)
-  h, err := newKeysetHandle(keyset, encryptedKeyset)
-  if err != nil {
-    t.Errorf("unexpected error when creating new KeysetHandle")
-  }
-  // test Keyset()
-  if h.Keyset() != keyset {
-    t.Errorf("Keyset() returns incorrect value")
-  }
-  // test EncryptedKeyset()
-  if h.EncryptedKeyset() != encryptedKeyset {
-    t.Errorf("EncryptedKeyset() returns incorrect value")
-  }
-  // test KeysetInfo()
-  tmp, _ := h.KeysetInfo()
-  if tmp.String() != keysetInfo.String() {
-    t.Errorf("KeysetInfo() returns incorrect value")
-  }
-  // test String()
-  if h.String() != keysetInfo.String() {
-    t.Errorf("String() returns incorrect value")
-  }
+	keyData := util.NewKeyData("some type url", []byte{0}, tinkpb.KeyData_SYMMETRIC)
+	key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
+	keyset := util.NewKeyset(1, []*tinkpb.Keyset_Key{key})
+	keysetInfo, _ := util.GetKeysetInfo(keyset)
+	encryptedKeyset := util.NewEncryptedKeyset([]byte{1}, keysetInfo)
+	h, err := newKeysetHandle(keyset, encryptedKeyset)
+	if err != nil {
+		t.Errorf("unexpected error when creating new KeysetHandle")
+	}
+	// test Keyset()
+	if h.Keyset() != keyset {
+		t.Errorf("Keyset() returns incorrect value")
+	}
+	// test EncryptedKeyset()
+	if h.EncryptedKeyset() != encryptedKeyset {
+		t.Errorf("EncryptedKeyset() returns incorrect value")
+	}
+	// test KeysetInfo()
+	tmp, _ := h.KeysetInfo()
+	if tmp.String() != keysetInfo.String() {
+		t.Errorf("KeysetInfo() returns incorrect value")
+	}
+	// test String()
+	if h.String() != keysetInfo.String() {
+		t.Errorf("String() returns incorrect value")
+	}
 }
 
 func TestNewKeysetHandleWithInvalidInput(t *testing.T) {
-  if _, err := newKeysetHandle(nil, nil); err == nil {
-    t.Errorf("NewKeysetHandle should not accept nil as Keyset")
-  }
-  if _, err := newKeysetHandle(new(tinkpb.Keyset), nil); err == nil {
-    t.Errorf("unexpected error: %s", err)
-  }
+	if _, err := newKeysetHandle(nil, nil); err == nil {
+		t.Errorf("NewKeysetHandle should not accept nil as Keyset")
+	}
+	if _, err := newKeysetHandle(new(tinkpb.Keyset), nil); err == nil {
+		t.Errorf("unexpected error: %s", err)
+	}
 }
 
-
 func TestGetPublicKeysetHandleBasic(t *testing.T) {
-  Registry().RegisterKeyManager(signature.NewEcdsaSignKeyManager())
-  Registry().RegisterKeyManager(signature.NewEcdsaVerifyKeyManager())
+	Registry().RegisterKeyManager(signature.NewEcdsaSignKeyManager())
+	Registry().RegisterKeyManager(signature.NewEcdsaVerifyKeyManager())
 
-  template := signature.EcdsaP256KeyTemplate()
-  privHandle, err := CleartextKeysetHandle().GenerateNew(template)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  privKeyset := privHandle.keyset
-  pubHandle, err := privHandle.GetPublicKeysetHandle()
-  if err != nil {
-    t.Errorf("getting public keyset handle failed: %s", err)
-  }
-  pubKeyset := pubHandle.keyset
-  // check Keyset's params
-  if len(pubKeyset.Key) != 1 {
-    t.Errorf("incorrect number of keys in the keyset handle: %s", len(pubHandle.keyset.Key))
-  }
-  if pubKeyset.PrimaryKeyId != privKeyset.PrimaryKeyId {
-    t.Errorf("incorrect primary key id")
-  }
-  // check Keyset_Key's params
-  pubKey := pubKeyset.Key[0]
-  privKey := privKeyset.Key[0]
-  if pubKey.OutputPrefixType != privKey.OutputPrefixType {
-    t.Errorf("incorrect output prefix type")
-  }
-  if pubKey.Status != privKey.Status {
-    t.Errorf("incorrect key status")
-  }
-  if pubKey.KeyId != privKey.KeyId {
-    t.Errorf("incorrect key id")
-  }
-  // check KeyData's params
-  pubKeyData := pubKey.KeyData
-  if pubKeyData.TypeUrl != signature.ECDSA_VERIFY_TYPE_URL {
-    t.Errorf("incorrect typeurl")
-  }
-  if pubKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PUBLIC {
-    t.Errorf("incorrect key material type")
-  }
+	template := signature.EcdsaP256KeyTemplate()
+	privHandle, err := CleartextKeysetHandle().GenerateNew(template)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	privKeyset := privHandle.keyset
+	pubHandle, err := privHandle.GetPublicKeysetHandle()
+	if err != nil {
+		t.Errorf("getting public keyset handle failed: %s", err)
+	}
+	pubKeyset := pubHandle.keyset
+	// check Keyset's params
+	if len(pubKeyset.Key) != 1 {
+		t.Errorf("incorrect number of keys in the keyset handle: %s", len(pubHandle.keyset.Key))
+	}
+	if pubKeyset.PrimaryKeyId != privKeyset.PrimaryKeyId {
+		t.Errorf("incorrect primary key id")
+	}
+	// check Keyset_Key's params
+	pubKey := pubKeyset.Key[0]
+	privKey := privKeyset.Key[0]
+	if pubKey.OutputPrefixType != privKey.OutputPrefixType {
+		t.Errorf("incorrect output prefix type")
+	}
+	if pubKey.Status != privKey.Status {
+		t.Errorf("incorrect key status")
+	}
+	if pubKey.KeyId != privKey.KeyId {
+		t.Errorf("incorrect key id")
+	}
+	// check KeyData's params
+	pubKeyData := pubKey.KeyData
+	if pubKeyData.TypeUrl != signature.ECDSA_VERIFY_TYPE_URL {
+		t.Errorf("incorrect typeurl")
+	}
+	if pubKeyData.KeyMaterialType != tinkpb.KeyData_ASYMMETRIC_PUBLIC {
+		t.Errorf("incorrect key material type")
+	}
 }

--- a/go/tink/keyset_manager.go
+++ b/go/tink/keyset_manager.go
@@ -16,12 +16,12 @@
 package tink
 
 import (
-  "bytes"
-  "fmt"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/util/util"
-  proto "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"bytes"
+	"fmt"
+	proto "github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // emptyAad is the additional authenticated data that is used in the encryption
@@ -32,149 +32,149 @@ var emptyAad = []byte{}
 // disable, enable or destroy keys.
 // Note: It is not thread-safe.
 type KeysetManager struct {
-  keyTemplate *tinkpb.KeyTemplate
-  masterKey Aead
-  keyset *tinkpb.Keyset
+	keyTemplate *tinkpb.KeyTemplate
+	masterKey   Aead
+	keyset      *tinkpb.Keyset
 }
 
 // NewKeysetManager creates a new instance of keyset manager.
 func NewKeysetManager(keyTemplate *tinkpb.KeyTemplate,
-                      masterKey Aead,
-                      keyset *tinkpb.Keyset) *KeysetManager {
-  ret := new(KeysetManager)
-  ret.SetKeyTemplate(keyTemplate)
-  ret.SetMasterKey(masterKey)
-  ret.SetKeyset(keyset)
-  return ret
+	masterKey Aead,
+	keyset *tinkpb.Keyset) *KeysetManager {
+	ret := new(KeysetManager)
+	ret.SetKeyTemplate(keyTemplate)
+	ret.SetMasterKey(masterKey)
+	ret.SetKeyset(keyset)
+	return ret
 }
 
 // Rotate generates a fresh key using the key template of the current keyset manager
 // and sets the new key as the primary key.
 func (km *KeysetManager) Rotate() error {
-  return km.RotateWithTemplate(km.keyTemplate)
+	return km.RotateWithTemplate(km.keyTemplate)
 }
 
 // RotateWithTemplate generates a fresh key using the given key template and
 // sets the new key as the primary key.
 func (km *KeysetManager) RotateWithTemplate(keyTemplate *tinkpb.KeyTemplate) error {
-  if keyTemplate == nil {
-    return fmt.Errorf("keyset_manager: cannot rotate, need key template")
-  }
-  keyData, err := Registry().NewKeyData(keyTemplate)
-  if err != nil {
-    return fmt.Errorf("keyset_manager: cannot create KeyData: %s", err)
-  }
-  keyID := km.newKeyID()
-  outputPrefixType := keyTemplate.OutputPrefixType
-  if outputPrefixType == tinkpb.OutputPrefixType_UNKNOWN_PREFIX {
-    outputPrefixType = tinkpb.OutputPrefixType_TINK
-  }
-  key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, outputPrefixType)
-  // Set the new key as the primary key
-  km.keyset.Key = append(km.keyset.Key, key)
-  km.keyset.PrimaryKeyId = keyID
-  return nil
+	if keyTemplate == nil {
+		return fmt.Errorf("keyset_manager: cannot rotate, need key template")
+	}
+	keyData, err := Registry().NewKeyData(keyTemplate)
+	if err != nil {
+		return fmt.Errorf("keyset_manager: cannot create KeyData: %s", err)
+	}
+	keyID := km.newKeyID()
+	outputPrefixType := keyTemplate.OutputPrefixType
+	if outputPrefixType == tinkpb.OutputPrefixType_UNKNOWN_PREFIX {
+		outputPrefixType = tinkpb.OutputPrefixType_TINK
+	}
+	key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, outputPrefixType)
+	// Set the new key as the primary key
+	km.keyset.Key = append(km.keyset.Key, key)
+	km.keyset.PrimaryKeyId = keyID
+	return nil
 }
 
 // GetKeysetHandle creates a new KeysetHandle for the managed keyset.
 func (km *KeysetManager) GetKeysetHandle() (*KeysetHandle, error) {
-  if km.masterKey == nil {
-    return newKeysetHandle(km.keyset, nil)
-  }
-  encryptedKeyset, err := EncryptKeyset(km.keyset, km.masterKey)
-  if err != nil {
-    return nil, err
-  }
-  return newKeysetHandle(km.keyset, encryptedKeyset)
+	if km.masterKey == nil {
+		return newKeysetHandle(km.keyset, nil)
+	}
+	encryptedKeyset, err := EncryptKeyset(km.keyset, km.masterKey)
+	if err != nil {
+		return nil, err
+	}
+	return newKeysetHandle(km.keyset, encryptedKeyset)
 }
 
 // SetKeyTemplate sets the key template of the manager.
 func (km *KeysetManager) SetKeyTemplate(template *tinkpb.KeyTemplate) {
-  km.keyTemplate = template
+	km.keyTemplate = template
 }
 
 // SetMasterKey sets the master key of the manager.
 func (km *KeysetManager) SetMasterKey(masterKey Aead) {
-  km.masterKey = masterKey
+	km.masterKey = masterKey
 }
 
 // SetKeyset sets the keyset of the manager. If the input is nil, it will use
 // an empty keyset as the input instead.
 func (km *KeysetManager) SetKeyset(keyset *tinkpb.Keyset) {
-  if keyset == nil {
-    km.keyset = new(tinkpb.Keyset)
-  } else {
-    km.keyset = keyset
-  }
+	if keyset == nil {
+		km.keyset = new(tinkpb.Keyset)
+	} else {
+		km.keyset = keyset
+	}
 }
 
 // KeyTemplate returns the key template of the manager.
 func (km *KeysetManager) KeyTemplate() *tinkpb.KeyTemplate {
-  return km.keyTemplate
+	return km.keyTemplate
 }
 
 // MasterKey returns the master key of the manager.
 func (km *KeysetManager) MasterKey() Aead {
-  return km.masterKey
+	return km.masterKey
 }
 
 // Keyset returns the keyset of the manager.
 func (km *KeysetManager) Keyset() *tinkpb.Keyset {
-  return km.keyset
+	return km.keyset
 }
 
 // newKeyID generates a key id that has not been used by any key in the keyset.
 func (km *KeysetManager) newKeyID() uint32 {
-  for {
-    ret := random.GetRandomUint32()
-    ok := true
-    for _, key := range km.keyset.Key {
-      if key.KeyId == ret {
-        ok = false
-        break
-      }
-    }
-    if ok {
-      return ret
-    }
-  }
+	for {
+		ret := random.GetRandomUint32()
+		ok := true
+		for _, key := range km.keyset.Key {
+			if key.KeyId == ret {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return ret
+		}
+	}
 }
 
 // EncryptKeyset encrypts the given keyset using the given master key.
 func EncryptKeyset(keyset *tinkpb.Keyset,
-                  masterKey Aead) (*tinkpb.EncryptedKeyset, error) {
-  serializedKeyset, err := proto.Marshal(keyset)
-  if err != nil {
-    return nil, fmt.Errorf("keyset_manager: invalid keyset")
-  }
-  encrypted, err := masterKey.Encrypt(serializedKeyset, emptyAad)
-  if err != nil {
-    return nil, fmt.Errorf("keyset_manager: encrypted failed: %s", err)
-  }
-  // check if we can decrypt, to detect errors
-  decrypted, err := masterKey.Decrypt(encrypted, emptyAad)
-  if err != nil || !bytes.Equal(decrypted, serializedKeyset) {
-    return nil, fmt.Errorf("keyset_manager: encryption failed: %s", err)
-  }
-  // get keyset info
-  info, err := util.GetKeysetInfo(keyset)
-  if err != nil {
-    return nil, fmt.Errorf("keyset_manager: cannot get keyset info: %s", err)
-  }
-  encryptedKeyset := util.NewEncryptedKeyset(encrypted, info)
-  return encryptedKeyset, nil
+	masterKey Aead) (*tinkpb.EncryptedKeyset, error) {
+	serializedKeyset, err := proto.Marshal(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("keyset_manager: invalid keyset")
+	}
+	encrypted, err := masterKey.Encrypt(serializedKeyset, emptyAad)
+	if err != nil {
+		return nil, fmt.Errorf("keyset_manager: encrypted failed: %s", err)
+	}
+	// check if we can decrypt, to detect errors
+	decrypted, err := masterKey.Decrypt(encrypted, emptyAad)
+	if err != nil || !bytes.Equal(decrypted, serializedKeyset) {
+		return nil, fmt.Errorf("keyset_manager: encryption failed: %s", err)
+	}
+	// get keyset info
+	info, err := util.GetKeysetInfo(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("keyset_manager: cannot get keyset info: %s", err)
+	}
+	encryptedKeyset := util.NewEncryptedKeyset(encrypted, info)
+	return encryptedKeyset, nil
 }
 
 // DecryptKeyset decrypts the given keyset using the given master key
 func DecryptKeyset(encryptedKeyset *tinkpb.EncryptedKeyset,
-                  masterKey Aead) (*tinkpb.Keyset, error) {
-  decrypted, err := masterKey.Decrypt(encryptedKeyset.EncryptedKeyset, []byte{})
-  if err != nil {
-    return nil, fmt.Errorf("keyset_manager: decryption failed: %s", err)
-  }
-  keyset := new(tinkpb.Keyset)
-  if err := proto.Unmarshal(decrypted, keyset); err != nil {
-    return nil, fmt.Errorf("keyset_manager: invalid encrypted keyset")
-  }
-  return keyset, nil
+	masterKey Aead) (*tinkpb.Keyset, error) {
+	decrypted, err := masterKey.Decrypt(encryptedKeyset.EncryptedKeyset, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("keyset_manager: decryption failed: %s", err)
+	}
+	keyset := new(tinkpb.Keyset)
+	if err := proto.Unmarshal(decrypted, keyset); err != nil {
+		return nil, fmt.Errorf("keyset_manager: invalid encrypted keyset")
+	}
+	return keyset, nil
 }

--- a/go/tink/keyset_manager_test.go
+++ b/go/tink/keyset_manager_test.go
@@ -16,138 +16,138 @@
 package tink_test
 
 import (
-  "fmt"
-  "strings"
-  "testing"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/testutil"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"strings"
+	"testing"
 )
 
 func setupKeysetManagerTest() {
-  _, err := mac.Config().RegisterStandardKeyTypes()
-  if err != nil {
-    panic(fmt.Sprintln("cannot register mac key types: %s", err))
-  }
-  _, err = aead.Config().RegisterStandardKeyTypes()
-  if err != nil {
-    panic(fmt.Sprintln("cannot register aead key types: %s", err))
-  }
+	_, err := mac.Config().RegisterStandardKeyTypes()
+	if err != nil {
+		panic(fmt.Sprintln("cannot register mac key types: %s", err))
+	}
+	_, err = aead.Config().RegisterStandardKeyTypes()
+	if err != nil {
+		panic(fmt.Sprintln("cannot register aead key types: %s", err))
+	}
 }
 
 func TestKeysetManagerBasic(t *testing.T) {
-  setupKeysetManagerTest()
+	setupKeysetManagerTest()
 
-  manager := tink.NewKeysetManager(nil, nil, nil)
-  err := manager.Rotate()
-  if err == nil || !strings.Contains(err.Error(), "need key template"){
-    t.Errorf("expect an error when key template is nil")
-  }
-  // Create a keyset that contains a single HmacKey.
-  template := mac.HmacSha256Tag128KeyTemplate()
-  manager = tink.NewKeysetManager(template, nil, nil)
-  err = manager.Rotate()
-  if err != nil {
-    t.Errorf("cannot rotate when key template is available: %s", err)
-  }
-  keyset := manager.Keyset()
-  if len(keyset.Key) != 1 {
-    t.Errorf("expect the number of keys in the keyset is 1")
-  }
-  if keyset.Key[0].KeyId != keyset.PrimaryKeyId ||
-      keyset.Key[0].KeyData.TypeUrl != mac.HMAC_TYPE_URL ||
-      keyset.Key[0].Status != tinkpb.KeyStatusType_ENABLED ||
-      keyset.Key[0].OutputPrefixType != tinkpb.OutputPrefixType_TINK {
-    t.Errorf("incorrect key information: %s", keyset.Key[0])
-  }
+	manager := tink.NewKeysetManager(nil, nil, nil)
+	err := manager.Rotate()
+	if err == nil || !strings.Contains(err.Error(), "need key template") {
+		t.Errorf("expect an error when key template is nil")
+	}
+	// Create a keyset that contains a single HmacKey.
+	template := mac.HmacSha256Tag128KeyTemplate()
+	manager = tink.NewKeysetManager(template, nil, nil)
+	err = manager.Rotate()
+	if err != nil {
+		t.Errorf("cannot rotate when key template is available: %s", err)
+	}
+	keyset := manager.Keyset()
+	if len(keyset.Key) != 1 {
+		t.Errorf("expect the number of keys in the keyset is 1")
+	}
+	if keyset.Key[0].KeyId != keyset.PrimaryKeyId ||
+		keyset.Key[0].KeyData.TypeUrl != mac.HMAC_TYPE_URL ||
+		keyset.Key[0].Status != tinkpb.KeyStatusType_ENABLED ||
+		keyset.Key[0].OutputPrefixType != tinkpb.OutputPrefixType_TINK {
+		t.Errorf("incorrect key information: %s", keyset.Key[0])
+	}
 }
 
 func TestEncryptedKeyset(t *testing.T) {
-  setupKeysetManagerTest()
-  macTemplate := mac.HmacSha256Tag128KeyTemplate()
-  aesTemplate := aead.Aes128GcmKeyTemplate()
-  keyData, err := tink.Registry().NewKeyData(aesTemplate)
-  if err != nil {
-    t.Errorf("cannot create new key data: %s", err)
-  }
-  p, err := tink.Registry().GetPrimitiveFromKeyData(keyData)
-  if p == nil || err != nil {
-    t.Errorf("cannot get primitive from key data: %s", err)
-  }
-  masterKey := p.(tink.Aead)
-  manager := tink.NewKeysetManager(macTemplate, masterKey, nil)
-  err = manager.Rotate()
-  if err != nil {
-    t.Errorf("cannot rotate when key template is available: %s", err)
-  }
-  handle, err := manager.GetKeysetHandle()
-  if handle == nil || err != nil {
-    t.Errorf("cannot get keyset handle: %s", err)
-  }
-  info, err := handle.KeysetInfo()
-  if info == nil || err != nil {
-    t.Errorf("cannot get keyset info: %s", err)
-  }
-  if len(info.KeyInfo) != 1 {
-    t.Errorf("incorrect number of keys: %v", len(info.KeyInfo))
-  }
-  if info.PrimaryKeyId != info.KeyInfo[0].KeyId {
-    t.Errorf("incorrect primary key id: %d >< %d", info.PrimaryKeyId, info.KeyInfo[0].KeyId)
-  }
-  if info.KeyInfo[0].TypeUrl != mac.HMAC_TYPE_URL ||
-    info.KeyInfo[0].Status != tinkpb.KeyStatusType_ENABLED ||
-    info.KeyInfo[0].OutputPrefixType != tinkpb.OutputPrefixType_TINK {
-    t.Errorf("incorrect key info: %s", info.KeyInfo[0])
-  }
+	setupKeysetManagerTest()
+	macTemplate := mac.HmacSha256Tag128KeyTemplate()
+	aesTemplate := aead.Aes128GcmKeyTemplate()
+	keyData, err := tink.Registry().NewKeyData(aesTemplate)
+	if err != nil {
+		t.Errorf("cannot create new key data: %s", err)
+	}
+	p, err := tink.Registry().GetPrimitiveFromKeyData(keyData)
+	if p == nil || err != nil {
+		t.Errorf("cannot get primitive from key data: %s", err)
+	}
+	masterKey := p.(tink.Aead)
+	manager := tink.NewKeysetManager(macTemplate, masterKey, nil)
+	err = manager.Rotate()
+	if err != nil {
+		t.Errorf("cannot rotate when key template is available: %s", err)
+	}
+	handle, err := manager.GetKeysetHandle()
+	if handle == nil || err != nil {
+		t.Errorf("cannot get keyset handle: %s", err)
+	}
+	info, err := handle.KeysetInfo()
+	if info == nil || err != nil {
+		t.Errorf("cannot get keyset info: %s", err)
+	}
+	if len(info.KeyInfo) != 1 {
+		t.Errorf("incorrect number of keys: %v", len(info.KeyInfo))
+	}
+	if info.PrimaryKeyId != info.KeyInfo[0].KeyId {
+		t.Errorf("incorrect primary key id: %d >< %d", info.PrimaryKeyId, info.KeyInfo[0].KeyId)
+	}
+	if info.KeyInfo[0].TypeUrl != mac.HMAC_TYPE_URL ||
+		info.KeyInfo[0].Status != tinkpb.KeyStatusType_ENABLED ||
+		info.KeyInfo[0].OutputPrefixType != tinkpb.OutputPrefixType_TINK {
+		t.Errorf("incorrect key info: %s", info.KeyInfo[0])
+	}
 }
 
 func TestExistingKeyset(t *testing.T) {
-  // Create a keyset that contains a single HmacKey.
-  macTemplate := mac.HmacSha256Tag128KeyTemplate()
-  manager1 := tink.NewKeysetManager(macTemplate, nil, nil)
-  err := manager1.Rotate()
-  if err != nil {
-    t.Errorf("cannot rotate when key template is available: %s", err)
-  }
-  handle1, err := manager1.GetKeysetHandle()
-  if err != nil {
-    t.Errorf("cannot get keyset handle: %s", err)
-  }
-  keyset1 := handle1.Keyset()
+	// Create a keyset that contains a single HmacKey.
+	macTemplate := mac.HmacSha256Tag128KeyTemplate()
+	manager1 := tink.NewKeysetManager(macTemplate, nil, nil)
+	err := manager1.Rotate()
+	if err != nil {
+		t.Errorf("cannot rotate when key template is available: %s", err)
+	}
+	handle1, err := manager1.GetKeysetHandle()
+	if err != nil {
+		t.Errorf("cannot get keyset handle: %s", err)
+	}
+	keyset1 := handle1.Keyset()
 
-  manager2 := tink.NewKeysetManager(nil, nil, keyset1)
-  manager2.RotateWithTemplate(macTemplate)
-  handle2, err := manager2.GetKeysetHandle()
-  if err != nil {
-    t.Errorf("cannot get keyset handle: %s", err)
-  }
-  keyset2 := handle2.Keyset()
-  if len(keyset2.Key) != 2 {
-    t.Errorf("expect the number of keys to be 2, got %d", len(keyset2.Key))
-  }
-  if keyset1.Key[0].String() != keyset2.Key[0].String() {
-    t.Errorf("expect the first key in two keysets to be the same")
-  }
-  if keyset2.Key[1].KeyId != keyset2.PrimaryKeyId {
-    t.Errorf("expect the second key to be primary")
-  }
+	manager2 := tink.NewKeysetManager(nil, nil, keyset1)
+	manager2.RotateWithTemplate(macTemplate)
+	handle2, err := manager2.GetKeysetHandle()
+	if err != nil {
+		t.Errorf("cannot get keyset handle: %s", err)
+	}
+	keyset2 := handle2.Keyset()
+	if len(keyset2.Key) != 2 {
+		t.Errorf("expect the number of keys to be 2, got %d", len(keyset2.Key))
+	}
+	if keyset1.Key[0].String() != keyset2.Key[0].String() {
+		t.Errorf("expect the first key in two keysets to be the same")
+	}
+	if keyset2.Key[1].KeyId != keyset2.PrimaryKeyId {
+		t.Errorf("expect the second key to be primary")
+	}
 }
 
 /**
  * Tests that when encryption with KMS failed, an exception is thrown.
  */
 func TestFaultyKms(t *testing.T) {
-  var masterKey tink.Aead = new(testutil.DummyAead)
-  template := mac.HmacSha256Tag128KeyTemplate()
-  manager := tink.NewKeysetManager(template, masterKey, nil)
-  err := manager.Rotate()
-  if err != nil {
-    t.Errorf("cannot rotate when key template is available: %s", err)
-  }
-  _, err = manager.GetKeysetHandle()
-  if err == nil || !strings.Contains(err.Error(), "dummy"){
-    t.Errorf("expect an error with dummy aead: %s", err)
-  }
+	var masterKey tink.Aead = new(testutil.DummyAead)
+	template := mac.HmacSha256Tag128KeyTemplate()
+	manager := tink.NewKeysetManager(template, masterKey, nil)
+	err := manager.Rotate()
+	if err != nil {
+		t.Errorf("cannot rotate when key template is available: %s", err)
+	}
+	_, err = manager.GetKeysetHandle()
+	if err == nil || !strings.Contains(err.Error(), "dummy") {
+		t.Errorf("expect an error with dummy aead: %s", err)
+	}
 }

--- a/go/tink/mac.go
+++ b/go/tink/mac.go
@@ -21,17 +21,17 @@
 package tink
 
 type Mac interface {
-  /**
-  * Computes message authentication code (MAC) for {@code data}.
-  *
-  * @return MAC value.
-  */
-  ComputeMac(data []byte) ([]byte, error)
+	/**
+	 * Computes message authentication code (MAC) for {@code data}.
+	 *
+	 * @return MAC value.
+	 */
+	ComputeMac(data []byte) ([]byte, error)
 
-  /**
-  * Verifies whether {@code mac} is a correct authentication code (MAC) for {@code data}.
-  *
-  * @return 0 if {@code mac} is correct; 1 otherwise.
-  */
-  VerifyMac(mac []byte, data []byte) (bool, error)
+	/**
+	 * Verifies whether {@code mac} is a correct authentication code (MAC) for {@code data}.
+	 *
+	 * @return 0 if {@code mac} is correct; 1 otherwise.
+	 */
+	VerifyMac(mac []byte, data []byte) (bool, error)
 }

--- a/go/tink/primitive_set.go
+++ b/go/tink/primitive_set.go
@@ -16,44 +16,44 @@
 package tink
 
 import (
-  "fmt"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // Entry represents a single entry in the keyset. In addition to the actual primitive,
 // it holds the identifier and status of the primitive.
 type Entry struct {
-  primitive interface{}
-  identifier string
-  status tinkpb.KeyStatusType
-  outputPrefixType tinkpb.OutputPrefixType
+	primitive        interface{}
+	identifier       string
+	status           tinkpb.KeyStatusType
+	outputPrefixType tinkpb.OutputPrefixType
 }
 
 // NewEntry creates a new instance of Entry using the given information.
 func NewEntry(p interface{}, id string, stt tinkpb.KeyStatusType,
-              outputPrefixType tinkpb.OutputPrefixType) *Entry {
-  return &Entry{
-    primitive: p,
-    identifier: id,
-    status: stt,
-    outputPrefixType: outputPrefixType,
-  }
+	outputPrefixType tinkpb.OutputPrefixType) *Entry {
+	return &Entry{
+		primitive:        p,
+		identifier:       id,
+		status:           stt,
+		outputPrefixType: outputPrefixType,
+	}
 }
 
 func (e *Entry) Primitive() interface{} {
-  return e.primitive
+	return e.primitive
 }
 
 func (e *Entry) Status() tinkpb.KeyStatusType {
-  return e.status
+	return e.status
 }
 
 func (e *Entry) Identifier() string {
-  return e.identifier
+	return e.identifier
 }
 
 func (e *Entry) OutputPrefixType() tinkpb.OutputPrefixType {
-  return e.outputPrefixType
+	return e.outputPrefixType
 }
 
 /**
@@ -72,86 +72,86 @@ func (e *Entry) OutputPrefixType() tinkpb.OutputPrefixType {
  *
  * PrimitiveSet is a public class to allow its use in implementations of custom primitives.
  */
-type PrimitiveSet struct{
-  // Primary entry
-  primary *Entry
+type PrimitiveSet struct {
+	// Primary entry
+	primary *Entry
 
-  // The primitives are stored in a map of
-  // (ciphertext prefix, list of primitives sharing the prefix).
-  // This allows quickly retrieving the primitives sharing some particular prefix.
-  // Because all RAW keys are using an empty prefix, this also quickly allows retrieving them.
-  primitives map[string][]*Entry
+	// The primitives are stored in a map of
+	// (ciphertext prefix, list of primitives sharing the prefix).
+	// This allows quickly retrieving the primitives sharing some particular prefix.
+	// Because all RAW keys are using an empty prefix, this also quickly allows retrieving them.
+	primitives map[string][]*Entry
 }
 
 // NewPrimitiveSet returns an empty instance of PrimitiveSet.
 func NewPrimitiveSet() *PrimitiveSet {
-  return &PrimitiveSet{
-    primary: nil,
-    primitives: make(map[string][]*Entry),
-  }
+	return &PrimitiveSet{
+		primary:    nil,
+		primitives: make(map[string][]*Entry),
+	}
 }
 
 // GetRawPrimitives returns all primitives in the set that have RAW prefix.
 func (ps *PrimitiveSet) GetRawPrimitives() ([]*Entry, error) {
-  return ps.GetPrimitivesWithStringIdentifier(RAW_PREFIX)
+	return ps.GetPrimitivesWithStringIdentifier(RAW_PREFIX)
 }
 
 // GetPrimitivesWithKey returns all primitives in the set that have prefix equal
 // to that of the given key.
 func (ps *PrimitiveSet) GetPrimitivesWithKey(key *tinkpb.Keyset_Key) ([]*Entry, error) {
-  if key == nil {
-    return nil, fmt.Errorf("primitive_set: key must not be nil")
-  }
-  id, err := GetOutputPrefix(key)
-  if err != nil {
-    return nil, fmt.Errorf("primitive_set: %s", err)
-  }
-  return ps.GetPrimitivesWithStringIdentifier(id)
+	if key == nil {
+		return nil, fmt.Errorf("primitive_set: key must not be nil")
+	}
+	id, err := GetOutputPrefix(key)
+	if err != nil {
+		return nil, fmt.Errorf("primitive_set: %s", err)
+	}
+	return ps.GetPrimitivesWithStringIdentifier(id)
 }
 
 // GetPrimitivesWithByteIdentifier returns all primitives in the set that have
 // the given prefix.
 func (ps *PrimitiveSet) GetPrimitivesWithByteIdentifier(id []byte) ([]*Entry, error) {
-  return ps.GetPrimitivesWithStringIdentifier(string(id))
+	return ps.GetPrimitivesWithStringIdentifier(string(id))
 }
 
 // GetPrimitivesWithStringIdentifier returns all primitives in the set that have
 // the given prefix.
 func (ps *PrimitiveSet) GetPrimitivesWithStringIdentifier(id string) ([]*Entry, error) {
-  result, found := ps.primitives[id]
-  if !found {
-    return []*Entry{}, nil
-  }
-  return result, nil
+	result, found := ps.primitives[id]
+	if !found {
+		return []*Entry{}, nil
+	}
+	return result, nil
 }
 
 // GetPrimitives returns all primitives of the set.
 func (ps *PrimitiveSet) Primitives() map[string][]*Entry {
-  return ps.primitives
+	return ps.primitives
 }
 
 // Primary returns the entry with the primary primitive.
 func (ps *PrimitiveSet) Primary() *Entry {
-  return ps.primary
+	return ps.primary
 }
 
 // SetPrimary sets the primary entry of the set to the given entry.
 func (ps *PrimitiveSet) SetPrimary(e *Entry) {
-  ps.primary = e
+	ps.primary = e
 }
 
 // AddPrimitive creates a new entry in the primitive set using the given information
 // and returns the added entry.
 func (ps *PrimitiveSet) AddPrimitive(primitive interface{},
-                                    key *tinkpb.Keyset_Key) (*Entry, error) {
-  if key == nil || primitive == nil {
-    return nil, fmt.Errorf("primitive_set: key and primitive must not be nil")
-  }
-  id, err := GetOutputPrefix(key)
-  if err != nil {
-    return nil, fmt.Errorf("primitive_set: %s", err)
-  }
-  e := NewEntry(primitive, id, key.Status, key.OutputPrefixType)
-  ps.primitives[id] = append(ps.primitives[id], e)
-  return e, nil
+	key *tinkpb.Keyset_Key) (*Entry, error) {
+	if key == nil || primitive == nil {
+		return nil, fmt.Errorf("primitive_set: key and primitive must not be nil")
+	}
+	id, err := GetOutputPrefix(key)
+	if err != nil {
+		return nil, fmt.Errorf("primitive_set: %s", err)
+	}
+	e := NewEntry(primitive, id, key.Status, key.OutputPrefixType)
+	ps.primitives[id] = append(ps.primitives[id], e)
+	return e, nil
 }

--- a/go/tink/primitive_set_test.go
+++ b/go/tink/primitive_set_test.go
@@ -16,156 +16,156 @@
 package tink_test
 
 import (
-  "fmt"
-  "testing"
-  "reflect"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/tink/tink"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"reflect"
+	"testing"
 )
 
 func genKeysForPrimitiveSetTest() []*tinkpb.Keyset_Key {
-  var keyId0 = 1234543
-  var keyId1 = 7213743
-  var keyId2 = keyId1
-  var keyId3 = 947327
-  var keyId4 = 529472
-  var keyId5 = keyId0
-  return []*tinkpb.Keyset_Key{
-    testutil.NewDummyKey(keyId0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
-    testutil.NewDummyKey(keyId1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_LEGACY),
-    testutil.NewDummyKey(keyId2, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
-    testutil.NewDummyKey(keyId3, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_RAW),
-    testutil.NewDummyKey(keyId4, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_RAW),
-    testutil.NewDummyKey(keyId5, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_TINK),
-  }
+	var keyId0 = 1234543
+	var keyId1 = 7213743
+	var keyId2 = keyId1
+	var keyId3 = 947327
+	var keyId4 = 529472
+	var keyId5 = keyId0
+	return []*tinkpb.Keyset_Key{
+		testutil.NewDummyKey(keyId0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
+		testutil.NewDummyKey(keyId1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_LEGACY),
+		testutil.NewDummyKey(keyId2, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
+		testutil.NewDummyKey(keyId3, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_RAW),
+		testutil.NewDummyKey(keyId4, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_RAW),
+		testutil.NewDummyKey(keyId5, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_TINK),
+	}
 }
 
 func TestPrimitiveSetBasic(t *testing.T) {
-  var err error
-  ps := tink.NewPrimitiveSet()
-  if ps.Primary() != nil || ps.Primitives() == nil {
-    t.Errorf("expect primary to be nil and primitives is initialized")
-  }
-  // generate test keys
-  keys := genKeysForPrimitiveSetTest()
-  // add all test primitives
-  macs := make([]testutil.DummyMac, len(keys))
-  entries := make([]*tink.Entry, len(macs))
-  for i := 0; i < len(macs); i++ {
-    macs[i] = testutil.DummyMac{Name: fmt.Sprintf("Mac#%d", i)}
-    entries[i], err = ps.AddPrimitive(macs[i], keys[i])
-    if err != nil {
-      t.Errorf("unexpected error when adding mac%d: %s", i, err)
-    }
-  }
-  // set primary entry
-  primaryId := 2
-  ps.SetPrimary(entries[primaryId])
-  // validate the primitive in primary
-  if !validateEntry(ps.Primary(), macs[primaryId], keys[primaryId].Status, keys[primaryId].OutputPrefixType) {
-    t.Errorf("SetPrimary is not working correctly")
-  }
-  // check raw primitive
-  rawMacs := []testutil.DummyMac{macs[3], macs[4]}
-  rawStatuses := []tinkpb.KeyStatusType{keys[3].Status, keys[4].Status}
-  rawPrefixTypes := []tinkpb.OutputPrefixType{keys[3].OutputPrefixType, keys[4].OutputPrefixType}
-  rawEntries, err := ps.GetRawPrimitives()
-  if err != nil {
-    t.Errorf("unexpected error when getting raw primitives: %s", err)
-  }
-  if !validateEntryList(rawEntries, rawMacs, rawStatuses, rawPrefixTypes) {
-    t.Errorf("raw primitives do not match input")
-  }
-  // check tink primitives, same id
-  tinkMacs := []testutil.DummyMac{macs[0], macs[5]}
-  tinkStatuses := []tinkpb.KeyStatusType{keys[0].Status, keys[5].Status}
-  tinkPrefixTypes := []tinkpb.OutputPrefixType{keys[0].OutputPrefixType, keys[5].OutputPrefixType}
-  tinkEntries, err := ps.GetPrimitivesWithKey(keys[0])
-  if err != nil {
-    t.Errorf("unexpected error when getting primitives: %s", err)
-  }
-  if !validateEntryList(tinkEntries, tinkMacs, tinkStatuses, tinkPrefixTypes) {
-    t.Errorf("tink primitives do not match the input key")
-  }
-  // check another tink primitive
-  tinkMacs = []testutil.DummyMac{macs[2]}
-  tinkStatuses = []tinkpb.KeyStatusType{keys[2].Status}
-  tinkPrefixTypes = []tinkpb.OutputPrefixType{keys[2].OutputPrefixType}
-  tinkEntries, err = ps.GetPrimitivesWithKey(keys[2])
-  if err != nil {
-    t.Errorf("unexpected error when getting tink primitives: %s", err)
-  }
-  if !validateEntryList(tinkEntries, tinkMacs, tinkStatuses, tinkPrefixTypes) {
-    t.Errorf("tink primitives do not match the input key")
-  }
-  //check legacy primitives
-  legacyMacs := []testutil.DummyMac{macs[1]}
-  legacyStatuses := []tinkpb.KeyStatusType{keys[1].Status}
-  legacyPrefixTypes := []tinkpb.OutputPrefixType{keys[1].OutputPrefixType}
-  legacyPrefix, _ := tink.GetOutputPrefix(keys[1])
-  legacyEntries, err := ps.GetPrimitivesWithStringIdentifier(legacyPrefix)
-  if err != nil {
-    t.Errorf("unexpected error when getting legacy primitives: %s", err)
-  }
-  if !validateEntryList(legacyEntries, legacyMacs, legacyStatuses, legacyPrefixTypes) {
-    t.Errorf("legacy primitives do not match the input key")
-  }
+	var err error
+	ps := tink.NewPrimitiveSet()
+	if ps.Primary() != nil || ps.Primitives() == nil {
+		t.Errorf("expect primary to be nil and primitives is initialized")
+	}
+	// generate test keys
+	keys := genKeysForPrimitiveSetTest()
+	// add all test primitives
+	macs := make([]testutil.DummyMac, len(keys))
+	entries := make([]*tink.Entry, len(macs))
+	for i := 0; i < len(macs); i++ {
+		macs[i] = testutil.DummyMac{Name: fmt.Sprintf("Mac#%d", i)}
+		entries[i], err = ps.AddPrimitive(macs[i], keys[i])
+		if err != nil {
+			t.Errorf("unexpected error when adding mac%d: %s", i, err)
+		}
+	}
+	// set primary entry
+	primaryId := 2
+	ps.SetPrimary(entries[primaryId])
+	// validate the primitive in primary
+	if !validateEntry(ps.Primary(), macs[primaryId], keys[primaryId].Status, keys[primaryId].OutputPrefixType) {
+		t.Errorf("SetPrimary is not working correctly")
+	}
+	// check raw primitive
+	rawMacs := []testutil.DummyMac{macs[3], macs[4]}
+	rawStatuses := []tinkpb.KeyStatusType{keys[3].Status, keys[4].Status}
+	rawPrefixTypes := []tinkpb.OutputPrefixType{keys[3].OutputPrefixType, keys[4].OutputPrefixType}
+	rawEntries, err := ps.GetRawPrimitives()
+	if err != nil {
+		t.Errorf("unexpected error when getting raw primitives: %s", err)
+	}
+	if !validateEntryList(rawEntries, rawMacs, rawStatuses, rawPrefixTypes) {
+		t.Errorf("raw primitives do not match input")
+	}
+	// check tink primitives, same id
+	tinkMacs := []testutil.DummyMac{macs[0], macs[5]}
+	tinkStatuses := []tinkpb.KeyStatusType{keys[0].Status, keys[5].Status}
+	tinkPrefixTypes := []tinkpb.OutputPrefixType{keys[0].OutputPrefixType, keys[5].OutputPrefixType}
+	tinkEntries, err := ps.GetPrimitivesWithKey(keys[0])
+	if err != nil {
+		t.Errorf("unexpected error when getting primitives: %s", err)
+	}
+	if !validateEntryList(tinkEntries, tinkMacs, tinkStatuses, tinkPrefixTypes) {
+		t.Errorf("tink primitives do not match the input key")
+	}
+	// check another tink primitive
+	tinkMacs = []testutil.DummyMac{macs[2]}
+	tinkStatuses = []tinkpb.KeyStatusType{keys[2].Status}
+	tinkPrefixTypes = []tinkpb.OutputPrefixType{keys[2].OutputPrefixType}
+	tinkEntries, err = ps.GetPrimitivesWithKey(keys[2])
+	if err != nil {
+		t.Errorf("unexpected error when getting tink primitives: %s", err)
+	}
+	if !validateEntryList(tinkEntries, tinkMacs, tinkStatuses, tinkPrefixTypes) {
+		t.Errorf("tink primitives do not match the input key")
+	}
+	//check legacy primitives
+	legacyMacs := []testutil.DummyMac{macs[1]}
+	legacyStatuses := []tinkpb.KeyStatusType{keys[1].Status}
+	legacyPrefixTypes := []tinkpb.OutputPrefixType{keys[1].OutputPrefixType}
+	legacyPrefix, _ := tink.GetOutputPrefix(keys[1])
+	legacyEntries, err := ps.GetPrimitivesWithStringIdentifier(legacyPrefix)
+	if err != nil {
+		t.Errorf("unexpected error when getting legacy primitives: %s", err)
+	}
+	if !validateEntryList(legacyEntries, legacyMacs, legacyStatuses, legacyPrefixTypes) {
+		t.Errorf("legacy primitives do not match the input key")
+	}
 }
 
 func TestGetPrimitivesWithInvalidInput(t *testing.T) {
-  ps := tink.NewPrimitiveSet()
-  if _, err := ps.GetPrimitivesWithKey(nil); err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
+	ps := tink.NewPrimitiveSet()
+	if _, err := ps.GetPrimitivesWithKey(nil); err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
 }
 
 func TestAddPrimitiveWithInvalidInput(t *testing.T) {
-  ps := tink.NewPrimitiveSet()
-  // nil input
-  key := testutil.NewDummyKey(0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK)
-  if _, err := ps.AddPrimitive(nil, key); err == nil {
-    t.Errorf("expect an error when primitive input is nil")
-  }
-  if _, err := ps.AddPrimitive(*new(testutil.DummyMac), nil); err == nil {
-    t.Errorf("expect an error when key input is nil")
-  }
-  // unknown prefix type
-  invalidKey := testutil.NewDummyKey(0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_UNKNOWN_PREFIX)
-  if _, err := ps.AddPrimitive(*new(testutil.DummyMac), invalidKey); err == nil {
-    t.Errorf("expect an error when key is invalid")
-  }
+	ps := tink.NewPrimitiveSet()
+	// nil input
+	key := testutil.NewDummyKey(0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK)
+	if _, err := ps.AddPrimitive(nil, key); err == nil {
+		t.Errorf("expect an error when primitive input is nil")
+	}
+	if _, err := ps.AddPrimitive(*new(testutil.DummyMac), nil); err == nil {
+		t.Errorf("expect an error when key input is nil")
+	}
+	// unknown prefix type
+	invalidKey := testutil.NewDummyKey(0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_UNKNOWN_PREFIX)
+	if _, err := ps.AddPrimitive(*new(testutil.DummyMac), invalidKey); err == nil {
+		t.Errorf("expect an error when key is invalid")
+	}
 }
 
 func validateEntryList(entries []*tink.Entry,
-                        macs []testutil.DummyMac,
-                        statuses []tinkpb.KeyStatusType,
-                        prefixTypes []tinkpb.OutputPrefixType) bool {
-  if len(entries) != len(macs) {
-    return false
-  }
-  for i := 0; i < len(entries); i++ {
-    if !validateEntry(entries[i], macs[i], statuses[i], prefixTypes[i]) {
-      return false
-    }
-  }
-  return true
+	macs []testutil.DummyMac,
+	statuses []tinkpb.KeyStatusType,
+	prefixTypes []tinkpb.OutputPrefixType) bool {
+	if len(entries) != len(macs) {
+		return false
+	}
+	for i := 0; i < len(entries); i++ {
+		if !validateEntry(entries[i], macs[i], statuses[i], prefixTypes[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // Compares an entry with the testutil.DummyMac that was used to create the entry
 func validateEntry(entry *tink.Entry,
-                    testMac testutil.DummyMac,
-                    status tinkpb.KeyStatusType,
-                    outputPrefixType tinkpb.OutputPrefixType) bool {
-  if entry.Status() != status || entry.OutputPrefixType() != outputPrefixType{
-    return false
-  }
-  var dummyMac = entry.Primitive().(testutil.DummyMac)
-  var m tink.Mac = &dummyMac
-  data := []byte{1, 2, 3, 4, 5}
-  digest, err := m.ComputeMac(data)
-  if err != nil || !reflect.DeepEqual(append(data, testMac.Name...), digest) {
-    return false
-  }
-  return true
+	testMac testutil.DummyMac,
+	status tinkpb.KeyStatusType,
+	outputPrefixType tinkpb.OutputPrefixType) bool {
+	if entry.Status() != status || entry.OutputPrefixType() != outputPrefixType {
+		return false
+	}
+	var dummyMac = entry.Primitive().(testutil.DummyMac)
+	var m tink.Mac = &dummyMac
+	data := []byte{1, 2, 3, 4, 5}
+	digest, err := m.ComputeMac(data)
+	if err != nil || !reflect.DeepEqual(append(data, testMac.Name...), digest) {
+		return false
+	}
+	return true
 }

--- a/go/tink/private_key_manager.go
+++ b/go/tink/private_key_manager.go
@@ -16,13 +16,13 @@
 package tink
 
 import (
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // PrivateKeyManager is a special type of KeyManager that understands private key types.
 type PrivateKeyManager interface {
-  KeyManager
+	KeyManager
 
-  // GetPublicKeyData extracts the public key data from the private key.
-  GetPublicKeyData(serializedKey []byte) (*tinkpb.KeyData, error)
+	// GetPublicKeyData extracts the public key data from the private key.
+	GetPublicKeyData(serializedKey []byte) (*tinkpb.KeyData, error)
 }

--- a/go/tink/public_key_sign.go
+++ b/go/tink/public_key_sign.go
@@ -20,11 +20,11 @@ package tink
  * Implementations of this interface are secure against adaptive chosen-message attacks.
  * Signing data ensures authenticity and integrity of that data, but not its secrecy.
  */
-type PublicKeySign interface{
-  /**
-   * Computes the signature for {@code data}.
-   *
-   * @return the signature of {$code data}.
-   */
-  Sign(data []byte) ([]byte, error)
+type PublicKeySign interface {
+	/**
+	 * Computes the signature for {@code data}.
+	 *
+	 * @return the signature of {$code data}.
+	 */
+	Sign(data []byte) ([]byte, error)
 }

--- a/go/tink/public_key_verify.go
+++ b/go/tink/public_key_verify.go
@@ -20,12 +20,12 @@ package tink
  * Implementations of this interface are secure against adaptive chosen-message attacks.
  * Signing data ensures authenticity and integrity of that data, but not its secrecy.
  */
-type PublicKeyVerify interface{
-  /**
-   * Verifies whether {@code signature} is a valid signature for {@code data}.
-   *
-   * @return an error if {@code signature} is not a valid signature for
-   * {@code data}; nil otherwise.
-   */
-  Verify(signature []byte, data []byte) error
+type PublicKeyVerify interface {
+	/**
+	 * Verifies whether {@code signature} is a valid signature for {@code data}.
+	 *
+	 * @return an error if {@code signature} is not a valid signature for
+	 * {@code data}; nil otherwise.
+	 */
+	Verify(signature []byte, data []byte) error
 }

--- a/go/tink/registry.go
+++ b/go/tink/registry.go
@@ -16,41 +16,41 @@
 package tink
 
 import (
-  "fmt"
-  "sync"
-  "github.com/google/tink/go/util/util"
-  "github.com/golang/protobuf/proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
 )
 
 // Mapping between typeUrl and KeyManager.
 // Using mutex for concurrency read and write
 type keyManagerMap struct {
-  sync.RWMutex
-  m map[string]KeyManager
+	sync.RWMutex
+	m map[string]KeyManager
 }
 
 // NewKeyManagerMap creates a new instance of keyManagerMap.
 func NewKeyManagerMap() *keyManagerMap {
-  kmMap := new(keyManagerMap)
-  kmMap.m = make(map[string]KeyManager)
-  return kmMap
+	kmMap := new(keyManagerMap)
+	kmMap.m = make(map[string]KeyManager)
+	return kmMap
 }
 
 // Get returns whether the specified typeUrl exists in the map and
 // the corresponding value if it exists.
 func (kmMap *keyManagerMap) Get(typeUrl string) (KeyManager, bool) {
-  kmMap.RLock()
-  defer kmMap.RUnlock()
-  km, existed := kmMap.m[typeUrl]
-  return km, existed
+	kmMap.RLock()
+	defer kmMap.RUnlock()
+	km, existed := kmMap.m[typeUrl]
+	return km, existed
 }
 
 // Put associates the given keyManager with the given typeUrl in the map.
 func (kmMap *keyManagerMap) Put(typeUrl string, keyManager KeyManager) {
-  kmMap.Lock()
-  defer kmMap.Unlock()
-  kmMap.m[typeUrl] = keyManager
+	kmMap.Lock()
+	defer kmMap.Unlock()
+	kmMap.m[typeUrl] = keyManager
 }
 
 // Registry for KeyMangers. <p>
@@ -68,15 +68,15 @@ func (kmMap *keyManagerMap) Put(typeUrl string, keyManager KeyManager) {
 // KeyManagers. Registry is public though, to enable configurations with custom
 // primitives and KeyManagers.
 type registry struct {
-  // Thread-safe mapping between typeUrl and KeyManager.
-  keyManagers *keyManagerMap
+	// Thread-safe mapping between typeUrl and KeyManager.
+	keyManagers *keyManagerMap
 }
 
 // newRegistry creates a new instance of registry.
 func newRegistry() *registry {
-  reg := new(registry)
-  reg.keyManagers = NewKeyManagerMap()
-  return reg
+	reg := new(registry)
+	reg.keyManagers = NewKeyManagerMap()
+	return reg
 }
 
 // registryInstance is a shared instance of registry. It is initialized only once
@@ -86,106 +86,106 @@ var once sync.Once
 
 // Registry creates an instance of registry if there isn't and returns the instance.
 func Registry() *registry {
-  // only create the registry instance once
-  once.Do(func() {
-    registryInstance = newRegistry()
-  })
-  return registryInstance
+	// only create the registry instance once
+	once.Do(func() {
+		registryInstance = newRegistry()
+	})
+	return registryInstance
 }
 
 // RegisterKeyManager registers the given key manager.
 // It does nothing if there already exists a key manager with the same type url.
 // It returns true if the key manager is registered; false otherwise.
 func (reg *registry) RegisterKeyManager(manager KeyManager) (bool, error) {
-  if manager == nil {
-    return false, fmt.Errorf("registry: invalid key manager")
-  }
-  typeUrl := manager.GetKeyType()
-  // try to get the key manager with the given typeUrl, return false if there is
-  _, existed := reg.keyManagers.Get(typeUrl)
-  if existed {
-    return false, nil
-  }
-  // add the manager
-  reg.keyManagers.Put(typeUrl, manager)
-  return true, nil
+	if manager == nil {
+		return false, fmt.Errorf("registry: invalid key manager")
+	}
+	typeUrl := manager.GetKeyType()
+	// try to get the key manager with the given typeUrl, return false if there is
+	_, existed := reg.keyManagers.Get(typeUrl)
+	if existed {
+		return false, nil
+	}
+	// add the manager
+	reg.keyManagers.Put(typeUrl, manager)
+	return true, nil
 }
 
 // GetKeyManager returns the key manager for the given type url if existed.
 func (reg *registry) GetKeyManager(typeUrl string) (KeyManager, error) {
-  manager, existed := reg.keyManagers.Get(typeUrl)
-  if !existed {
-    return nil, fmt.Errorf("registry: unsupported key type: %s", typeUrl)
-  }
-  return manager, nil
+	manager, existed := reg.keyManagers.Get(typeUrl)
+	if !existed {
+		return nil, fmt.Errorf("registry: unsupported key type: %s", typeUrl)
+	}
+	return manager, nil
 }
 
 // NewKeyData generates a new KeyData for the given KeyTemplate.
 func (reg *registry) NewKeyData(template *tinkpb.KeyTemplate) (*tinkpb.KeyData, error) {
-  if template == nil {
-    return nil, fmt.Errorf("registry: invalid key template")
-  }
-  manager, err := reg.GetKeyManager(template.TypeUrl)
-  if err != nil {
-    return nil, err
-  }
-  return manager.NewKeyData(template.Value)
+	if template == nil {
+		return nil, fmt.Errorf("registry: invalid key template")
+	}
+	manager, err := reg.GetKeyManager(template.TypeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return manager.NewKeyData(template.Value)
 }
 
 // NewKeyFromKeyTemplate generates a new key for the given KeyTemplate.
 func (reg *registry) NewKeyFromKeyTemplate(template *tinkpb.KeyTemplate) (proto.Message, error) {
-  if template == nil {
-    return nil, fmt.Errorf("registry: invalid key template")
-  }
-  manager, err := reg.GetKeyManager(template.TypeUrl)
-  if err != nil {
-    return nil, err
-  }
-  return manager.NewKeyFromSerializedKeyFormat(template.Value)
+	if template == nil {
+		return nil, fmt.Errorf("registry: invalid key template")
+	}
+	manager, err := reg.GetKeyManager(template.TypeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return manager.NewKeyFromSerializedKeyFormat(template.Value)
 }
 
 // NewKeyFromKeyFormat generates a new key for the given KeyFormat using the
 // KeyManager identified by the given typeUrl.
 func (reg *registry) NewKeyFromKeyFormat(typeUrl string,
-                                        format proto.Message) (proto.Message, error) {
-  manager, err := reg.GetKeyManager(typeUrl)
-  if err != nil {
-    return nil, err
-  }
-  return manager.NewKeyFromKeyFormat(format)
+	format proto.Message) (proto.Message, error) {
+	manager, err := reg.GetKeyManager(typeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return manager.NewKeyFromKeyFormat(format)
 }
 
 // GetPrimitiveFromKey creates a new primitive for the given key using the KeyManager
 // identified by the given typeUrl.
 func (reg *registry) GetPrimitiveFromKey(typeUrl string,
-                                        key proto.Message) (interface{}, error) {
-  manager, err := reg.GetKeyManager(typeUrl)
-  if err != nil {
-    return nil, err
-  }
-  return manager.GetPrimitiveFromKey(key);
+	key proto.Message) (interface{}, error) {
+	manager, err := reg.GetKeyManager(typeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return manager.GetPrimitiveFromKey(key)
 }
 
 // GetPrimitiveFromKeyData creates a new primitive for the key given in the given KeyData.
 func (reg *registry) GetPrimitiveFromKeyData(keyData *tinkpb.KeyData) (interface{}, error) {
-  if keyData == nil {
-    return nil, fmt.Errorf("registry: invalid key data")
-  }
-  return reg.GetPrimitiveFromSerializedKey(keyData.TypeUrl, keyData.Value)
+	if keyData == nil {
+		return nil, fmt.Errorf("registry: invalid key data")
+	}
+	return reg.GetPrimitiveFromSerializedKey(keyData.TypeUrl, keyData.Value)
 }
 
 // GetPrimitiveFromSerializedKey creates a new primitive for the given serialized key
 // using the KeyManager identified by the given typeUrl.
 func (reg *registry) GetPrimitiveFromSerializedKey(typeUrl string,
-                                                  serializedKey []byte) (interface{}, error) {
-  if len(serializedKey) == 0 {
-    return nil, fmt.Errorf("registry: invalid serialized key")
-  }
-  manager, err := reg.GetKeyManager(typeUrl)
-  if err != nil {
-    return nil, err
-  }
-  return manager.GetPrimitiveFromSerializedKey(serializedKey);
+	serializedKey []byte) (interface{}, error) {
+	if len(serializedKey) == 0 {
+		return nil, fmt.Errorf("registry: invalid serialized key")
+	}
+	manager, err := reg.GetKeyManager(typeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return manager.GetPrimitiveFromSerializedKey(serializedKey)
 }
 
 // GetPrimitives creates a set of primitives corresponding to the keys with
@@ -195,7 +195,7 @@ func (reg *registry) GetPrimitiveFromSerializedKey(typeUrl string,
 // The returned set is usually later "wrapped" into a class that implements
 // the corresponding Primitive-interface.
 func (reg *registry) GetPrimitives(keysetHandle *KeysetHandle) (*PrimitiveSet, error) {
-  return reg.GetPrimitivesWithCustomManager(keysetHandle, nil)
+	return reg.GetPrimitivesWithCustomManager(keysetHandle, nil)
 }
 
 // GetPrimitivesWithCustomManager creates a set of primitives corresponding to
@@ -211,53 +211,53 @@ func (reg *registry) GetPrimitives(keysetHandle *KeysetHandle) (*PrimitiveSet, e
 // The returned set is usually later "wrapped" into a class that implements
 // the corresponding Primitive-interface.
 func (reg *registry) GetPrimitivesWithCustomManager(
-    keysetHandle *KeysetHandle, customManager KeyManager) (*PrimitiveSet, error) {
-  // TODO(thaidn): check that all keys are of the same primitive
-  if keysetHandle == nil {
-    return nil, fmt.Errorf("registry: invalid keyset handle")
-  }
-  keyset := keysetHandle.Keyset()
-  if err := util.ValidateKeyset(keyset); err != nil {
-    return nil, fmt.Errorf("registry: invalid keyset: %s", err)
-  }
-  primitiveSet := NewPrimitiveSet()
-  for _, key := range keyset.Key {
-    if key.Status != tinkpb.KeyStatusType_ENABLED {
-      continue
-    }
-    var primitive interface{}
-    var err error
-    if customManager != nil && customManager.DoesSupport(key.KeyData.TypeUrl) {
-      primitive, err = customManager.GetPrimitiveFromSerializedKey(key.KeyData.Value)
-    } else {
-      primitive, err = reg.GetPrimitiveFromKeyData(key.KeyData)
-    }
-    if err != nil {
-      return nil, fmt.Errorf("registry: cannot get primitive from key: %s", err)
-    }
-    entry, err := primitiveSet.AddPrimitive(primitive, key)
-    if err != nil {
-      return nil, fmt.Errorf("registry: cannot add primitive: %s", err)
-    }
-    if key.KeyId == keyset.PrimaryKeyId {
-      primitiveSet.SetPrimary(entry)
-    }
-  }
-  return primitiveSet, nil
+	keysetHandle *KeysetHandle, customManager KeyManager) (*PrimitiveSet, error) {
+	// TODO(thaidn): check that all keys are of the same primitive
+	if keysetHandle == nil {
+		return nil, fmt.Errorf("registry: invalid keyset handle")
+	}
+	keyset := keysetHandle.Keyset()
+	if err := util.ValidateKeyset(keyset); err != nil {
+		return nil, fmt.Errorf("registry: invalid keyset: %s", err)
+	}
+	primitiveSet := NewPrimitiveSet()
+	for _, key := range keyset.Key {
+		if key.Status != tinkpb.KeyStatusType_ENABLED {
+			continue
+		}
+		var primitive interface{}
+		var err error
+		if customManager != nil && customManager.DoesSupport(key.KeyData.TypeUrl) {
+			primitive, err = customManager.GetPrimitiveFromSerializedKey(key.KeyData.Value)
+		} else {
+			primitive, err = reg.GetPrimitiveFromKeyData(key.KeyData)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("registry: cannot get primitive from key: %s", err)
+		}
+		entry, err := primitiveSet.AddPrimitive(primitive, key)
+		if err != nil {
+			return nil, fmt.Errorf("registry: cannot add primitive: %s", err)
+		}
+		if key.KeyId == keyset.PrimaryKeyId {
+			primitiveSet.SetPrimary(entry)
+		}
+	}
+	return primitiveSet, nil
 }
 
 // GetPublicKeyData is Convenience method for extracting the public key data
 // from the given serialized private key. It looks up a PrivateKeyManager
 // identified by the given typeUrl, and calls the manager's GetPublicKeyData() method.
 func (reg *registry) GetPublicKeyData(typeUrl string,
-                                    serializedPrivKey []byte) (*tinkpb.KeyData, error) {
-  keyManager, err := reg.GetKeyManager(typeUrl)
-  if err != nil {
-    return nil, err
-  }
-  privateKeyManager, ok := keyManager.(PrivateKeyManager)
-  if !ok {
-    return nil, fmt.Errorf("registry: %s is not belong to a PrivateKeyManager", typeUrl)
-  }
-  return privateKeyManager.GetPublicKeyData(serializedPrivKey)
+	serializedPrivKey []byte) (*tinkpb.KeyData, error) {
+	keyManager, err := reg.GetKeyManager(typeUrl)
+	if err != nil {
+		return nil, err
+	}
+	privateKeyManager, ok := keyManager.(PrivateKeyManager)
+	if !ok {
+		return nil, fmt.Errorf("registry: %s is not belong to a PrivateKeyManager", typeUrl)
+	}
+	return privateKeyManager.GetPublicKeyData(serializedPrivKey)
 }

--- a/go/tink/registry_test.go
+++ b/go/tink/registry_test.go
@@ -16,344 +16,344 @@
 package tink_test
 
 import (
-  "fmt"
-  "sync"
-  "testing"
-  "github.com/google/tink/go/subtle/hmac"
-  "github.com/google/tink/go/subtle/aes"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/golang/protobuf/proto"
-  hmacpb "github.com/google/tink/proto/hmac_go_proto"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
-  commonpb "github.com/google/tink/proto/common_go_proto"
-  gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/subtle/aes"
+	"github.com/google/tink/go/subtle/hmac"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	gcmpb "github.com/google/tink/proto/aes_gcm_go_proto"
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	hmacpb "github.com/google/tink/proto/hmac_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"sync"
+	"testing"
 )
 
 func TestKeyManagerMapBasic(t *testing.T) {
-  kmMap := tink.NewKeyManagerMap()
-  // try to put a HmacKeyManager
-  hmacManager := mac.NewHmacKeyManager()
-  typeUrl := mac.HMAC_TYPE_URL
-  kmMap.Put(typeUrl, hmacManager)
-  tmp, existed := kmMap.Get(typeUrl)
-  if !existed {
-    t.Errorf("a HmacKeyManager should be found")
-  }
-  var _ = tmp.(*mac.HmacKeyManager)
-  // Get type url that doesn't exist
-  if _, existed := kmMap.Get("some url"); existed == true {
-    t.Errorf("unknown typeUrl shouldn't exist in the map")
-  }
+	kmMap := tink.NewKeyManagerMap()
+	// try to put a HmacKeyManager
+	hmacManager := mac.NewHmacKeyManager()
+	typeUrl := mac.HMAC_TYPE_URL
+	kmMap.Put(typeUrl, hmacManager)
+	tmp, existed := kmMap.Get(typeUrl)
+	if !existed {
+		t.Errorf("a HmacKeyManager should be found")
+	}
+	var _ = tmp.(*mac.HmacKeyManager)
+	// Get type url that doesn't exist
+	if _, existed := kmMap.Get("some url"); existed == true {
+		t.Errorf("unknown typeUrl shouldn't exist in the map")
+	}
 }
 
 func TestKeyManagerMapConcurrency(t *testing.T) {
-  kmMap := tink.NewKeyManagerMap()
-  n := 100
-  urlPrefix := "typeUrl#"
-  // put
-  var wg sync.WaitGroup
-  wg.Add(n)
-  for i := 0; i < n; i++ {
-    go func(i int) {
-      defer wg.Done()
-      hmacManager := mac.NewHmacKeyManager()
-      kmMap.Put(fmt.Sprintf("%s%d", urlPrefix, i), hmacManager)
-    }(i)
-  }
-  wg.Wait()
-  // get
-  wg.Add(n)
-  for i := 0; i < n; i++ {
-    go func(i int) {
-      defer wg.Done()
-      km, existed := kmMap.Get(fmt.Sprintf("%s%d", urlPrefix, i))
-      var _ = km.(*mac.HmacKeyManager)
-      if !existed {
-        t.Errorf("key manager %d is missing", i)
-      }
-    }(i)
-  }
-  wg.Wait()
+	kmMap := tink.NewKeyManagerMap()
+	n := 100
+	urlPrefix := "typeUrl#"
+	// put
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			hmacManager := mac.NewHmacKeyManager()
+			kmMap.Put(fmt.Sprintf("%s%d", urlPrefix, i), hmacManager)
+		}(i)
+	}
+	wg.Wait()
+	// get
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			km, existed := kmMap.Get(fmt.Sprintf("%s%d", urlPrefix, i))
+			var _ = km.(*mac.HmacKeyManager)
+			if !existed {
+				t.Errorf("key manager %d is missing", i)
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func setupRegistryTests() {
-  _, err := mac.Config().RegisterStandardKeyTypes()
-  if err != nil {
-    panic("cannot register Mac key types")
-  }
-  _, err = aead.Config().RegisterStandardKeyTypes()
-  if err != nil {
-    panic("cannot register Aead key types")
-  }
+	_, err := mac.Config().RegisterStandardKeyTypes()
+	if err != nil {
+		panic("cannot register Mac key types")
+	}
+	_, err = aead.Config().RegisterStandardKeyTypes()
+	if err != nil {
+		panic("cannot register Aead key types")
+	}
 }
 
 func TestKeyManagerRegistration(t *testing.T) {
-  var km tink.KeyManager
-  var err error
-  // register mac and aead types.
-  setupRegistryTests()
-  // get HmacKeyManager
-  km, err = tink.Registry().GetKeyManager(mac.HMAC_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *mac.HmacKeyManager = km.(*mac.HmacKeyManager)
-  // get AesGcmKeyManager
-  km, err = tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *aead.AesGcmKeyManager = km.(*aead.AesGcmKeyManager)
-  // some random typeurl
-  if _, err = tink.Registry().GetKeyManager("some url"); err == nil {
-    t.Errorf("expect an error when a type url doesn't exist in the registry")
-  }
+	var km tink.KeyManager
+	var err error
+	// register mac and aead types.
+	setupRegistryTests()
+	// get HmacKeyManager
+	km, err = tink.Registry().GetKeyManager(mac.HMAC_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *mac.HmacKeyManager = km.(*mac.HmacKeyManager)
+	// get AesGcmKeyManager
+	km, err = tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *aead.AesGcmKeyManager = km.(*aead.AesGcmKeyManager)
+	// some random typeurl
+	if _, err = tink.Registry().GetKeyManager("some url"); err == nil {
+		t.Errorf("expect an error when a type url doesn't exist in the registry")
+	}
 }
 
 func TestKeyManagerRegistrationWithCollision(t *testing.T) {
-  // register mac and aead types.
-  setupRegistryTests()
-  // dummyKeyManager's typeUrl is equal to that of AesGcm
-  var dummyKeyManager tink.KeyManager = new(testutil.DummyAeadKeyManager)
-  // this should not overwrite the existing manager.
-  ok, err := tink.Registry().RegisterKeyManager(dummyKeyManager)
-  if ok == true || err != nil {
-    t.Errorf("AES_GCM_TYPE_URL shouldn't be registered again")
-  }
-  km, err := tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *aead.AesGcmKeyManager = km.(*aead.AesGcmKeyManager)
+	// register mac and aead types.
+	setupRegistryTests()
+	// dummyKeyManager's typeUrl is equal to that of AesGcm
+	var dummyKeyManager tink.KeyManager = new(testutil.DummyAeadKeyManager)
+	// this should not overwrite the existing manager.
+	ok, err := tink.Registry().RegisterKeyManager(dummyKeyManager)
+	if ok == true || err != nil {
+		t.Errorf("AES_GCM_TYPE_URL shouldn't be registered again")
+	}
+	km, err := tink.Registry().GetKeyManager(aead.AES_GCM_TYPE_URL)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *aead.AesGcmKeyManager = km.(*aead.AesGcmKeyManager)
 }
 
 func TestNewKeyData(t *testing.T) {
-  setupRegistryTests()
-  // new Keydata from a Hmac KeyTemplate
-  keyData, err := tink.Registry().NewKeyData(mac.HmacSha256Tag128KeyTemplate())
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  if keyData.TypeUrl != mac.HMAC_TYPE_URL {
-    t.Errorf("invalid key data")
-  }
-  key := new(hmacpb.HmacKey)
-  if err := proto.Unmarshal(keyData.Value, key); err != nil {
-    t.Errorf("unexpected error when unmarshal HmacKey: %s", err)
-  }
-  // nil
-  if _, err := tink.Registry().NewKeyData(nil); err == nil {
-    t.Errorf("expect an error when key template is nil")
-  }
-  // unregistered type url
-  template := &tinkpb.KeyTemplate{TypeUrl: "some url", Value: []byte{0}}
-  if _, err := tink.Registry().NewKeyData(template); err == nil {
-    t.Errorf("expect an error when key template contains unregistered typeUrl")
-  }
+	setupRegistryTests()
+	// new Keydata from a Hmac KeyTemplate
+	keyData, err := tink.Registry().NewKeyData(mac.HmacSha256Tag128KeyTemplate())
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if keyData.TypeUrl != mac.HMAC_TYPE_URL {
+		t.Errorf("invalid key data")
+	}
+	key := new(hmacpb.HmacKey)
+	if err := proto.Unmarshal(keyData.Value, key); err != nil {
+		t.Errorf("unexpected error when unmarshal HmacKey: %s", err)
+	}
+	// nil
+	if _, err := tink.Registry().NewKeyData(nil); err == nil {
+		t.Errorf("expect an error when key template is nil")
+	}
+	// unregistered type url
+	template := &tinkpb.KeyTemplate{TypeUrl: "some url", Value: []byte{0}}
+	if _, err := tink.Registry().NewKeyData(template); err == nil {
+		t.Errorf("expect an error when key template contains unregistered typeUrl")
+	}
 }
 
 func TestNewKeyFromKeyTemplate(t *testing.T) {
-  setupRegistryTests()
-  // aead template
-  aesGcmTemplate := aead.Aes128GcmKeyTemplate()
-  key, err := tink.Registry().NewKeyFromKeyTemplate(aesGcmTemplate)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var aesGcmKey *gcmpb.AesGcmKey = key.(*gcmpb.AesGcmKey)
-  aesGcmFormat := new(gcmpb.AesGcmKeyFormat)
-  if err := proto.Unmarshal(aesGcmTemplate.Value, aesGcmFormat); err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  if aesGcmFormat.KeySize != uint32(len(aesGcmKey.KeyValue)) {
-    t.Errorf("key doesn't match template")
-  }
-  //nil
-  if _, err := tink.Registry().NewKeyFromKeyTemplate(nil); err == nil {
-    t.Errorf("expect an error when key template is nil")
-  }
-  // unregistered type url
-  template := &tinkpb.KeyTemplate{TypeUrl: "some url", Value: []byte{0}}
-  if _, err := tink.Registry().NewKeyFromKeyTemplate(template); err == nil {
-    t.Errorf("expect an error when key template is not registered")
-  }
+	setupRegistryTests()
+	// aead template
+	aesGcmTemplate := aead.Aes128GcmKeyTemplate()
+	key, err := tink.Registry().NewKeyFromKeyTemplate(aesGcmTemplate)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var aesGcmKey *gcmpb.AesGcmKey = key.(*gcmpb.AesGcmKey)
+	aesGcmFormat := new(gcmpb.AesGcmKeyFormat)
+	if err := proto.Unmarshal(aesGcmTemplate.Value, aesGcmFormat); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if aesGcmFormat.KeySize != uint32(len(aesGcmKey.KeyValue)) {
+		t.Errorf("key doesn't match template")
+	}
+	//nil
+	if _, err := tink.Registry().NewKeyFromKeyTemplate(nil); err == nil {
+		t.Errorf("expect an error when key template is nil")
+	}
+	// unregistered type url
+	template := &tinkpb.KeyTemplate{TypeUrl: "some url", Value: []byte{0}}
+	if _, err := tink.Registry().NewKeyFromKeyTemplate(template); err == nil {
+		t.Errorf("expect an error when key template is not registered")
+	}
 }
 
 func TestNewKeyFromKeyFormat(t *testing.T) {
-  setupRegistryTests()
-  // use aes-gcm key format
-  format := util.NewAesGcmKeyFormat(16)
-  key, err := tink.Registry().NewKeyFromKeyFormat(aead.AES_GCM_TYPE_URL, format)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var aesGcmKey *gcmpb.AesGcmKey = key.(*gcmpb.AesGcmKey)
-  if uint32(len(aesGcmKey.KeyValue)) != format.KeySize {
-    t.Errorf("key doesn't match format")
-  }
-  // unregistered url
-  if _, err := tink.Registry().NewKeyFromKeyFormat("some url", format); err == nil {
-    t.Errorf("expect an error when typeUrl has not been registered")
-  }
-  // unmatched url
-  if _, err := tink.Registry().NewKeyFromKeyFormat(mac.HMAC_TYPE_URL, format); err == nil {
-    t.Errorf("expect an error when typeUrl doesn't match format")
-  }
-  // nil format
-  if _, err := tink.Registry().NewKeyFromKeyFormat(mac.HMAC_TYPE_URL, nil); err == nil {
-    t.Errorf("expect an error when format is nil")
-  }
+	setupRegistryTests()
+	// use aes-gcm key format
+	format := util.NewAesGcmKeyFormat(16)
+	key, err := tink.Registry().NewKeyFromKeyFormat(aead.AES_GCM_TYPE_URL, format)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var aesGcmKey *gcmpb.AesGcmKey = key.(*gcmpb.AesGcmKey)
+	if uint32(len(aesGcmKey.KeyValue)) != format.KeySize {
+		t.Errorf("key doesn't match format")
+	}
+	// unregistered url
+	if _, err := tink.Registry().NewKeyFromKeyFormat("some url", format); err == nil {
+		t.Errorf("expect an error when typeUrl has not been registered")
+	}
+	// unmatched url
+	if _, err := tink.Registry().NewKeyFromKeyFormat(mac.HMAC_TYPE_URL, format); err == nil {
+		t.Errorf("expect an error when typeUrl doesn't match format")
+	}
+	// nil format
+	if _, err := tink.Registry().NewKeyFromKeyFormat(mac.HMAC_TYPE_URL, nil); err == nil {
+		t.Errorf("expect an error when format is nil")
+	}
 }
 
 func TestGetPrimitiveFromKey(t *testing.T) {
-  setupRegistryTests()
-  // hmac key
-  key := testutil.NewHmacKey(commonpb.HashType_SHA256, 16)
-  p, err := tink.Registry().GetPrimitiveFromKey(mac.HMAC_TYPE_URL, key)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *hmac.Hmac = p.(*hmac.Hmac)
-  // unregistered url
-  if _, err := tink.Registry().GetPrimitiveFromKey("some url", key); err == nil {
-    t.Errorf("expect an error when typeUrl has not been registered")
-  }
-  // unmatched url
-  if _, err := tink.Registry().GetPrimitiveFromKey(aead.AES_GCM_TYPE_URL, key); err == nil {
-    t.Errorf("expect an error when typeUrl doesn't match key")
-  }
-  // nil key
-  if _, err := tink.Registry().GetPrimitiveFromKey(aead.AES_GCM_TYPE_URL, nil); err == nil {
-    t.Errorf("expect an error when key is nil")
-  }
+	setupRegistryTests()
+	// hmac key
+	key := testutil.NewHmacKey(commonpb.HashType_SHA256, 16)
+	p, err := tink.Registry().GetPrimitiveFromKey(mac.HMAC_TYPE_URL, key)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *hmac.Hmac = p.(*hmac.Hmac)
+	// unregistered url
+	if _, err := tink.Registry().GetPrimitiveFromKey("some url", key); err == nil {
+		t.Errorf("expect an error when typeUrl has not been registered")
+	}
+	// unmatched url
+	if _, err := tink.Registry().GetPrimitiveFromKey(aead.AES_GCM_TYPE_URL, key); err == nil {
+		t.Errorf("expect an error when typeUrl doesn't match key")
+	}
+	// nil key
+	if _, err := tink.Registry().GetPrimitiveFromKey(aead.AES_GCM_TYPE_URL, nil); err == nil {
+		t.Errorf("expect an error when key is nil")
+	}
 }
 
 func TestGetPrimitiveFromKeyData(t *testing.T) {
-  setupRegistryTests()
-  // hmac keydata
-  keyData := testutil.NewHmacKeyData(commonpb.HashType_SHA256, 16)
-  p, err := tink.Registry().GetPrimitiveFromKeyData(keyData)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *hmac.Hmac = p.(*hmac.Hmac)
-  // unregistered url
-  keyData.TypeUrl = "some url"
-  if _, err := tink.Registry().GetPrimitiveFromKeyData(keyData); err == nil {
-    t.Errorf("expect an error when typeUrl has not been registered")
-  }
-  // unmatched url
-  keyData.TypeUrl = aead.AES_GCM_TYPE_URL
-  if _, err := tink.Registry().GetPrimitiveFromKeyData(keyData); err == nil {
-    t.Errorf("expect an error when typeUrl doesn't match key")
-  }
-  // nil
-  if _, err := tink.Registry().GetPrimitiveFromKeyData(nil); err == nil {
-    t.Errorf("expect an error when key data is nil")
-  }
+	setupRegistryTests()
+	// hmac keydata
+	keyData := testutil.NewHmacKeyData(commonpb.HashType_SHA256, 16)
+	p, err := tink.Registry().GetPrimitiveFromKeyData(keyData)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *hmac.Hmac = p.(*hmac.Hmac)
+	// unregistered url
+	keyData.TypeUrl = "some url"
+	if _, err := tink.Registry().GetPrimitiveFromKeyData(keyData); err == nil {
+		t.Errorf("expect an error when typeUrl has not been registered")
+	}
+	// unmatched url
+	keyData.TypeUrl = aead.AES_GCM_TYPE_URL
+	if _, err := tink.Registry().GetPrimitiveFromKeyData(keyData); err == nil {
+		t.Errorf("expect an error when typeUrl doesn't match key")
+	}
+	// nil
+	if _, err := tink.Registry().GetPrimitiveFromKeyData(nil); err == nil {
+		t.Errorf("expect an error when key data is nil")
+	}
 }
 
 func TestGetPrimitiveFromSerializedKey(t *testing.T) {
-  setupRegistryTests()
-  // hmac key
-  key := testutil.NewHmacKey(commonpb.HashType_SHA256, 16)
-  serializedKey, _ := proto.Marshal(key)
-  p, err := tink.Registry().GetPrimitiveFromSerializedKey(mac.HMAC_TYPE_URL, serializedKey)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *hmac.Hmac = p.(*hmac.Hmac)
-  // unregistered url
-  if _, err := tink.Registry().GetPrimitiveFromSerializedKey("some url", serializedKey); err == nil {
-    t.Errorf("expect an error when typeUrl has not been registered")
-  }
-  // unmatched url
-  if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, serializedKey); err == nil {
-    t.Errorf("expect an error when typeUrl doesn't match key")
-  }
-  // void key
-  if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, nil); err == nil {
-    t.Errorf("expect an error when key is nil")
-  }
-  if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, []byte{}); err == nil {
-    t.Errorf("expect an error when key is nil")
-  }
-  if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, []byte{0}); err == nil {
-    t.Errorf("expect an error when key is nil")
-  }
+	setupRegistryTests()
+	// hmac key
+	key := testutil.NewHmacKey(commonpb.HashType_SHA256, 16)
+	serializedKey, _ := proto.Marshal(key)
+	p, err := tink.Registry().GetPrimitiveFromSerializedKey(mac.HMAC_TYPE_URL, serializedKey)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *hmac.Hmac = p.(*hmac.Hmac)
+	// unregistered url
+	if _, err := tink.Registry().GetPrimitiveFromSerializedKey("some url", serializedKey); err == nil {
+		t.Errorf("expect an error when typeUrl has not been registered")
+	}
+	// unmatched url
+	if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, serializedKey); err == nil {
+		t.Errorf("expect an error when typeUrl doesn't match key")
+	}
+	// void key
+	if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, nil); err == nil {
+		t.Errorf("expect an error when key is nil")
+	}
+	if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, []byte{}); err == nil {
+		t.Errorf("expect an error when key is nil")
+	}
+	if _, err := tink.Registry().GetPrimitiveFromSerializedKey(aead.AES_GCM_TYPE_URL, []byte{0}); err == nil {
+		t.Errorf("expect an error when key is nil")
+	}
 }
 
 func TestGetPrimitives(t *testing.T) {
-  setupRegistryTests()
-  // valid input
-  template1 := aead.Aes128GcmKeyTemplate()
-  template2 := aead.Aes256GcmKeyTemplate()
-  keyData1, _ := tink.Registry().NewKeyData(template1)
-  keyData2, _ := tink.Registry().NewKeyData(template2)
-  keyset := util.NewKeyset(2, []*tinkpb.Keyset_Key{
-    util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
-    util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
-  })
-  handle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  ps, err := tink.Registry().GetPrimitives(handle)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var aesGcm *aes.AesGcm = ps.Primary().Primitive().(*aes.AesGcm)
-  if len(aesGcm.Key) != 32 {
-    t.Errorf("primitive doesn't match input keyset handle")
-  }
-  // custom manager
-  customManager := new(testutil.DummyAeadKeyManager)
-  ps, err = tink.Registry().GetPrimitivesWithCustomManager(handle, customManager)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  var _ *testutil.DummyAead = ps.Primary().Primitive().(*testutil.DummyAead)
-  // keysethandle is nil
-  if _, err := tink.Registry().GetPrimitives(nil); err == nil {
-    t.Errorf("expect an error when keysethandle is nil")
-  }
-  // keyset is empty
-  keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{})
-  handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
-   if _, err := tink.Registry().GetPrimitives(handle); err == nil {
-    t.Errorf("expect an error when keyset is empty")
-  }
-  keyset = util.NewKeyset(1, nil)
-  handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  if _, err := tink.Registry().GetPrimitives(handle); err == nil {
-    t.Errorf("expect an error when keyset is empty")
-  }
-  // no primary key
-  keyset = util.NewKeyset(3, []*tinkpb.Keyset_Key{
-    util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
-    util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
-  })
-  handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  if _, err := tink.Registry().GetPrimitives(handle); err == nil {
-    t.Errorf("expect an error when there is no primary key")
-  }
-  // there is primary key but it is disabled
-  keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{
-    util.NewKey(keyData1, tinkpb.KeyStatusType_DISABLED, 1, tinkpb.OutputPrefixType_TINK),
-    util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
-  })
-  handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  if _, err := tink.Registry().GetPrimitives(handle); err == nil {
-    t.Errorf("expect an error when primary key is disabled")
-  }
-  // multiple primary keys
-  keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{
-    util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
-    util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
-  })
-  handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
-  if _, err := tink.Registry().GetPrimitives(handle); err == nil {
-    t.Errorf("expect an error when there are multiple primary keys")
-  }
+	setupRegistryTests()
+	// valid input
+	template1 := aead.Aes128GcmKeyTemplate()
+	template2 := aead.Aes256GcmKeyTemplate()
+	keyData1, _ := tink.Registry().NewKeyData(template1)
+	keyData2, _ := tink.Registry().NewKeyData(template2)
+	keyset := util.NewKeyset(2, []*tinkpb.Keyset_Key{
+		util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
+		util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
+	})
+	handle, _ := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	ps, err := tink.Registry().GetPrimitives(handle)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var aesGcm *aes.AesGcm = ps.Primary().Primitive().(*aes.AesGcm)
+	if len(aesGcm.Key) != 32 {
+		t.Errorf("primitive doesn't match input keyset handle")
+	}
+	// custom manager
+	customManager := new(testutil.DummyAeadKeyManager)
+	ps, err = tink.Registry().GetPrimitivesWithCustomManager(handle, customManager)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	var _ *testutil.DummyAead = ps.Primary().Primitive().(*testutil.DummyAead)
+	// keysethandle is nil
+	if _, err := tink.Registry().GetPrimitives(nil); err == nil {
+		t.Errorf("expect an error when keysethandle is nil")
+	}
+	// keyset is empty
+	keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{})
+	handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	if _, err := tink.Registry().GetPrimitives(handle); err == nil {
+		t.Errorf("expect an error when keyset is empty")
+	}
+	keyset = util.NewKeyset(1, nil)
+	handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	if _, err := tink.Registry().GetPrimitives(handle); err == nil {
+		t.Errorf("expect an error when keyset is empty")
+	}
+	// no primary key
+	keyset = util.NewKeyset(3, []*tinkpb.Keyset_Key{
+		util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
+		util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
+	})
+	handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	if _, err := tink.Registry().GetPrimitives(handle); err == nil {
+		t.Errorf("expect an error when there is no primary key")
+	}
+	// there is primary key but it is disabled
+	keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{
+		util.NewKey(keyData1, tinkpb.KeyStatusType_DISABLED, 1, tinkpb.OutputPrefixType_TINK),
+		util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 2, tinkpb.OutputPrefixType_TINK),
+	})
+	handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	if _, err := tink.Registry().GetPrimitives(handle); err == nil {
+		t.Errorf("expect an error when primary key is disabled")
+	}
+	// multiple primary keys
+	keyset = util.NewKeyset(1, []*tinkpb.Keyset_Key{
+		util.NewKey(keyData1, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
+		util.NewKey(keyData2, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
+	})
+	handle, _ = tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	if _, err := tink.Registry().GetPrimitives(handle); err == nil {
+		t.Errorf("expect an error when there are multiple primary keys")
+	}
 }

--- a/go/util/keyutil.go
+++ b/go/util/keyutil.go
@@ -16,57 +16,57 @@
 package util
 
 import (
-  "fmt"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"fmt"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
 // ValidateVersion checks whether the given version is valid. The version is valid
 // only if it is the range [0..maxExpected]
 func ValidateVersion(version uint32, maxExpected uint32) error {
-  if version > maxExpected {
-    msg := fmt.Sprintf("key has version %v; " +
-        "only keys with version in range [0..%v] are supported",
-        version, maxExpected)
-    return fmt.Errorf("subtle/util: " + msg)
-  }
-  return nil
+	if version > maxExpected {
+		msg := fmt.Sprintf("key has version %v; "+
+			"only keys with version in range [0..%v] are supported",
+			version, maxExpected)
+		return fmt.Errorf("subtle/util: " + msg)
+	}
+	return nil
 }
 
 /**
  * @return a tinkpb.KeysetInfo-proto from a {@code keyset} protobuf.
  */
 func GetKeysetInfo(keyset *tinkpb.Keyset) (*tinkpb.KeysetInfo, error) {
-  if keyset == nil {
-    return nil, fmt.Errorf("key_util: Gettinkpb.KeysetInfo() called with nil")
-  }
-  nKey := len(keyset.Key)
-  keyInfos := make([]*tinkpb.KeysetInfo_KeyInfo, nKey)
-  for i, key := range keyset.Key {
-    info, err := GetKeyInfo(key)
-    if err != nil {
-      return nil, err
-    }
-    keyInfos[i] = info
-  }
-  return &tinkpb.KeysetInfo{
-    PrimaryKeyId: keyset.PrimaryKeyId,
-    KeyInfo: keyInfos,
-  }, nil
+	if keyset == nil {
+		return nil, fmt.Errorf("key_util: Gettinkpb.KeysetInfo() called with nil")
+	}
+	nKey := len(keyset.Key)
+	keyInfos := make([]*tinkpb.KeysetInfo_KeyInfo, nKey)
+	for i, key := range keyset.Key {
+		info, err := GetKeyInfo(key)
+		if err != nil {
+			return nil, err
+		}
+		keyInfos[i] = info
+	}
+	return &tinkpb.KeysetInfo{
+		PrimaryKeyId: keyset.PrimaryKeyId,
+		KeyInfo:      keyInfos,
+	}, nil
 }
 
 /**
  * @return a KeyInfo-proto from a {@code key} protobuf.
  */
 func GetKeyInfo(key *tinkpb.Keyset_Key) (*tinkpb.KeysetInfo_KeyInfo, error) {
-  if key == nil {
-    return nil, fmt.Errorf("keyutil: GetKeyInfo() called with nil")
-  }
-  return &tinkpb.KeysetInfo_KeyInfo{
-    TypeUrl: key.KeyData.TypeUrl,
-    Status: key.Status,
-    KeyId: key.KeyId,
-    OutputPrefixType: key.OutputPrefixType,
-  }, nil
+	if key == nil {
+		return nil, fmt.Errorf("keyutil: GetKeyInfo() called with nil")
+	}
+	return &tinkpb.KeysetInfo_KeyInfo{
+		TypeUrl:          key.KeyData.TypeUrl,
+		Status:           key.Status,
+		KeyId:            key.KeyId,
+		OutputPrefixType: key.OutputPrefixType,
+	}, nil
 }
 
 /**
@@ -75,29 +75,29 @@ func GetKeyInfo(key *tinkpb.Keyset_Key) (*tinkpb.KeysetInfo_KeyInfo, error) {
  */
 // TODO(thaidn): use TypeLiteral to ensure that all keys are of the same primitive.
 func ValidateKeyset(keyset *tinkpb.Keyset) error {
-  if keyset == nil {
-    return fmt.Errorf("keyutil: ValidateKeyset() called with nil")
-  }
-  if len(keyset.Key) == 0 {
-    return fmt.Errorf("keyutil: empty keyset")
-  }
-  primaryKeyId := keyset.PrimaryKeyId
-  hasPrimaryKey := false
-  for _, key := range keyset.Key {
-    if err := ValidateKey(key); err != nil {
-      return err
-    }
-    if key.Status == tinkpb.KeyStatusType_ENABLED && key.KeyId == primaryKeyId {
-      if hasPrimaryKey {
-        return fmt.Errorf("keyutil: keyset contains multiple primary keys")
-      }
-      hasPrimaryKey = true
-    }
-  }
-  if !hasPrimaryKey {
-    return fmt.Errorf("keyutil: keyset does not contain a valid primary key")
-  }
-  return nil
+	if keyset == nil {
+		return fmt.Errorf("keyutil: ValidateKeyset() called with nil")
+	}
+	if len(keyset.Key) == 0 {
+		return fmt.Errorf("keyutil: empty keyset")
+	}
+	primaryKeyId := keyset.PrimaryKeyId
+	hasPrimaryKey := false
+	for _, key := range keyset.Key {
+		if err := ValidateKey(key); err != nil {
+			return err
+		}
+		if key.Status == tinkpb.KeyStatusType_ENABLED && key.KeyId == primaryKeyId {
+			if hasPrimaryKey {
+				return fmt.Errorf("keyutil: keyset contains multiple primary keys")
+			}
+			hasPrimaryKey = true
+		}
+	}
+	if !hasPrimaryKey {
+		return fmt.Errorf("keyutil: keyset does not contain a valid primary key")
+	}
+	return nil
 }
 
 /**
@@ -105,25 +105,25 @@ func ValidateKeyset(keyset *tinkpb.Keyset) error {
  * Returns nil if it is valid; an error otherwise
  */
 func ValidateKey(key *tinkpb.Keyset_Key) error {
-  if key == nil {
-    return fmt.Errorf("keyutil: ValidateKey() called with nil")
-  }
-  if key.KeyId <= 0 {
-    return fmt.Errorf("keyutil: key has non-positive key id: %d", key.KeyId)
-  }
-  if key.KeyData == nil {
-    return fmt.Errorf("keyutil: key %d has no key data", key.KeyId)
-  }
-  if key.OutputPrefixType != tinkpb.OutputPrefixType_TINK &&
-      key.OutputPrefixType != tinkpb.OutputPrefixType_LEGACY &&
-      key.OutputPrefixType != tinkpb.OutputPrefixType_RAW &&
-      key.OutputPrefixType != tinkpb.OutputPrefixType_CRUNCHY {
-    return fmt.Errorf("keyutil: key %d has unknown prefix", key.KeyId)
-  }
-  if key.Status != tinkpb.KeyStatusType_ENABLED &&
-      key.Status != tinkpb.KeyStatusType_DISABLED &&
-      key.Status != tinkpb.KeyStatusType_DESTROYED {
-    return fmt.Errorf("keyutil: key %d has unknown status", key.KeyId)
-  }
-  return nil
+	if key == nil {
+		return fmt.Errorf("keyutil: ValidateKey() called with nil")
+	}
+	if key.KeyId <= 0 {
+		return fmt.Errorf("keyutil: key has non-positive key id: %d", key.KeyId)
+	}
+	if key.KeyData == nil {
+		return fmt.Errorf("keyutil: key %d has no key data", key.KeyId)
+	}
+	if key.OutputPrefixType != tinkpb.OutputPrefixType_TINK &&
+		key.OutputPrefixType != tinkpb.OutputPrefixType_LEGACY &&
+		key.OutputPrefixType != tinkpb.OutputPrefixType_RAW &&
+		key.OutputPrefixType != tinkpb.OutputPrefixType_CRUNCHY {
+		return fmt.Errorf("keyutil: key %d has unknown prefix", key.KeyId)
+	}
+	if key.Status != tinkpb.KeyStatusType_ENABLED &&
+		key.Status != tinkpb.KeyStatusType_DISABLED &&
+		key.Status != tinkpb.KeyStatusType_DESTROYED {
+		return fmt.Errorf("keyutil: key %d has unknown status", key.KeyId)
+	}
+	return nil
 }

--- a/go/util/keyutil_test.go
+++ b/go/util/keyutil_test.go
@@ -16,127 +16,127 @@
 package util_test
 
 import (
-  "testing"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/util/testutil"
-  tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"github.com/google/tink/go/util/testutil"
+	"github.com/google/tink/go/util/util"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	"testing"
 )
 
 func TestValidateVersion(t *testing.T) {
-  if util.ValidateVersion(2, 1) == nil ||
-      util.ValidateVersion(1, 1) != nil ||
-      util.ValidateVersion(1, 2) != nil {
-    t.Errorf("incorrect version validation")
-  }
+	if util.ValidateVersion(2, 1) == nil ||
+		util.ValidateVersion(1, 1) != nil ||
+		util.ValidateVersion(1, 2) != nil {
+		t.Errorf("incorrect version validation")
+	}
 }
 
 func TestGetKeyInfo(t *testing.T) {
-  _ ,err := util.GetKeyInfo(nil)
-  if err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  keyData := util.NewKeyData("some url", []byte{1}, tinkpb.KeyData_SYMMETRIC)
-  key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
-  info, err := util.GetKeyInfo(key)
-  if err != nil {
-    t.Errorf("unexpected error")
-  }
-  if !compareKeyInfo(info, key) {
-    t.Errorf("KeyInfo mismatched")
-  }
+	_, err := util.GetKeyInfo(nil)
+	if err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	keyData := util.NewKeyData("some url", []byte{1}, tinkpb.KeyData_SYMMETRIC)
+	key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
+	info, err := util.GetKeyInfo(key)
+	if err != nil {
+		t.Errorf("unexpected error")
+	}
+	if !compareKeyInfo(info, key) {
+		t.Errorf("KeyInfo mismatched")
+	}
 }
 
 func TestGetKeysetInfo(t *testing.T) {
-  _ ,err := util.GetKeysetInfo(nil)
-  if err == nil {
-    t.Errorf("expect an error when input is nil")
-  }
-  keyData := util.NewKeyData("some url", []byte{1}, tinkpb.KeyData_SYMMETRIC)
-  key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
-  keyset := util.NewKeyset(1, []*tinkpb.Keyset_Key{key})
-  keysetInfo, err := util.GetKeysetInfo(keyset)
-  if keysetInfo.PrimaryKeyId != keyset.PrimaryKeyId {
-    t.Errorf("PrimaryKeyId mismatched")
-  }
-  for i, keyInfo := range keysetInfo.KeyInfo {
-    if !compareKeyInfo(keyInfo, keyset.Key[i]) {
-      t.Errorf("KeyInfo mismatched")
-    }
-  }
+	_, err := util.GetKeysetInfo(nil)
+	if err == nil {
+		t.Errorf("expect an error when input is nil")
+	}
+	keyData := util.NewKeyData("some url", []byte{1}, tinkpb.KeyData_SYMMETRIC)
+	key := util.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK)
+	keyset := util.NewKeyset(1, []*tinkpb.Keyset_Key{key})
+	keysetInfo, err := util.GetKeysetInfo(keyset)
+	if keysetInfo.PrimaryKeyId != keyset.PrimaryKeyId {
+		t.Errorf("PrimaryKeyId mismatched")
+	}
+	for i, keyInfo := range keysetInfo.KeyInfo {
+		if !compareKeyInfo(keyInfo, keyset.Key[i]) {
+			t.Errorf("KeyInfo mismatched")
+		}
+	}
 }
 
 func TestValidateKey(t *testing.T) {
-  invalidKeys := generateInvalidKeys()
-  for i, key := range invalidKeys {
-    if err := util.ValidateKey(key); err == nil {
-      t.Errorf("expect an error for invalid key #%d", i)
-    }
-  }
+	invalidKeys := generateInvalidKeys()
+	for i, key := range invalidKeys {
+		if err := util.ValidateKey(key); err == nil {
+			t.Errorf("expect an error for invalid key #%d", i)
+		}
+	}
 }
 
 func TestValidateKeyset(t *testing.T) {
-  var err error
-  // nil input
-  if err = util.ValidateKeyset(nil); err == nil {
-    t.Errorf("expect an error when keyset is nil")
-  }
-  // empty keyset
-  emptyKeys := make([]*tinkpb.Keyset_Key, 0)
-  if err = util.ValidateKeyset(util.NewKeyset(1, emptyKeys)); err == nil {
-    t.Errorf("expect an error when keyset is empty")
-  }
-  // no primary key
-  var keys []*tinkpb.Keyset_Key
-  keys = []*tinkpb.Keyset_Key{
-    testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
-  }
-  if err = util.ValidateKeyset(util.NewKeyset(2, keys)); err == nil {
-    t.Errorf("expect an error when there is no primary key")
-  }
-  // primary key is disabled
-  keys = []*tinkpb.Keyset_Key{
-    testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
-    testutil.NewDummyKey(2, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_LEGACY),
-  }
-  if err = util.ValidateKeyset(util.NewKeyset(2, keys)); err == nil {
-    t.Errorf("expect an error when primary key is disabled")
-  }
-  // multiple primary keys
-  keys = []*tinkpb.Keyset_Key{
-    testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
-    testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_LEGACY),
-  }
-  if err = util.ValidateKeyset(util.NewKeyset(1, keys)); err == nil {
-    t.Errorf("expect an error when there are multiple primary keys")
-  }
-  // invalid keys
-  invalidKeys := generateInvalidKeys()
-  for i, key := range invalidKeys {
-    err = util.ValidateKeyset(util.NewKeyset(1, []*tinkpb.Keyset_Key{key}))
-    if err == nil {
-      t.Errorf("expect an error when validate invalid key %d", i)
-    }
-  }
+	var err error
+	// nil input
+	if err = util.ValidateKeyset(nil); err == nil {
+		t.Errorf("expect an error when keyset is nil")
+	}
+	// empty keyset
+	emptyKeys := make([]*tinkpb.Keyset_Key, 0)
+	if err = util.ValidateKeyset(util.NewKeyset(1, emptyKeys)); err == nil {
+		t.Errorf("expect an error when keyset is empty")
+	}
+	// no primary key
+	var keys []*tinkpb.Keyset_Key
+	keys = []*tinkpb.Keyset_Key{
+		testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
+	}
+	if err = util.ValidateKeyset(util.NewKeyset(2, keys)); err == nil {
+		t.Errorf("expect an error when there is no primary key")
+	}
+	// primary key is disabled
+	keys = []*tinkpb.Keyset_Key{
+		testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
+		testutil.NewDummyKey(2, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_LEGACY),
+	}
+	if err = util.ValidateKeyset(util.NewKeyset(2, keys)); err == nil {
+		t.Errorf("expect an error when primary key is disabled")
+	}
+	// multiple primary keys
+	keys = []*tinkpb.Keyset_Key{
+		testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_TINK),
+		testutil.NewDummyKey(1, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_LEGACY),
+	}
+	if err = util.ValidateKeyset(util.NewKeyset(1, keys)); err == nil {
+		t.Errorf("expect an error when there are multiple primary keys")
+	}
+	// invalid keys
+	invalidKeys := generateInvalidKeys()
+	for i, key := range invalidKeys {
+		err = util.ValidateKeyset(util.NewKeyset(1, []*tinkpb.Keyset_Key{key}))
+		if err == nil {
+			t.Errorf("expect an error when validate invalid key %d", i)
+		}
+	}
 }
 
-func generateInvalidKeys() []*tinkpb.Keyset_Key{
-  return []*tinkpb.Keyset_Key{
-    nil,
-    // nil KeyData
-    util.NewKey(nil, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
-    // unknown status
-    util.NewKey(new(tinkpb.KeyData), tinkpb.KeyStatusType_UNKNOWN_STATUS, 1, tinkpb.OutputPrefixType_TINK),
-    // unknown prefix
-    util.NewKey(new(tinkpb.KeyData), tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_UNKNOWN_PREFIX),
-  }
+func generateInvalidKeys() []*tinkpb.Keyset_Key {
+	return []*tinkpb.Keyset_Key{
+		nil,
+		// nil KeyData
+		util.NewKey(nil, tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_TINK),
+		// unknown status
+		util.NewKey(new(tinkpb.KeyData), tinkpb.KeyStatusType_UNKNOWN_STATUS, 1, tinkpb.OutputPrefixType_TINK),
+		// unknown prefix
+		util.NewKey(new(tinkpb.KeyData), tinkpb.KeyStatusType_ENABLED, 1, tinkpb.OutputPrefixType_UNKNOWN_PREFIX),
+	}
 }
 
-func compareKeyInfo(info *tinkpb.KeysetInfo_KeyInfo, key *tinkpb.Keyset_Key) bool{
-  if info.TypeUrl != key.KeyData.TypeUrl ||
-      info.Status != key.Status ||
-      info.KeyId != key.KeyId ||
-      info.OutputPrefixType != key.OutputPrefixType {
-    return false
-  }
-  return true
+func compareKeyInfo(info *tinkpb.KeysetInfo_KeyInfo, key *tinkpb.Keyset_Key) bool {
+	if info.TypeUrl != key.KeyData.TypeUrl ||
+		info.Status != key.Status ||
+		info.KeyId != key.KeyId ||
+		info.OutputPrefixType != key.OutputPrefixType {
+		return false
+	}
+	return true
 }

--- a/go/util/protoutil.go
+++ b/go/util/protoutil.go
@@ -16,145 +16,145 @@
 package util
 
 import (
-  . "github.com/google/tink/proto/tink_go_proto"
-  . "github.com/google/tink/proto/hmac_go_proto"
-  . "github.com/google/tink/proto/common_go_proto"
-  . "github.com/google/tink/proto/aes_gcm_go_proto"
-  . "github.com/google/tink/proto/ecdsa_go_proto"
+	. "github.com/google/tink/proto/aes_gcm_go_proto"
+	. "github.com/google/tink/proto/common_go_proto"
+	. "github.com/google/tink/proto/ecdsa_go_proto"
+	. "github.com/google/tink/proto/hmac_go_proto"
+	. "github.com/google/tink/proto/tink_go_proto"
 )
 
 // Utilities for Hmac Protos
 func NewHmacParams(hashType HashType, tagSize uint32) *HmacParams {
-  return &HmacParams{
-    Hash: hashType,
-    TagSize: tagSize,
-  }
+	return &HmacParams{
+		Hash:    hashType,
+		TagSize: tagSize,
+	}
 }
 
 func NewHmacKey(params *HmacParams, version uint32, keyValue []byte) *HmacKey {
-  return &HmacKey{
-    Version: version,
-    Params: params,
-    KeyValue: keyValue,
-  }
+	return &HmacKey{
+		Version:  version,
+		Params:   params,
+		KeyValue: keyValue,
+	}
 }
 
 func NewHmacKeyFormat(params *HmacParams, keySize uint32) *HmacKeyFormat {
-  return &HmacKeyFormat{
-    Params: params,
-    KeySize: keySize,
-  }
+	return &HmacKeyFormat{
+		Params:  params,
+		KeySize: keySize,
+	}
 }
 
 // Utilities for Key Protos
 func NewKeyData(typeUrl string,
-                value []byte,
-                materialType KeyData_KeyMaterialType) *KeyData {
-  return &KeyData{
-    TypeUrl: typeUrl,
-    Value: value,
-    KeyMaterialType: materialType,
-  }
+	value []byte,
+	materialType KeyData_KeyMaterialType) *KeyData {
+	return &KeyData{
+		TypeUrl:         typeUrl,
+		Value:           value,
+		KeyMaterialType: materialType,
+	}
 }
 
 func NewKey(keyData *KeyData,
-            status KeyStatusType,
-            keyId uint32,
-            prefixType OutputPrefixType) *Keyset_Key {
-  return &Keyset_Key{
-    KeyData: keyData,
-    Status: status,
-    KeyId: keyId,
-    OutputPrefixType: prefixType,
-  }
+	status KeyStatusType,
+	keyId uint32,
+	prefixType OutputPrefixType) *Keyset_Key {
+	return &Keyset_Key{
+		KeyData:          keyData,
+		Status:           status,
+		KeyId:            keyId,
+		OutputPrefixType: prefixType,
+	}
 }
 
 func NewKeyset(primaryKeyId uint32,
-                keys []*Keyset_Key) *Keyset {
-  return &Keyset{
-    PrimaryKeyId: primaryKeyId,
-    Key: keys,
-  }
+	keys []*Keyset_Key) *Keyset {
+	return &Keyset{
+		PrimaryKeyId: primaryKeyId,
+		Key:          keys,
+	}
 }
 
 func NewEncryptedKeyset(encryptedKeySet []byte, info *KeysetInfo) *EncryptedKeyset {
-  return &EncryptedKeyset{
-      EncryptedKeyset: encryptedKeySet,
-      KeysetInfo: info,
-  }
+	return &EncryptedKeyset{
+		EncryptedKeyset: encryptedKeySet,
+		KeysetInfo:      info,
+	}
 }
 
 // Utilities for AesGcm protos
 func NewAesGcmKey(version uint32, keyValue []byte) *AesGcmKey {
-  return &AesGcmKey{
-    Version: version,
-    KeyValue: keyValue,
-  }
+	return &AesGcmKey{
+		Version:  version,
+		KeyValue: keyValue,
+	}
 }
 
 func NewAesGcmKeyFormat(keySize uint32) *AesGcmKeyFormat {
-  return &AesGcmKeyFormat{
-    KeySize: keySize,
-  }
+	return &AesGcmKeyFormat{
+		KeySize: keySize,
+	}
 }
 
 // Utilities for Ecdsa protos
 func NewEcdsaPrivateKey(version uint32,
-                        publicKey *EcdsaPublicKey,
-                        keyValue []byte) *EcdsaPrivateKey {
-  return &EcdsaPrivateKey{
-    Version: version,
-    PublicKey: publicKey,
-    KeyValue: keyValue,
-  }
+	publicKey *EcdsaPublicKey,
+	keyValue []byte) *EcdsaPrivateKey {
+	return &EcdsaPrivateKey{
+		Version:   version,
+		PublicKey: publicKey,
+		KeyValue:  keyValue,
+	}
 }
 
 func NewEcdsaPublicKey(version uint32,
-                        params *EcdsaParams,
-                        x []byte, y []byte) *EcdsaPublicKey {
-  return &EcdsaPublicKey{
-    Version: version,
-    Params: params,
-    X: x,
-    Y: y,
-  }
+	params *EcdsaParams,
+	x []byte, y []byte) *EcdsaPublicKey {
+	return &EcdsaPublicKey{
+		Version: version,
+		Params:  params,
+		X:       x,
+		Y:       y,
+	}
 }
 
 func NewEcdsaParams(hashType HashType,
-                    curve EllipticCurveType,
-                    encoding EcdsaSignatureEncoding) *EcdsaParams {
-  return &EcdsaParams{
-    HashType: hashType,
-    Curve: curve,
-    Encoding: encoding,
-  }
+	curve EllipticCurveType,
+	encoding EcdsaSignatureEncoding) *EcdsaParams {
+	return &EcdsaParams{
+		HashType: hashType,
+		Curve:    curve,
+		Encoding: encoding,
+	}
 }
 
 func NewEcdsaKeyFormat(params *EcdsaParams) *EcdsaKeyFormat {
-  return &EcdsaKeyFormat{Params: params}
+	return &EcdsaKeyFormat{Params: params}
 }
 
 // utilities for converting proto types to strings
 func GetHashName(hashType HashType) string {
-  ret, _ := HashType_name[int32(hashType)]
-  return ret
+	ret, _ := HashType_name[int32(hashType)]
+	return ret
 }
 
 func GetCurveName(curve EllipticCurveType) string {
-  ret, _ := EllipticCurveType_name[int32(curve)]
-  return ret
+	ret, _ := EllipticCurveType_name[int32(curve)]
+	return ret
 }
 
 func GetEncodingName(encoding EcdsaSignatureEncoding) string {
-  ret, _ := EcdsaSignatureEncoding_name[int32(encoding)]
-  return ret
+	ret, _ := EcdsaSignatureEncoding_name[int32(encoding)]
+	return ret
 }
 
 // GetEcdsaParamNames returns the string representations of each parameter in
 // the given EcdsaParams
 func GetEcdsaParamNames(params *EcdsaParams) (string, string, string) {
-  hashName := GetHashName(params.HashType)
-  curveName := GetCurveName(params.Curve)
-  encodingName := GetEncodingName(params.Encoding)
-  return hashName, curveName, encodingName
+	hashName := GetHashName(params.HashType)
+	curveName := GetCurveName(params.Curve)
+	encodingName := GetEncodingName(params.Encoding)
+	return hashName, curveName, encodingName
 }

--- a/go/util/testutil/testutil.go
+++ b/go/util/testutil/testutil.go
@@ -16,185 +16,185 @@
 package testutil
 
 import (
-  "fmt"
-  "crypto/ecdsa"
-  "crypto/rand"
-  "github.com/google/tink/go/subtle/random"
-  "github.com/google/tink/go/util/util"
-  "github.com/google/tink/go/subtle/subtleutil"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/mac/mac"
-  "github.com/google/tink/go/aead/aead"
-  "github.com/google/tink/go/signature/signature"
-  "github.com/golang/protobuf/proto"
-  . "github.com/google/tink/proto/tink_go_proto"
-  . "github.com/google/tink/proto/hmac_go_proto"
-  . "github.com/google/tink/proto/common_go_proto"
-  . "github.com/google/tink/proto/aes_gcm_go_proto"
-  . "github.com/google/tink/proto/ecdsa_go_proto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead/aead"
+	"github.com/google/tink/go/mac/mac"
+	"github.com/google/tink/go/signature/signature"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/subtle/subtleutil"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/util"
+	. "github.com/google/tink/proto/aes_gcm_go_proto"
+	. "github.com/google/tink/proto/common_go_proto"
+	. "github.com/google/tink/proto/ecdsa_go_proto"
+	. "github.com/google/tink/proto/hmac_go_proto"
+	. "github.com/google/tink/proto/tink_go_proto"
 )
 
 // DummyAeadKeyManager is a dummy implementation of the KeyManager interface.
 // It returns DummyAead when GetPrimitive() functions are called.
-type DummyAeadKeyManager struct {}
+type DummyAeadKeyManager struct{}
+
 var _ tink.KeyManager = (*DummyAeadKeyManager)(nil)
 
 func (_ *DummyAeadKeyManager) GetPrimitiveFromSerializedKey(serializedKey []byte) (interface{}, error) {
-  return new(DummyAead), nil
+	return new(DummyAead), nil
 }
 func (_ *DummyAeadKeyManager) GetPrimitiveFromKey(m proto.Message) (interface{}, error) {
-  return new(DummyAead), nil
+	return new(DummyAead), nil
 }
 func (_ *DummyAeadKeyManager) NewKeyFromSerializedKeyFormat(serializedKeyFormat []byte) (proto.Message, error) {
-  return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("not implemented")
 }
 func (_ *DummyAeadKeyManager) NewKeyFromKeyFormat(m proto.Message) (proto.Message, error) {
-  return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("not implemented")
 }
 func (_ *DummyAeadKeyManager) NewKeyData(serializedKeyFormat []byte) (*KeyData, error) {
-  return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("not implemented")
 }
 func (_ *DummyAeadKeyManager) DoesSupport(typeUrl string) bool {
-  return typeUrl == aead.AES_GCM_TYPE_URL
+	return typeUrl == aead.AES_GCM_TYPE_URL
 }
 func (_ *DummyAeadKeyManager) GetKeyType() string {
-  return aead.AES_GCM_TYPE_URL
+	return aead.AES_GCM_TYPE_URL
 }
 
-
 // DummyAead is a dummy implementation of Aead interface.
-type DummyAead struct {}
+type DummyAead struct{}
 
 func (_ *DummyAead) Encrypt(plaintext []byte, additionalData []byte) ([]byte, error) {
-  return nil, fmt.Errorf("dummy aead encrypt")
+	return nil, fmt.Errorf("dummy aead encrypt")
 }
 
 func (_ *DummyAead) Decrypt(ciphertext []byte, additionalData []byte) ([]byte, error) {
-  return nil, fmt.Errorf("dummy aead decrypt")
+	return nil, fmt.Errorf("dummy aead decrypt")
 }
 
 // DummyMac is a dummy implementation of Mac interface.
 type DummyMac struct {
-  Name string
+	Name string
 }
 
 func (h *DummyMac) ComputeMac(data []byte) ([]byte, error) {
-  var m []byte
-  m = append(m, data...)
-  m = append(m, h.Name...)
-  return m, nil
+	var m []byte
+	m = append(m, data...)
+	m = append(m, h.Name...)
+	return m, nil
 }
 
 func (h *DummyMac) VerifyMac(mac []byte, data []byte) (bool, error) {
-  return true, nil
+	return true, nil
 }
 
 func NewTestAesGcmKeyset(primaryOutputPrefixType OutputPrefixType) *Keyset {
-  keyData := NewAesGcmKeyData(16)
-  return NewTestKeyset(keyData, primaryOutputPrefixType)
+	keyData := NewAesGcmKeyData(16)
+	return NewTestKeyset(keyData, primaryOutputPrefixType)
 }
 
 func NewTestHmacKeyset(tagSize uint32,
-                      primaryOutputPrefixType OutputPrefixType) *Keyset {
-  keyData := NewHmacKeyData(HashType_SHA256, tagSize)
-  return NewTestKeyset(keyData, primaryOutputPrefixType)
+	primaryOutputPrefixType OutputPrefixType) *Keyset {
+	keyData := NewHmacKeyData(HashType_SHA256, tagSize)
+	return NewTestKeyset(keyData, primaryOutputPrefixType)
 }
 
 func NewTestKeyset(keyData *KeyData,
-                  primaryOutputPrefixType OutputPrefixType) *Keyset {
-  primaryKey := util.NewKey(keyData, KeyStatusType_ENABLED, 42, primaryOutputPrefixType)
-  rawKey := util.NewKey(keyData, KeyStatusType_ENABLED, 43, OutputPrefixType_RAW)
-  legacyKey := util.NewKey(keyData, KeyStatusType_ENABLED, 44, OutputPrefixType_LEGACY)
-  tinkKey := util.NewKey(keyData, KeyStatusType_ENABLED, 45, OutputPrefixType_TINK)
-  crunchyKey := util.NewKey(keyData, KeyStatusType_ENABLED, 46, OutputPrefixType_CRUNCHY)
-  keys := []*Keyset_Key{primaryKey, rawKey, legacyKey, tinkKey, crunchyKey}
-  return util.NewKeyset(primaryKey.KeyId, keys)
+	primaryOutputPrefixType OutputPrefixType) *Keyset {
+	primaryKey := util.NewKey(keyData, KeyStatusType_ENABLED, 42, primaryOutputPrefixType)
+	rawKey := util.NewKey(keyData, KeyStatusType_ENABLED, 43, OutputPrefixType_RAW)
+	legacyKey := util.NewKey(keyData, KeyStatusType_ENABLED, 44, OutputPrefixType_LEGACY)
+	tinkKey := util.NewKey(keyData, KeyStatusType_ENABLED, 45, OutputPrefixType_TINK)
+	crunchyKey := util.NewKey(keyData, KeyStatusType_ENABLED, 46, OutputPrefixType_CRUNCHY)
+	keys := []*Keyset_Key{primaryKey, rawKey, legacyKey, tinkKey, crunchyKey}
+	return util.NewKeyset(primaryKey.KeyId, keys)
 }
 
 func NewDummyKey(keyId int, status KeyStatusType, outputPrefixType OutputPrefixType) *Keyset_Key {
-  return &Keyset_Key{
-    KeyData: new(KeyData),
-    Status: status,
-    KeyId: uint32(keyId),
-    OutputPrefixType: outputPrefixType,
-  }
+	return &Keyset_Key{
+		KeyData:          new(KeyData),
+		Status:           status,
+		KeyId:            uint32(keyId),
+		OutputPrefixType: outputPrefixType,
+	}
 }
 
 func NewEcdsaPrivateKey(hashType HashType, curve EllipticCurveType) *EcdsaPrivateKey {
-  curveName, _ := EllipticCurveType_name[int32(curve)]
-  priv, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curveName), rand.Reader)
-  params := util.NewEcdsaParams(hashType,
-                                curve,
-                                EcdsaSignatureEncoding_DER)
-  publicKey := util.NewEcdsaPublicKey(signature.ECDSA_VERIFY_KEY_VERSION,
-                                      params, priv.X.Bytes(), priv.Y.Bytes())
-  return util.NewEcdsaPrivateKey(signature.ECDSA_SIGN_KEY_VERSION,
-                                publicKey, priv.D.Bytes())
+	curveName, _ := EllipticCurveType_name[int32(curve)]
+	priv, _ := ecdsa.GenerateKey(subtleutil.GetCurve(curveName), rand.Reader)
+	params := util.NewEcdsaParams(hashType,
+		curve,
+		EcdsaSignatureEncoding_DER)
+	publicKey := util.NewEcdsaPublicKey(signature.ECDSA_VERIFY_KEY_VERSION,
+		params, priv.X.Bytes(), priv.Y.Bytes())
+	return util.NewEcdsaPrivateKey(signature.ECDSA_SIGN_KEY_VERSION,
+		publicKey, priv.D.Bytes())
 }
 
 func NewEcdsaPrivateKeyData(hashType HashType, curve EllipticCurveType) *KeyData {
-  key := NewEcdsaPrivateKey(hashType, curve)
-  serializedKey, _ := proto.Marshal(key)
-  return &KeyData{
-    TypeUrl: signature.ECDSA_SIGN_TYPE_URL,
-    Value: serializedKey,
-    KeyMaterialType: KeyData_ASYMMETRIC_PRIVATE,
-  }
+	key := NewEcdsaPrivateKey(hashType, curve)
+	serializedKey, _ := proto.Marshal(key)
+	return &KeyData{
+		TypeUrl:         signature.ECDSA_SIGN_TYPE_URL,
+		Value:           serializedKey,
+		KeyMaterialType: KeyData_ASYMMETRIC_PRIVATE,
+	}
 }
 
 func NewEcdsaPublicKey(hashType HashType, curve EllipticCurveType) *EcdsaPublicKey {
-  return NewEcdsaPrivateKey(hashType, curve).PublicKey
+	return NewEcdsaPrivateKey(hashType, curve).PublicKey
 }
 
 func NewAesGcmKey(keySize uint32) *AesGcmKey {
-  keyValue := random.GetRandomBytes(keySize)
-  return util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, keyValue)
+	keyValue := random.GetRandomBytes(keySize)
+	return util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, keyValue)
 }
 
-func NewAesGcmKeyData(keySize uint32) *KeyData{
-  keyValue := random.GetRandomBytes(keySize)
-  key := util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, keyValue)
-  serializedKey, _ := proto.Marshal(key)
-  return util.NewKeyData(aead.AES_GCM_TYPE_URL, serializedKey, KeyData_SYMMETRIC)
+func NewAesGcmKeyData(keySize uint32) *KeyData {
+	keyValue := random.GetRandomBytes(keySize)
+	key := util.NewAesGcmKey(aead.AES_GCM_KEY_VERSION, keyValue)
+	serializedKey, _ := proto.Marshal(key)
+	return util.NewKeyData(aead.AES_GCM_TYPE_URL, serializedKey, KeyData_SYMMETRIC)
 }
 
 func NewSerializedAesGcmKey(keySize uint32) []byte {
-  key := NewAesGcmKey(keySize)
-  serializedKey, err := proto.Marshal(key)
-  if err != nil {
-    panic(fmt.Sprintf("cannot marshal AesGcmKey: %s", err))
-  }
-  return serializedKey
+	key := NewAesGcmKey(keySize)
+	serializedKey, err := proto.Marshal(key)
+	if err != nil {
+		panic(fmt.Sprintf("cannot marshal AesGcmKey: %s", err))
+	}
+	return serializedKey
 }
 
 func NewHmacKey(hashType HashType, tagSize uint32) *HmacKey {
-  params := util.NewHmacParams(hashType, tagSize)
-  keyValue := random.GetRandomBytes(20)
-  return util.NewHmacKey(params, mac.HMAC_KEY_VERSION, keyValue)
+	params := util.NewHmacParams(hashType, tagSize)
+	keyValue := random.GetRandomBytes(20)
+	return util.NewHmacKey(params, mac.HMAC_KEY_VERSION, keyValue)
 }
 
 func NewHmacKeyFormat(hashType HashType, tagSize uint32) *HmacKeyFormat {
-  params := util.NewHmacParams(hashType, tagSize)
-  keySize := uint32(20)
-  return util.NewHmacKeyFormat(params, keySize)
+	params := util.NewHmacParams(hashType, tagSize)
+	keySize := uint32(20)
+	return util.NewHmacKeyFormat(params, keySize)
 }
 
 func NewHmacKeysetManager() *tink.KeysetManager {
-  macTemplate := mac.HmacSha256Tag128KeyTemplate()
-  manager := tink.NewKeysetManager(macTemplate, nil, nil)
-  err := manager.Rotate()
-  if err != nil {
-    panic(fmt.Sprintf("cannot rotate keyset manager: %s", err))
-  }
-  return manager
+	macTemplate := mac.HmacSha256Tag128KeyTemplate()
+	manager := tink.NewKeysetManager(macTemplate, nil, nil)
+	err := manager.Rotate()
+	if err != nil {
+		panic(fmt.Sprintf("cannot rotate keyset manager: %s", err))
+	}
+	return manager
 }
 
 func NewHmacKeyData(hashType HashType, tagSize uint32) *KeyData {
-  key := NewHmacKey(hashType, tagSize)
-  serializedKey, _ := proto.Marshal(key)
-  return &KeyData{
-    TypeUrl: mac.HMAC_TYPE_URL,
-    Value: serializedKey,
-    KeyMaterialType: KeyData_SYMMETRIC,
-  }
+	key := NewHmacKey(hashType, tagSize)
+	serializedKey, _ := proto.Marshal(key)
+	return &KeyData{
+		TypeUrl:         mac.HMAC_TYPE_URL,
+		Value:           serializedKey,
+		KeyMaterialType: KeyData_SYMMETRIC,
+	}
 }

--- a/go/util/testutil/testutil_test.go
+++ b/go/util/testutil/testutil_test.go
@@ -16,31 +16,31 @@
 package testutil_test
 
 import (
-  "testing"
-  "bytes"
-  "github.com/google/tink/go/tink/tink"
-  "github.com/google/tink/go/util/testutil"
+	"bytes"
+	"github.com/google/tink/go/tink/tink"
+	"github.com/google/tink/go/util/testutil"
+	"testing"
 )
 
 func TestDummyAead(t *testing.T) {
-  // Assert that DummyAead implements the Aead interface.
-  var _ tink.Aead = (*testutil.DummyAead)(nil)
+	// Assert that DummyAead implements the Aead interface.
+	var _ tink.Aead = (*testutil.DummyAead)(nil)
 }
 
 func TestDummyMac(t *testing.T) {
-  // Assert that DummyMac implements the Aead interface.
-  var _ tink.Mac = (*testutil.DummyMac)(nil)
-  // try to compute mac
-  data := []byte{1, 2, 3, 4, 5}
-  dummyMac := &testutil.DummyMac{Name: "Mac12347"}
-  digest, err := dummyMac.ComputeMac(data)
-  if err != nil {
-    t.Errorf("unexpected error: %s", err)
-  }
-  if bytes.Compare(append(data, dummyMac.Name...), digest) != 0 {
-    t.Errorf("incorrect digest")
-  }
-  if valid, err := dummyMac.VerifyMac(nil, nil); valid == false || err != nil {
-    t.Errorf("unexpected result of VerifyMac")
-  }
+	// Assert that DummyMac implements the Aead interface.
+	var _ tink.Mac = (*testutil.DummyMac)(nil)
+	// try to compute mac
+	data := []byte{1, 2, 3, 4, 5}
+	dummyMac := &testutil.DummyMac{Name: "Mac12347"}
+	digest, err := dummyMac.ComputeMac(data)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if bytes.Compare(append(data, dummyMac.Name...), digest) != 0 {
+		t.Errorf("incorrect digest")
+	}
+	if valid, err := dummyMac.VerifyMac(nil, nil); valid == false || err != nil {
+		t.Errorf("unexpected result of VerifyMac")
+	}
 }


### PR DESCRIPTION
Go style strongly recommends that *.go files be formatted with `go fmt`. 

This PR simply runs `go fmt ./go/...` on the go subdirectory. 

One may want to include a presubmit hook that enforces this requirement in the future. 
