### PR TITLE
add Travis-CI support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+matrix:
+  include:
+    - language: python
+      python: 3.4      
+
+    - language: android
+      os: linux
+      jdk: oraclejdk8
+      os: osx
+      osx_image: xcode8
+      
+    - language: go
+      go: 1.3
+
+sudo: false      


### PR DESCRIPTION
add support on Travis CI
languages: Java, GO and Python. 

[ref 1](https://docs.travis-ci.com/user/languages/community-supported-languages/)
[ref 2](https://docs.travis-ci.com/user/languages/android/)
