### PR TITLE
Update build path for bazel

### DIFF
--- a/examples/helloworld/java/README.md
+++ b/examples/helloworld/java/README.md
@@ -34,7 +34,7 @@ cat foo2.txt
 ```shell
 git clone https://github.com/google/tink
 cd tink
-bazel build ...
+bazel build //examples/helloworld/java/...
 echo foo > foo.txt
 ./bazel-bin/examples/helloworld/java/helloworld encrypt --keyset test.cfg --in foo.txt --out bar.encrypted
 ./bazel-bin/examples/helloworld/java/helloworld decrypt --keyset test.cfg --in bar.encrypted --out foo2.txt


### PR DESCRIPTION
Updated build command to  build only the java helloworld example, and avoid the androidsdk error.