### PR TITLE
go: remove redundant check negative for uint32

### DIFF
--- a/go/tink/util.go
+++ b/go/tink/util.go
@@ -111,8 +111,8 @@ func ValidateKey(key *tinkpb.Keyset_Key) error {
 	if key == nil {
 		return fmt.Errorf("ValidateKey() called with nil")
 	}
-	if key.KeyId <= 0 {
-		return fmt.Errorf("key has non-positive key id: %d", key.KeyId)
+	if key.KeyId == 0 {
+		return fmt.Errorf("key has zero key id: %d", key.KeyId)
 	}
 	if key.KeyData == nil {
 		return fmt.Errorf("key %d has no key data", key.KeyId)


### PR DESCRIPTION
[Keyset_Key.KeyId](https://github.com/google/tink/blob/ce16ca037fe43cee50c65351b60b62170be6a26a/proto/tink_go_proto/tink.pb.go#L336) is an `uint32`, it's never less than 0