### PR TITLE
Hkdf

### DIFF
--- a/go/subtle/kdf/hkdf.go
+++ b/go/subtle/kdf/hkdf.go
@@ -1,0 +1,31 @@
+package kdf
+
+//Package kdf is just a wrapper arround the golang kdf method
+
+import (
+	"hash"
+
+	"github.com/google/tink/go/subtle"
+	"golang.org/x/crypto/hkdf"
+)
+
+//HKDF is shallow wrapper around x/crypto/HKDF
+type HKDF struct {
+}
+
+// GenerateKeyWithHash is just a shallow wrapper around x/crypto/hkdf, takes an actual hash function
+func (h *HKDF) GenerateKeyWithHash(hash func() hash.Hash, secret, salt, info []byte, keySize int) ([]byte, error) {
+	keyReader := hkdf.New(hash, secret, salt, info)
+	key := make([]byte, keySize)
+	_, err := keyReader.Read(key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// GenerateKey is just a shallow wrapper around x/crypto/hkdf, takes the name of a hash function
+func (h *HKDF) GenerateKey(hashName string, secret, salt, info []byte, keySize int) ([]byte, error) {
+	hash := subtle.GetHashFunc(hashName)
+	return h.GenerateKeyWithHash(hash, secret, salt, info, keySize)
+}

--- a/go/subtle/kdf/hkdf.go
+++ b/go/subtle/kdf/hkdf.go
@@ -16,12 +16,7 @@ type HKDF struct {
 // GenerateKeyWithHash is just a shallow wrapper around x/crypto/hkdf, takes an actual hash function
 func (h *HKDF) GenerateKeyWithHash(hash func() hash.Hash, secret, salt, info []byte, keySize int) ([]byte, error) {
 	keyReader := hkdf.New(hash, secret, salt, info)
-	key := make([]byte, keySize)
-	_, err := keyReader.Read(key)
-	if err != nil {
-		return nil, err
-	}
-	return key, nil
+	return generateIV(keySize, keyReader)
 }
 
 // GenerateKey is just a shallow wrapper around x/crypto/hkdf, takes the name of a hash function

--- a/go/subtle/kdf/hkdf_test.go
+++ b/go/subtle/kdf/hkdf_test.go
@@ -1,0 +1,119 @@
+package kdf
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidCodeSize(t *testing.T) {
+	hkdf := HKDF{}
+	_, err := hkdf.GenerateKey("SHA256", []byte{}, []byte{}, []byte{}, 32*256)
+	assert.Error(t, err)
+}
+
+func computeHkdfHex(hashName, ikmHex, saltHex, infoHex string, size int) ([]byte, error) {
+	hkdf := HKDF{}
+	ikm, _ := base64.StdEncoding.DecodeString(ikmHex)
+	salt, _ := base64.StdEncoding.DecodeString(saltHex)
+	info, _ := base64.StdEncoding.DecodeString(infoHex)
+	return hkdf.GenerateKey(hashName, ikm, salt, info, size)
+}
+
+func TestKDF(t *testing.T) {
+	key, err := computeHkdfHex("SHA256",
+		"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+		"000102030405060708090a0b0c",
+		"f0f1f2f3f4f5f6f7f8f9", 42)
+	assert.NoError(t, err)
+	hexKey := base64.StdEncoding.EncodeToString(key)
+	assert.Equal(t, "MDFJg97H91JppleTh7LgEMbsSOdfdudNeZa2NGOwgGVgC2Lhc89nRYoF", hexKey)
+}
+
+//   /**
+//    * Tests the implementation against the test vectors from RFC 5869.
+//    */
+//   @Test
+//   public void testVectors() throws Exception {
+//     // Test case 1
+//     assertEquals(
+//         "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+//         computeHkdfHex("HmacSha256",
+//           "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+//           "000102030405060708090a0b0c",
+//           "f0f1f2f3f4f5f6f7f8f9",
+//           42));
+//
+//     // Test case 2
+//     assertEquals(
+//         "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c"
+//         + "59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71"
+//         + "cc30c58179ec3e87c14c01d5c1f3434f1d87",
+//         computeHkdfHex("HmacSha256",
+//           "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+//           + "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+//           + "404142434445464748494a4b4c4d4e4f",
+//           "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+//           + "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+//           + "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+//           "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+//           + "d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+//           + "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+//           82));
+//
+//     // Test case 3: salt is empty
+//     assertEquals(
+//         "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d"
+//         + "9d201395faa4b61a96c8",
+//         computeHkdfHex("HmacSha256", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "", 42));
+//
+//     // Test Case 4
+//     assertEquals(
+//         "085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896",
+//         computeHkdfHex(
+//             "HmacSha1",
+//             "0b0b0b0b0b0b0b0b0b0b0b",
+//             "000102030405060708090a0b0c",
+//             "f0f1f2f3f4f5f6f7f8f9",
+//             42));
+//
+//     // Test Case 5
+//     assertEquals(
+//         "0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe"
+//         + "8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e"
+//         + "927336d0441f4c4300e2cff0d0900b52d3b4",
+//         computeHkdfHex(
+//             "HmacSha1",
+//             "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+//             + "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+//             + "404142434445464748494a4b4c4d4e4f",
+//             "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+//             + "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+//             + "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+//             "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+//             + "d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+//             + "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+//             82));
+//
+//     // Test Case 6: salt is empty
+//     assertEquals(
+//         "0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0"
+//         + "ea00033de03984d34918",
+//         computeHkdfHex("HmacSha1", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "", 42));
+//
+//     // Test Case 7
+//     assertEquals(
+//         "2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5"
+//         + "673a081d70cce7acfc48",
+//         computeHkdfHex("HmacSha1", "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", "", "", 42));
+//   }
+//   /**
+//    * Test version of Hkdf where all inputs and outputs are hexadecimal.
+//    */
+//   private String computeHkdfHex(String macAlgorithm, String ikmHex, String saltHex, String infoHex,
+//       int size) throws GeneralSecurityException {
+//     return TestUtil.hexEncode(
+//         Hkdf.computeHkdf(macAlgorithm, TestUtil.hexDecode(ikmHex), TestUtil.hexDecode(saltHex),
+//           TestUtil.hexDecode(infoHex), size));
+//   }

--- a/go/subtle/kdf/sp_800.go
+++ b/go/subtle/kdf/sp_800.go
@@ -1,0 +1,58 @@
+package kdf
+
+//Taken from golang ethereum project
+
+import (
+	"fmt"
+	"hash"
+	"math/big"
+)
+
+type SP_800 struct{}
+
+var (
+	big2To32          = new(big.Int).Exp(big.NewInt(2), big.NewInt(32), nil)
+	big2To32M1        = new(big.Int).Sub(big2To32, big.NewInt(1))
+	ErrKeyDataTooLong = fmt.Errorf("can't supply requested key data")
+)
+
+func incCounter(ctr []byte) {
+	if ctr[3]++; ctr[3] != 0 {
+		return
+	} else if ctr[2]++; ctr[2] != 0 {
+		return
+	} else if ctr[1]++; ctr[1] != 0 {
+		return
+	} else if ctr[0]++; ctr[0] != 0 {
+		return
+	}
+	return
+}
+
+// NIST SP 800-56 Concatenation Key Derivation Function (see section 5.8.1).
+func (*SP_800) ConcatKDF(hash hash.Hash, z, s1 []byte, kdLen int) (k []byte, err error) {
+	if s1 == nil {
+		s1 = make([]byte, 0)
+	}
+
+	reps := ((kdLen + 7) * 8) / (hash.BlockSize() * 8)
+	if big.NewInt(int64(reps)).Cmp(big2To32M1) > 0 {
+		fmt.Println(big2To32M1)
+		return nil, ErrKeyDataTooLong
+	}
+
+	counter := []byte{0, 0, 0, 1}
+	k = make([]byte, 0)
+
+	for i := 0; i <= reps; i++ {
+		hash.Write(counter)
+		hash.Write(z)
+		hash.Write(s1)
+		k = append(k, hash.Sum(nil)...)
+		hash.Reset()
+		incCounter(counter)
+	}
+
+	k = k[:kdLen]
+	return
+}

--- a/go/subtle/kdf/util.go
+++ b/go/subtle/kdf/util.go
@@ -1,0 +1,10 @@
+package kdf
+
+// Generate an initialisation vector for CTR mode.
+import "io"
+
+func generateIV(keySize int, rand io.Reader) (iv []byte, err error) {
+	iv = make([]byte, keySize)
+	_, err = io.ReadFull(rand, iv)
+	return
+}


### PR DESCRIPTION
This adds HKDF as kdf, as well as SP_800. hkdf.go is just a wrapper around golang.org/x/crypto/hkdf