### PR TITLE
Fixed spelling

### DIFF
--- a/cc/signature/signature_key_templates.h
+++ b/cc/signature/signature_key_templates.h
@@ -39,7 +39,7 @@ class SignatureKeyTemplates {
   // with the following parameters:
   //   - EC curve: NIST P-256
   //   - hash function: SHA256
-  //   - signature endocding: DER
+  //   - signature encoding: DER
   //   - OutputPrefixType: TINK
   static const google::crypto::tink::KeyTemplate& EcdsaP256();
 
@@ -47,7 +47,7 @@ class SignatureKeyTemplates {
   // with the following parameters:
   //   - EC curve: NIST P-384
   //   - hash function: SHA512
-  //   - signature endocding: DER
+  //   - signature encoding: DER
   //   - OutputPrefixType: TINK
   static const google::crypto::tink::KeyTemplate& EcdsaP384();
 
@@ -55,7 +55,7 @@ class SignatureKeyTemplates {
   // with the following parameters:
   //   - EC curve: NIST P-521
   //   - hash function: SHA512
-  //   - signature endocding: DER
+  //   - signature encoding: DER
   //   - OutputPrefixType: TINK
   static const google::crypto::tink::KeyTemplate& EcdsaP521();
 };

--- a/objc/TINKSignatureKeyTemplate.h
+++ b/objc/TINKSignatureKeyTemplate.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, TINKSignatureKeyTemplates) {
    * EcdsaPrivateKey with the following parameters:
    *   - EC curve: NIST P-256
    *   - hash function: SHA256
-   *   - signature endocding: DER
+   *   - signature encoding: DER
    *   - OutputPrefixType: TINK
    */
   TINKEcdsaP256 = 1,
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, TINKSignatureKeyTemplates) {
    * EcdsaPrivateKey with the following parameters:
    *   - EC curve: NIST P-384
    *   - hash function: SHA512
-   *   - signature endocding: DER
+   *   - signature encoding: DER
    *   - OutputPrefixType: TINK
    */
   TINKEcdsaP384 = 2,
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSInteger, TINKSignatureKeyTemplates) {
    * EcdsaPrivateKey with the following parameters:
    *   - EC curve: NIST P-521
    *   - hash function: SHA512
-   *   - signature endocding: DER
+   *   - signature encoding: DER
    *   - OutputPrefixType: TINK
    */
   TINKEcdsaP521 = 3,


### PR DESCRIPTION
Fixed spelling: `endocding` => `encoding`