### PR TITLE
Added eliptic curve wrappers and functions

### DIFF
--- a/go/subtle/elliptic_curve.go
+++ b/go/subtle/elliptic_curve.go
@@ -1,0 +1,70 @@
+//https://github.com/obscuren/ecies (taken from go-ethereum)
+// See conditions and license on:
+//https://github.com/ethereum/go-ethereum/blob/master/crypto/ecies/ecies.go
+package subtle
+
+import (
+	"crypto/elliptic"
+	"errors"
+	"io"
+	"math/big"
+)
+
+type EllipticPublicKey struct {
+	X, Y  *big.Int
+	Curve elliptic.Curve
+}
+
+type EllipticPrivateKey struct {
+	D *big.Int
+	EllipticPublicKey
+}
+
+// The default curve for this package is the NIST P256 curve, which
+// provides security equivalent to AES-128.
+var DefaultCurve = elliptic.P256()
+
+// Generate an elliptic curve public / private keypair. If params is nil,
+// the recommended default paramters for the key will be chosen.
+func GenerateKey(rand io.Reader, curve elliptic.Curve) (prv *EllipticPrivateKey, err error) {
+	pb, x, y, err := elliptic.GenerateKey(curve, rand)
+	if err != nil {
+		return
+	}
+	prv = new(EllipticPrivateKey)
+	prv.EllipticPublicKey.X = x
+	prv.EllipticPublicKey.Y = y
+	prv.EllipticPublicKey.Curve = curve
+	prv.D = new(big.Int).SetBytes(pb)
+	return
+}
+
+var (
+	ErrBadSharedKeys   = errors.New("Curves do not match")
+	ErrSharedKeyTooBig = errors.New("Requested invalid key size (too big)")
+)
+
+// ECDH key agreement method used to establish secret keys for encryption.
+func (prv *EllipticPrivateKey) GenerateShared(pub *EllipticPublicKey, keyLength int) (sk []byte, err error) {
+	if prv.EllipticPublicKey.Curve != pub.Curve {
+		return nil, ErrBadSharedKeys
+	}
+	if keyLength > MaxSharedKeyLength(pub) {
+		return nil, ErrSharedKeyTooBig
+	}
+	x, _ := pub.Curve.ScalarMult(pub.X, pub.Y, prv.D.Bytes())
+	if x == nil || err != nil {
+		return nil, errors.New("Could not generate shared key")
+	}
+
+	sk = make([]byte, keyLength)
+	skBytes := x.Bytes()
+	copy(sk[len(sk)-len(skBytes):], skBytes)
+	return sk, nil
+}
+
+// MaxSharedKeyLength returns the maximum length of the shared key the
+// public key can produce.
+func MaxSharedKeyLength(pub *EllipticPublicKey) int {
+	return (pub.Curve.Params().BitSize + 7) / 8
+}

--- a/go/subtle/elliptic_curve.go
+++ b/go/subtle/elliptic_curve.go
@@ -4,27 +4,57 @@
 package subtle
 
 import (
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
 	"io"
 	"math/big"
 )
 
+//EllipticPublicKey define curve and point
 type EllipticPublicKey struct {
-	X, Y  *big.Int
 	Curve elliptic.Curve
+	X, Y  *big.Int
 }
 
+//EllipticPrivateKey contains corresponding public key and generator D
 type EllipticPrivateKey struct {
-	D *big.Int
 	EllipticPublicKey
+	D *big.Int
 }
 
-// The default curve for this package is the NIST P256 curve, which
+// ExportECDSA an ECIES public key as an ECDSA public key.
+func (pub *EllipticPublicKey) ExportECDSA() *ecdsa.PublicKey {
+	return &ecdsa.PublicKey{pub.Curve, pub.X, pub.Y}
+}
+
+// ImportECDSAPublic an ECDSA public key as an ECIES public key.
+func ImportECDSAPublic(pub *ecdsa.PublicKey) *EllipticPublicKey {
+	return &EllipticPublicKey{
+		X:     pub.X,
+		Y:     pub.Y,
+		Curve: pub.Curve,
+	}
+}
+
+// ExportECDSA an ECIES private key as an ECDSA private key.
+func (prv *EllipticPrivateKey) ExportECDSA() *ecdsa.PrivateKey {
+	pub := &prv.EllipticPublicKey
+	pubECDSA := pub.ExportECDSA()
+	return &ecdsa.PrivateKey{*pubECDSA, prv.D}
+}
+
+// ImportECDSA an ECDSA private key as an ECIES private key.
+func ImportECDSA(prv *ecdsa.PrivateKey) *EllipticPrivateKey {
+	pub := ImportECDSAPublic(&prv.PublicKey)
+	return &EllipticPrivateKey{*pub, prv.D}
+}
+
+// DefaultCurve for this package is the NIST P256 curve, which
 // provides security equivalent to AES-128.
 var DefaultCurve = elliptic.P256()
 
-// Generate an elliptic curve public / private keypair. If params is nil,
+// GenerateKey returns an elliptic curve public / private keypair. If params is nil,
 // the recommended default paramters for the key will be chosen.
 func GenerateKey(rand io.Reader, curve elliptic.Curve) (prv *EllipticPrivateKey, err error) {
 	pb, x, y, err := elliptic.GenerateKey(curve, rand)
@@ -44,7 +74,7 @@ var (
 	ErrSharedKeyTooBig = errors.New("Requested invalid key size (too big)")
 )
 
-// ECDH key agreement method used to establish secret keys for encryption.
+// GenerateShared is part of ECDH key agreement method used to establish secret keys for encryption.
 func (prv *EllipticPrivateKey) GenerateShared(pub *EllipticPublicKey, keyLength int) (sk []byte, err error) {
 	if prv.EllipticPublicKey.Curve != pub.Curve {
 		return nil, ErrBadSharedKeys

--- a/go/subtle/elliptic_curve_test.go
+++ b/go/subtle/elliptic_curve_test.go
@@ -1,0 +1,71 @@
+package subtle
+
+// Validate the ECDH component.
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+var skLen int
+
+func TestSharedKey(t *testing.T) {
+	prv1, err := GenerateKey(rand.Reader, DefaultCurve)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+	skLen = MaxSharedKeyLength(&prv1.EllipticPublicKey) / 2
+
+	prv2, err := GenerateKey(rand.Reader, DefaultCurve)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+
+	sk1, err := prv1.GenerateShared(&prv2.EllipticPublicKey, skLen+skLen)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+
+	sk2, err := prv2.GenerateShared(&prv1.EllipticPublicKey, skLen+skLen)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+
+	if !bytes.Equal(sk1, sk2) {
+		fmt.Println(ErrBadSharedKeys.Error())
+		t.FailNow()
+	}
+}
+
+// Verify that the key generation code fails when too much key data is
+// requested.
+func TestTooBigSharedKey(t *testing.T) {
+	prv1, err := GenerateKey(rand.Reader, DefaultCurve)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+
+	prv2, err := GenerateKey(rand.Reader, DefaultCurve)
+	if err != nil {
+		fmt.Println(err.Error())
+		t.FailNow()
+	}
+
+	_, err = prv1.GenerateShared(&prv2.EllipticPublicKey, skLen*2+skLen*2)
+	if err != ErrSharedKeyTooBig {
+		fmt.Println("ecdh: shared key should be too large for curve")
+		t.FailNow()
+	}
+
+	_, err = prv2.GenerateShared(&prv1.EllipticPublicKey, skLen*2+skLen*2)
+	if err != ErrSharedKeyTooBig {
+		fmt.Println("ecdh: shared key should be too large for curve")
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
This wraps around the elliptic curves, and explicitly generates a shared key, which is used for ECIES