### PR TITLE
docs(readme): use aead instead of aad

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AEAD primitive in Java:
     Aead aead = AeadFactory.getPrimitive(keysetHandle);
 
     // 3. Use the primitive.
-    byte[] ciphertext = aead.encrypt(plaintext, aad);
+    byte[] ciphertext = aead.encrypt(plaintext, aead);
 ```
 
 ## Current Status


### PR DESCRIPTION
The Java code example has a tiny little typo.