### PR TITLE
Bazel Javascript rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -218,6 +218,29 @@ load("@build_stack_rules_proto//cpp:deps.bzl", "cpp_grpc_library")
 cpp_grpc_library()
 
 #-----------------------------------------------------------------------------
+# Javascript
+#-----------------------------------------------------------------------------
+
+http_archive(
+    name = "io_bazel_rules_closure",
+    sha256 = "fecda06179906857ac79af6500124bf03fe1630fd1b3d4dcf6c65346b9c0725d",
+    strip_prefix = "rules_closure-03110588392d8c6c05b99c08a6f1c2121604ca27",
+    urls = [
+        "https://github.com/bazelbuild/rules_closure/archive/03110588392d8c6c05b99c08a6f1c2121604ca27.zip",
+    ],
+)
+
+#local_repository(
+#    name = "io_bazel_rules_closure",
+#    path = "/Users/michael/src/self/rules_closure",
+#)
+
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
+
+closure_repositories()
+
+#-----------------------------------------------------------------------------
 # java
 #-----------------------------------------------------------------------------
 
@@ -385,7 +408,7 @@ java_import_external(
 )
 
 java_import_external(
-    name = "com_google_auto_common",
+    name = "com_google_auto_common_08",
     licenses = ["notice"],  # Apache 2.0
     jar_sha256 = "97db1709f57b91b32edacb596ef4641872f227b7d99ad90e467f0d77f5ba134a",
     jar_urls = [
@@ -404,7 +427,7 @@ java_import_external(
         "https://repo1.maven.org/maven2/com/google/auto/service/auto-service/1.0-rc3/auto-service-1.0-rc3.jar",
     ],
     deps = [
-        "@com_google_auto_common",
+        "@com_google_auto_common_08",
         "@com_google_guava",
     ],
 )
@@ -767,23 +790,3 @@ go_repository(
     commit = "182cda27d0921b14139ff6d352c09e0cb20e4578",
     importpath = "github.com/aws/aws-sdk-go",
 )
-
-
-#-----------------------------------------------------------------------------
-# Javascript
-#-----------------------------------------------------------------------------
-
-http_archive(
-    name = "io_bazel_rules_closure",
-    sha256 = "6113983b357de085515c5356405e2391fda88edc3d8f214789b560a0e70d9968",
-    strip_prefix = "rules_closure-6794c2755113e967394eec53ed4ceb6c7eb4d065",
-    urls = [
-        "https://github.com/bazelbuild/rules_closure/archive/6794c2755113e967394eec53ed4ceb6c7eb4d065.zip",
-    ],
-)
-
-
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
-
-closure_repositories()
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -223,18 +223,12 @@ cpp_grpc_library()
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "fecda06179906857ac79af6500124bf03fe1630fd1b3d4dcf6c65346b9c0725d",
-    strip_prefix = "rules_closure-03110588392d8c6c05b99c08a6f1c2121604ca27",
+    sha256 = "87e5734a31fc20844de11f16323ab8d85159ca62ec752a2d9d159a8f471632c4",
+    strip_prefix = "rules_closure-9b43421460db85773d121414a81ec7d5bec6b7ce",
     urls = [
-        "https://github.com/bazelbuild/rules_closure/archive/03110588392d8c6c05b99c08a6f1c2121604ca27.zip",
+        "https://github.com/bazelbuild/rules_closure/archive/9b43421460db85773d121414a81ec7d5bec6b7ce.zip",
     ],
 )
-
-#local_repository(
-#    name = "io_bazel_rules_closure",
-#    path = "/Users/michael/src/self/rules_closure",
-#)
-
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 

--- a/java/src/main/java/com/google/crypto/tink/integration/awskms/BUILD.bazel
+++ b/java/src/main/java/com/google/crypto/tink/integration/awskms/BUILD.bazel
@@ -45,7 +45,7 @@ java_plugin(
     name = "auto_service_plugin",
     processor_class = "com.google.auto.service.processor.AutoServiceProcessor",
     deps = [
-        "@com_google_auto_common",
+        "@com_google_auto_common_08",
         "@com_google_auto_service",
         "@com_google_guava",
     ],

--- a/java/src/main/java/com/google/crypto/tink/integration/gcpkms/BUILD.bazel
+++ b/java/src/main/java/com/google/crypto/tink/integration/gcpkms/BUILD.bazel
@@ -40,7 +40,7 @@ java_plugin(
     name = "auto_service_plugin",
     processor_class = "com.google.auto.service.processor.AutoServiceProcessor",
     deps = [
-        "@com_google_auto_common",
+        "@com_google_auto_common_08",
         "@com_google_auto_service",
         "@com_google_guava",
     ],

--- a/javascript/BUILD.bazel
+++ b/javascript/BUILD.bazel
@@ -38,6 +38,20 @@ closure_js_library(
 )
 
 closure_js_library(
+    name = "binary_writer",
+    #lenient = True,
+    srcs = [
+        "binary_keyset_writer.js",
+    ],
+    deps = [
+        ":readers_writers",
+        "//javascript/exception",
+        "//proto:tink_closure_proto",
+        "@io_bazel_rules_closure//closure/library",
+    ],
+)
+
+closure_js_library(
     name = "readers_writers",
     #lenient = True,
     srcs = [
@@ -64,6 +78,7 @@ closure_js_library(
         ":registry",
         ":util",
         "//javascript/exception",
+        "//javascript/subtle",
         "//proto:tink_closure_proto",
         "@io_bazel_rules_closure//closure/library",
     ],
@@ -77,6 +92,8 @@ closure_js_library(
     ],
     deps = [
         ":keyset_handle",
+        ":binary_reader",
+        ":binary_writer",
         "//proto:tink_closure_proto",
         "@io_bazel_rules_closure//closure/library",
     ],
@@ -220,6 +237,7 @@ closure_js_test(
     ]),
     entry_points = {
         "binary_keyset_reader_test.js": ["tink.BinaryKeysetReaderTest"],
+        "binary_keyset_writer_test.js": ["tink.BinaryKeysetWriterTest"],
         "cleartext_keyset_handle_test.js": ["tink.CleartextKeysetHandleTest"],
         "config_test.js": ["tink.ConfigTest"],
         "crypto_format_test.js": ["tink.CryptoFormatTest"],
@@ -231,6 +249,7 @@ closure_js_test(
     },
     deps = [
         ":binary_reader",
+        ":binary_writer",
         ":catalogue",
         ":cleartext_keyset_handle",
         ":config",

--- a/javascript/BUILD.bazel
+++ b/javascript/BUILD.bazel
@@ -8,6 +8,7 @@ load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure
 
 closure_js_library(
     name = "primitives",
+    #lenient = True,
     srcs = [
         "aead.js",
         "hybrid_decrypt.js",
@@ -24,6 +25,7 @@ closure_js_library(
 
 closure_js_library(
     name = "binary_reader",
+    #lenient = True,
     srcs = [
         "binary_keyset_reader.js",
     ],
@@ -37,6 +39,7 @@ closure_js_library(
 
 closure_js_library(
     name = "readers_writers",
+    #lenient = True,
     srcs = [
         "keyset_reader.js",
         "keyset_writer.js",
@@ -49,6 +52,7 @@ closure_js_library(
 
 closure_js_library(
     name = "keyset_handle",
+    #lenient = True,
     srcs = [
         "keyset_handle.js",
     ],
@@ -67,6 +71,7 @@ closure_js_library(
 
 closure_js_library(
     name = "cleartext_keyset_handle",
+    #lenient = True,
     srcs = [
         "cleartext_keyset_handle.js",
     ],
@@ -79,6 +84,7 @@ closure_js_library(
 
 closure_js_library(
     name = "primitive_set",
+    #lenient = True,
     srcs = [
         "primitive_set.js",
     ],
@@ -92,6 +98,7 @@ closure_js_library(
 
 closure_js_library(
     name = "key_manager",
+    #lenient = True,
     srcs = [
         "key_manager.js",
     ],
@@ -105,6 +112,7 @@ closure_js_library(
 
 closure_js_library(
     name = "primitive_wrapper",
+    #lenient = True,
     srcs = [
         "primitive_wrapper.js",
     ],
@@ -116,6 +124,7 @@ closure_js_library(
 
 closure_js_library(
     name = "catalogue",
+    #lenient = True,
     srcs = [
         "catalogue.js",
     ],
@@ -127,6 +136,7 @@ closure_js_library(
 
 closure_js_library(
     name = "registry",
+    #lenient = True,
     srcs = [
         "registry.js",
     ],
@@ -145,6 +155,7 @@ closure_js_library(
 
 closure_js_library(
     name = "crypto_format",
+    #lenient = True,
     srcs = [
         "crypto_format.js",
     ],
@@ -157,6 +168,7 @@ closure_js_library(
 
 closure_js_library(
     name = "util",
+    #lenient = True,
     srcs = [
         "util.js",
     ],
@@ -171,6 +183,7 @@ closure_js_library(
 
 closure_js_library(
     name = "config",
+    #lenient = True,
     srcs = [
         "config.js",
     ],
@@ -185,3 +198,66 @@ closure_js_library(
 )
 
 # test
+closure_js_library(
+    name = "test_utils",
+    #lenient = True,
+    testonly = 1,
+    srcs = [
+        "test_utils.js",
+    ],
+    deps = [
+        "//proto:tink_closure_proto",
+        "@io_bazel_rules_closure//closure/library",
+    ],
+)
+
+closure_js_test(
+    name = "test_lib",
+    testonly = 1,
+    #lenient = True,
+    srcs = glob([
+        "*_test.js",
+    ]),
+    entry_points = {
+        "binary_keyset_reader_test.js": ["tink.BinaryKeysetReaderTest"],
+        "cleartext_keyset_handle_test.js": ["tink.CleartextKeysetHandleTest"],
+        "config_test.js": ["tink.ConfigTest"],
+        "crypto_format_test.js": ["tink.CryptoFormatTest"],
+        "keyset_handle_test.js": ["tink.KeysetHandleTest"],
+        "primitive_set_test.js": ["tink.PrimitiveSetTest"],
+        "proto_test.js": ["tink.ProtoTest"],
+        "registry_test.js": ["tink.RegistryTest"],
+        "util_test.js": ["tink.UtilTest"],
+    },
+    deps = [
+        ":binary_reader",
+        ":catalogue",
+        ":cleartext_keyset_handle",
+        ":config",
+        ":crypto_format",
+        ":keyset_handle",
+        ":key_manager",
+        ":primitive_set",
+        ":primitive_wrapper",
+        ":primitives",
+        ":registry",
+        ":util",
+        ":test_utils",
+        "//javascript/aead",
+        "//javascript/hybrid",
+        "//javascript/subtle",
+        "//javascript/subtle:aead",
+        "//javascript/exception",
+        "//proto:aes_ctr_closure_proto",
+        "//proto:aes_ctr_hmac_aead_closure_proto",
+        "//proto:common_closure_proto",
+        "//proto:config_closure_proto",
+        "//proto:ecdsa_closure_proto",
+        "//proto:ecies_aead_hkdf_closure_proto",
+        "//proto:hmac_closure_proto",
+        "//proto:tink_closure_proto",
+        "@io_bazel_rules_closure//closure/library:testing",
+        "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/protobuf:jspb",
+    ],
+)

--- a/javascript/aead/BUILD.bazel
+++ b/javascript/aead/BUILD.bazel
@@ -6,7 +6,7 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
 
 closure_js_library(
     name = "aead",
@@ -22,6 +22,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aes_ctr_hmac_aead_key_manager",
+    #lenient = True,
     srcs = [
         "aes_ctr_hmac_aead_key_manager.js",
     ],
@@ -42,6 +43,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aes_gcm_key_manager",
+    #lenient = True,
     srcs = [
         "aes_gcm_key_manager.js",
     ],
@@ -60,6 +62,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aead_key_templates",
+    #lenient = True,
     srcs = [
         "aead_key_templates.js",
     ],
@@ -77,6 +80,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aead_catalogue",
+    #lenient = True,
     srcs = [
         "aead_catalogue.js",
     ],
@@ -93,6 +97,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aead_config",
+    #lenient = True,
     srcs = [
         "aead_config.js",
     ],
@@ -110,6 +115,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aead_wrapper",
+    #lenient = True,
     srcs = [
         "aead_wrapper.js",
     ],
@@ -126,23 +132,37 @@ closure_js_library(
 
 # test
 
-closure_js_library(
+closure_js_test(
     name = "test_lib",
     testonly = 1,
+    #lenient = True,
     srcs = glob([
         "*_test.js",
     ]),
+    entry_points = {
+        "aead_catalogue_test.js": ["tink.aead.AeadCatalogueTest"],
+        "aead_config_test.js": ["tink.aead.AeadConfigTest"],
+        "aead_key_templates_test.js": ["tink.aead.AeadKeyTemplatesTest"],
+        "aead_wrapper_test.js": ["tink.aead.AeadWrapperTest"],
+        "aes_ctr_hmac_aead_key_manager_test.js": ["tink.aead.AesCtrHmacAeadKeyManagerTest"],
+        "aes_gcm_key_manager_test.js": ["tink.aead.AesGcmKeyManagerTest"],
+    },
     deps = [
+        "//javascript/aead",
+        "//javascript/exception",
+        "//javascript/subtle",
+        "//javascript:registry",
+        "//javascript:crypto_format",
+        "//javascript:keyset_handle",
+        "//javascript:primitives",
+        "//javascript:primitive_set",
         "//proto:aes_ctr_closure_proto",
         "//proto:aes_ctr_hmac_aead_closure_proto",
         "//proto:aes_gcm_closure_proto",
         "//proto:common_closure_proto",
         "//proto:hmac_closure_proto",
         "//proto:tink_closure_proto",
-        "@io_bazel_rules_closure//closure/library",
-        "@io_bazel_rules_closure//closure/library/testing:asserts",
-        "@io_bazel_rules_closure//closure/library/testing:jsunit",
-        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+        "@io_bazel_rules_closure//closure/library:testing",
         "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )

--- a/javascript/aead/aead_catalogue.js
+++ b/javascript/aead/aead_catalogue.js
@@ -24,7 +24,7 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 /**
  * A catalogue of TINK Aead key managers.
  *
- * @implements {Catalogue<Aead>}
+ * @implements {Catalogue<!Aead>}
  * @final
  */
 class AeadCatalogue {

--- a/javascript/aead/aead_catalogue_test.js
+++ b/javascript/aead/aead_catalogue_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AeadCatalogueTest');
 goog.setTestOnly('tink.aead.AeadCatalogueTest');
 

--- a/javascript/aead/aead_catalogue_test.js
+++ b/javascript/aead/aead_catalogue_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AeadCatalogueTest');
 goog.setTestOnly('tink.aead.AeadCatalogueTest');
@@ -47,7 +47,7 @@ testSuite({
       catalogue.getKeyManager(
           AesCtrHmacAeadKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.wrongPrimitive(
               anotherPrimitiveName, SUPPORTED_PRIMITIVE_NAME),
@@ -65,7 +65,7 @@ testSuite({
     try {
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.badVersion(manager.getVersion()), e.toString());
       return;
@@ -80,7 +80,7 @@ testSuite({
     const catalogue = new AeadCatalogue();
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
       return;
     }

--- a/javascript/aead/aead_catalogue_test.js
+++ b/javascript/aead/aead_catalogue_test.js
@@ -43,7 +43,7 @@ testSuite({
       catalogue.getKeyManager(
           AesCtrHmacAeadKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.wrongPrimitive(
               anotherPrimitiveName, SUPPORTED_PRIMITIVE_NAME),
@@ -61,7 +61,7 @@ testSuite({
     try {
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.badVersion(manager.getVersion()), e.toString());
       return;
@@ -76,7 +76,7 @@ testSuite({
     const catalogue = new AeadCatalogue();
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
       return;
     }

--- a/javascript/aead/aead_config_test.js
+++ b/javascript/aead/aead_config_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AeadConfigTest');
 goog.setTestOnly('tink.aead.AeadConfigTest');
 

--- a/javascript/aead/aead_config_test.js
+++ b/javascript/aead/aead_config_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AeadConfigTest');
 goog.setTestOnly('tink.aead.AeadConfigTest');

--- a/javascript/aead/aead_key_templates_test.js
+++ b/javascript/aead/aead_key_templates_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AeadKeyTemplatesTest');
 goog.setTestOnly('tink.aead.AeadKeyTemplatesTest');

--- a/javascript/aead/aead_key_templates_test.js
+++ b/javascript/aead/aead_key_templates_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AeadKeyTemplatesTest');
 goog.setTestOnly('tink.aead.AeadKeyTemplatesTest');
 

--- a/javascript/aead/aead_wrapper.js
+++ b/javascript/aead/aead_wrapper.js
@@ -107,7 +107,7 @@ class WrappedAead {
    * throws an exception if no entry succeeds.
    *
    * @private
-   * @param {!Array<!PrimitiveSet.Entry>} entriesArray
+   * @param {!Array<!PrimitiveSet.Entry<!Aead>>} entriesArray
    * @param {!Uint8Array} ciphertext
    * @param {?Uint8Array=} opt_associatedData
    *

--- a/javascript/aead/aead_wrapper.js
+++ b/javascript/aead/aead_wrapper.js
@@ -27,17 +27,17 @@ const SecurityException = goog.require('tink.exception.SecurityException');
  */
 class WrappedAead {
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} aeadSet
+   * @param {!PrimitiveSet.PrimitiveSet<!Aead>} aeadSet
    */
   // The constructor should be @private, but it is not supported by Closure
   // (see https://github.com/google/closure-compiler/issues/2761).
   constructor(aeadSet) {
-    /** @private @const {!PrimitiveSet.PrimitiveSet} */
+    /** @private @const {!PrimitiveSet.PrimitiveSet<!Aead>} */
     this.aeadSet_ = aeadSet;
   }
 
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} aeadSet
+   * @param {!PrimitiveSet.PrimitiveSet<!Aead>} aeadSet
    *
    * @return {!Aead}
    */
@@ -87,7 +87,7 @@ class WrappedAead {
       try {
         decryptedText = await this.tryDecryption_(
             entries, rawCiphertext, opt_associatedData);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
       }
 
       if (decryptedText) {
@@ -124,7 +124,7 @@ class WrappedAead {
       try {
         decryptionResult =
             await primitive.decrypt(ciphertext, opt_associatedData);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         continue;
       }
       return decryptionResult;
@@ -134,7 +134,7 @@ class WrappedAead {
 }
 
 /**
- * @implements {PrimitiveWrapper<Aead>}
+ * @implements {PrimitiveWrapper<!Aead>}
  */
 class AeadWrapper {
   // The constructor should be @private, but it is not supported by Closure

--- a/javascript/aead/aead_wrapper_test.js
+++ b/javascript/aead/aead_wrapper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AeadWrapperTest');
 goog.setTestOnly('tink.aead.AeadWrapperTest');
@@ -35,7 +35,7 @@ testSuite({
   async testNewAeadNullPrimitiveSet() {
     try {
       new AeadWrapper().wrap(null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
       return;
     }
@@ -46,7 +46,7 @@ testSuite({
     const primitiveSet = createPrimitiveSet(/* opt_withPrimary = */ false);
     try {
       new AeadWrapper().wrap(primitiveSet);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.primitiveSetWithoutPrimary(), e.toString());
       return;
     }
@@ -82,7 +82,7 @@ testSuite({
 
     try {
       await aead.decrypt(ciphertext);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
       return;
     }
@@ -168,7 +168,7 @@ testSuite({
     // used to neither encryption nor decryption.
     try {
       await aead.decrypt(ciphertext);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
       return;
     }
@@ -249,7 +249,7 @@ const createKey = function(keyId, outputPrefix, enabled) {
  *
  * @param {boolean=} opt_withPrimary
  *
- * @return {!PrimitiveSet.PrimitiveSet<!Aead>}
+ * @return {!PrimitiveSet.PrimitiveSet}
  */
 const createPrimitiveSet = function(opt_withPrimary = true) {
   const numberOfPrimitives = 5;

--- a/javascript/aead/aead_wrapper_test.js
+++ b/javascript/aead/aead_wrapper_test.js
@@ -31,7 +31,7 @@ testSuite({
   async testNewAeadNullPrimitiveSet() {
     try {
       new AeadWrapper().wrap(null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
       return;
     }
@@ -42,7 +42,7 @@ testSuite({
     const primitiveSet = createPrimitiveSet(/* opt_withPrimary = */ false);
     try {
       new AeadWrapper().wrap(primitiveSet);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.primitiveSetWithoutPrimary(), e.toString());
       return;
     }
@@ -78,7 +78,7 @@ testSuite({
 
     try {
       await aead.decrypt(ciphertext);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
       return;
     }
@@ -164,7 +164,7 @@ testSuite({
     // used to neither encryption nor decryption.
     try {
       await aead.decrypt(ciphertext);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
       return;
     }
@@ -245,7 +245,7 @@ const createKey = function(keyId, outputPrefix, enabled) {
  *
  * @param {boolean=} opt_withPrimary
  *
- * @return {!PrimitiveSet.PrimitiveSet}
+ * @return {!PrimitiveSet.PrimitiveSet<!Aead>}
  */
 const createPrimitiveSet = function(opt_withPrimary = true) {
   const numberOfPrimitives = 5;

--- a/javascript/aead/aead_wrapper_test.js
+++ b/javascript/aead/aead_wrapper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AeadWrapperTest');
 goog.setTestOnly('tink.aead.AeadWrapperTest');
 

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager.js
@@ -38,11 +38,11 @@ class AesCtrHmacAeadKeyFactory {
    * @override
    */
   newKey(keyFormat) {
-    let /** PbAesCtrHmacAeadKeyFormat */ keyFormatProto;
+    let /** !PbAesCtrHmacAeadKeyFormat */ keyFormatProto;
     if (keyFormat instanceof Uint8Array) {
       try {
         keyFormatProto = PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyFormat);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         throw new SecurityException(
             'Could not parse the given Uint8Array as a serialized proto of ' +
             AesCtrHmacAeadKeyManager.KEY_TYPE);
@@ -62,21 +62,21 @@ class AesCtrHmacAeadKeyFactory {
     }
 
     this.validateAesCtrKeyFormat(keyFormatProto.getAesCtrKeyFormat());
-    let /** PbAesCtrKey */ aesCtrKey = new PbAesCtrKey();
+    let /** !PbAesCtrKey */ aesCtrKey = new PbAesCtrKey();
     aesCtrKey.setVersion(AesCtrHmacAeadKeyFactory.VERSION_);
     aesCtrKey.setParams(keyFormatProto.getAesCtrKeyFormat().getParams());
     aesCtrKey.setKeyValue(
         Random.randBytes(keyFormatProto.getAesCtrKeyFormat().getKeySize()));
 
     this.validateHmacKeyFormat(keyFormatProto.getHmacKeyFormat());
-    let /** PbHmacKey */ hmacKey = new PbHmacKey();
+    let /** !PbHmacKey */ hmacKey = new PbHmacKey();
     hmacKey.setVersion(AesCtrHmacAeadKeyFactory.VERSION_);
     hmacKey.setParams(keyFormatProto.getHmacKeyFormat().getParams());
     hmacKey.setKeyValue(
         Random.randBytes(keyFormatProto.getHmacKeyFormat().getKeySize()));
 
 
-    let /** PbAesCtrHmacAeadKey */ aesCtrHmacAeadKey =
+    let /** !PbAesCtrHmacAeadKey */ aesCtrHmacAeadKey =
         new PbAesCtrHmacAeadKey();
     aesCtrHmacAeadKey.setAesCtrKey(aesCtrKey);
     aesCtrHmacAeadKey.setHmacKey(hmacKey);
@@ -181,7 +181,7 @@ AesCtrHmacAeadKeyFactory.MAX_TAG_SIZE_ = new Map(
     [[PbHashType.SHA1, 20], [PbHashType.SHA256, 32], [PbHashType.SHA512, 64]]);
 
 /**
- * @implements {KeyManager.KeyManager<Aead>}
+ * @implements {KeyManager.KeyManager<!Aead>}
  * @final
  */
 class AesCtrHmacAeadKeyManager {
@@ -202,7 +202,7 @@ class AesCtrHmacAeadKeyManager {
           'supported by this key manager.');
     }
 
-    let /** PbAesCtrHmacAeadKey */ deserializedKey;
+    let /** !PbAesCtrHmacAeadKey */ deserializedKey;
     if (key instanceof PbKeyData) {
       if (!this.doesSupport(key.getTypeUrl())) {
         throw new SecurityException('Key type ' + key.getTypeUrl() +
@@ -211,7 +211,7 @@ class AesCtrHmacAeadKeyManager {
       }
       try {
         deserializedKey = PbAesCtrHmacAeadKey.deserializeBinary(key.getValue());
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         throw new SecurityException(
             'Could not parse the key in key data as a serialized proto of ' +
             AesCtrHmacAeadKeyManager.KEY_TYPE);

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AesCtrHmacAeadKeyManagerTest');
 goog.setTestOnly('tink.aead.AesCtrHmacAeadKeyManagerTest');
@@ -127,7 +127,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Expected AesCtrHmacAeadKeyFormat-proto', e.toString());
       return;
@@ -142,7 +142,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(serializedKeyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Could not parse the given Uint8Array as a serialized' +
               ' proto of ' + KEY_TYPE,
@@ -162,7 +162,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: unsupported AES key size: ' + keySize, e.toString());
       return;
@@ -171,7 +171,7 @@ testSuite({
   },
 
   async testNewKeyIvSizeOutOfRange() {
-    const /** !Array<number> */ ivSizeOutOfRange = [10, 18];
+    const /** Array<number> */ ivSizeOutOfRange = [10, 18];
     const manager = new AesCtrHmacAeadKeyManager();
 
     let keyFormat = createTestKeyFormat();
@@ -181,7 +181,7 @@ testSuite({
       keyFormat.getAesCtrKeyFormat().getParams().setIvSize(ivSizeOutOfRange[i]);
       try {
         manager.getKeyFactory().newKey(keyFormat);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Invalid AES CTR HMAC key format: IV size is ' +
                 'out of range: ' + ivSizeOutOfRange[i],
@@ -203,7 +203,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Invalid AES CTR HMAC key format: HMAC key is' +
               ' too small: ' + keySize,
@@ -221,7 +221,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: Unknown hash type.', e.toString());
       return;
     }
@@ -237,7 +237,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Invalid HMAC params: tag size ' + SMALL_TAG_SIZE +
               ' is too small.',
@@ -248,7 +248,7 @@ testSuite({
   },
 
   async testNewKeyBigTagSizeForHashType() {
-    const /** !Array<{hashType: number, tagSize: number}> */tagSizes = [
+    const tagSizes = [
       {'hashType': PbHashType.SHA1, 'tagSize': 22},
       {'hashType': PbHashType.SHA256, 'tagSize': 34},
       {'hashType': PbHashType.SHA512, 'tagSize': 66},
@@ -264,7 +264,7 @@ testSuite({
           tagSizes[i]['tagSize']);
       try {
         manager.getKeyFactory().newKey(keyFormat);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Invalid HMAC params: tag size ' +
                 tagSizes[i]['tagSize'] + ' is out of range.',
@@ -351,7 +351,7 @@ testSuite({
     for (let i = 0; i < serializedKeyFormatsLength; i++) {
       try {
         aeadKeyManager.getKeyFactory().newKeyData(serializedKeyFormats[i]);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Could not parse the given Uint8Array as a ' +
                 'serialized proto of ' + KEY_TYPE,
@@ -390,12 +390,12 @@ testSuite({
 
   async testGetPrimitiveUnsupportedKeyDataType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbKeyData */ keyData = createTestKeyData();
+    let /** PbKeyData */ keyData = createTestKeyData();
     keyData.setTypeUrl('bad type url');
 
     try {
       await aeadKeyManager.getPrimitive(Aead, keyData);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Key type ' + keyData.getTypeUrl() +
           ' is not supported. This key manager supports ' +
@@ -411,7 +411,7 @@ testSuite({
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Given key type is not supported. ' +
           'This key manager supports ' + KEY_TYPE + '.', e.toString());
@@ -423,13 +423,13 @@ testSuite({
   async testGetPrimitiveBadVersion() {
     const version = 1;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setVersion(version);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Version is out of bound, must be between 0 ' +
               'and ' + VERSION + '.',
@@ -442,13 +442,13 @@ testSuite({
   async testGetPrimitiveShortAesCtrKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setKeyValue(new Uint8Array(keySize));
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: unsupported AES key size: ' + keySize, e.toString());
       return;
@@ -457,16 +457,16 @@ testSuite({
   },
 
   async testGetPrimitiveAesCtrKeySmallIvSize() {
-    const /** !Array<number> */ ivSizeOutOfRange = [9, 19];
+    const /** Array<number> */ ivSizeOutOfRange = [9, 19];
     const manager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
     for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
       key.getAesCtrKey().getParams().setIvSize(ivSizeOutOfRange[i]);
       try {
         await manager.getPrimitive(Aead, key);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Invalid AES CTR HMAC key format: IV size is ' +
                 'out of range: ' + ivSizeOutOfRange[i],
@@ -480,13 +480,13 @@ testSuite({
   async testGetPrimitiveShortHmacKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().setKeyValue(new Uint8Array(keySize));
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Invalid AES CTR HMAC key format: HMAC key is' +
               ' too small: ' + keySize,
@@ -498,13 +498,13 @@ testSuite({
 
   async testGetPrimitiveHmacKeyUnsupportedHashType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setHash(PbHashType.UNKNOWN_HASH);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: Unknown hash type.', e.toString());
       return;
     }
@@ -514,13 +514,13 @@ testSuite({
   async testGetPrimitiveHmacKeySmallTagSize() {
     const SMALL_TAG_SIZE = 9;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setTagSize(SMALL_TAG_SIZE);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Invalid HMAC params: tag size ' + SMALL_TAG_SIZE +
               ' is too small.',
@@ -538,7 +538,7 @@ testSuite({
     ];
     const manager = new AesCtrHmacAeadKeyManager();
 
-    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const tagSizesLength = tagSizes.length;
     for (let i = 0; i < tagSizesLength; i++) {
@@ -546,7 +546,7 @@ testSuite({
       key.getHmacKey().getParams().setTagSize(tagSizes[i]['tagSize']);
       try {
         await manager.getPrimitive(Aead, key);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Invalid HMAC params: tag size ' +
                 tagSizes[i]['tagSize'] + ' is out of range.',
@@ -564,7 +564,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** !Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
+    const /** Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
 
@@ -577,7 +577,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** !Aead */ primitive =
+    const /** Aead */ primitive =
         await aeadKeyManager.getPrimitive(Aead, keyData);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
@@ -591,7 +591,7 @@ testSuite({
 
     try {
       await manager.getPrimitive(Mac, keyData);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Requested primitive type which is not ' +
               'supported by this key manager.',

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
@@ -123,7 +123,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Expected AesCtrHmacAeadKeyFormat-proto', e.toString());
       return;
@@ -138,7 +138,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(serializedKeyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Could not parse the given Uint8Array as a serialized' +
               ' proto of ' + KEY_TYPE,
@@ -158,7 +158,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: unsupported AES key size: ' + keySize, e.toString());
       return;
@@ -167,7 +167,7 @@ testSuite({
   },
 
   async testNewKeyIvSizeOutOfRange() {
-    const /** Array<number> */ ivSizeOutOfRange = [10, 18];
+    const /** !Array<number> */ ivSizeOutOfRange = [10, 18];
     const manager = new AesCtrHmacAeadKeyManager();
 
     let keyFormat = createTestKeyFormat();
@@ -177,7 +177,7 @@ testSuite({
       keyFormat.getAesCtrKeyFormat().getParams().setIvSize(ivSizeOutOfRange[i]);
       try {
         manager.getKeyFactory().newKey(keyFormat);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Invalid AES CTR HMAC key format: IV size is ' +
                 'out of range: ' + ivSizeOutOfRange[i],
@@ -199,7 +199,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Invalid AES CTR HMAC key format: HMAC key is' +
               ' too small: ' + keySize,
@@ -217,7 +217,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: Unknown hash type.', e.toString());
       return;
     }
@@ -233,7 +233,7 @@ testSuite({
 
     try {
       manager.getKeyFactory().newKey(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Invalid HMAC params: tag size ' + SMALL_TAG_SIZE +
               ' is too small.',
@@ -260,7 +260,7 @@ testSuite({
           tagSizes[i]['tagSize']);
       try {
         manager.getKeyFactory().newKey(keyFormat);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Invalid HMAC params: tag size ' +
                 tagSizes[i]['tagSize'] + ' is out of range.',
@@ -347,7 +347,7 @@ testSuite({
     for (let i = 0; i < serializedKeyFormatsLength; i++) {
       try {
         aeadKeyManager.getKeyFactory().newKeyData(serializedKeyFormats[i]);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Could not parse the given Uint8Array as a ' +
                 'serialized proto of ' + KEY_TYPE,
@@ -386,12 +386,12 @@ testSuite({
 
   async testGetPrimitiveUnsupportedKeyDataType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbKeyData */ keyData = createTestKeyData();
+    let /** !PbKeyData */ keyData = createTestKeyData();
     keyData.setTypeUrl('bad type url');
 
     try {
       await aeadKeyManager.getPrimitive(Aead, keyData);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Key type ' + keyData.getTypeUrl() +
           ' is not supported. This key manager supports ' +
@@ -407,7 +407,7 @@ testSuite({
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Given key type is not supported. ' +
           'This key manager supports ' + KEY_TYPE + '.', e.toString());
@@ -419,13 +419,13 @@ testSuite({
   async testGetPrimitiveBadVersion() {
     const version = 1;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setVersion(version);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Version is out of bound, must be between 0 ' +
               'and ' + VERSION + '.',
@@ -438,13 +438,13 @@ testSuite({
   async testGetPrimitiveShortAesCtrKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setKeyValue(new Uint8Array(keySize));
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: unsupported AES key size: ' + keySize, e.toString());
       return;
@@ -453,16 +453,16 @@ testSuite({
   },
 
   async testGetPrimitiveAesCtrKeySmallIvSize() {
-    const /** Array<number> */ ivSizeOutOfRange = [9, 19];
+    const /** !Array<number> */ ivSizeOutOfRange = [9, 19];
     const manager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
     for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
       key.getAesCtrKey().getParams().setIvSize(ivSizeOutOfRange[i]);
       try {
         await manager.getPrimitive(Aead, key);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Invalid AES CTR HMAC key format: IV size is ' +
                 'out of range: ' + ivSizeOutOfRange[i],
@@ -476,13 +476,13 @@ testSuite({
   async testGetPrimitiveShortHmacKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().setKeyValue(new Uint8Array(keySize));
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Invalid AES CTR HMAC key format: HMAC key is' +
               ' too small: ' + keySize,
@@ -494,13 +494,13 @@ testSuite({
 
   async testGetPrimitiveHmacKeyUnsupportedHashType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setHash(PbHashType.UNKNOWN_HASH);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: Unknown hash type.', e.toString());
       return;
     }
@@ -510,13 +510,13 @@ testSuite({
   async testGetPrimitiveHmacKeySmallTagSize() {
     const SMALL_TAG_SIZE = 9;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setTagSize(SMALL_TAG_SIZE);
 
     try {
       await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Invalid HMAC params: tag size ' + SMALL_TAG_SIZE +
               ' is too small.',
@@ -534,7 +534,7 @@ testSuite({
     ];
     const manager = new AesCtrHmacAeadKeyManager();
 
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const tagSizesLength = tagSizes.length;
     for (let i = 0; i < tagSizesLength; i++) {
@@ -542,7 +542,7 @@ testSuite({
       key.getHmacKey().getParams().setTagSize(tagSizes[i]['tagSize']);
       try {
         await manager.getPrimitive(Aead, key);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Invalid HMAC params: tag size ' +
                 tagSizes[i]['tagSize'] + ' is out of range.',
@@ -560,7 +560,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
+    const /** !Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
 
@@ -573,7 +573,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** Aead */ primitive =
+    const /** !Aead */ primitive =
         await aeadKeyManager.getPrimitive(Aead, keyData);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
@@ -587,7 +587,7 @@ testSuite({
 
     try {
       await manager.getPrimitive(Mac, keyData);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Requested primitive type which is not ' +
               'supported by this key manager.',

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
@@ -171,7 +171,7 @@ testSuite({
   },
 
   async testNewKeyIvSizeOutOfRange() {
-    const /** Array<number> */ ivSizeOutOfRange = [10, 18];
+    const /** !Array<number> */ ivSizeOutOfRange = [10, 18];
     const manager = new AesCtrHmacAeadKeyManager();
 
     let keyFormat = createTestKeyFormat();
@@ -390,7 +390,7 @@ testSuite({
 
   async testGetPrimitiveUnsupportedKeyDataType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbKeyData */ keyData = createTestKeyData();
+    let /** !PbKeyData */ keyData = createTestKeyData();
     keyData.setTypeUrl('bad type url');
 
     try {
@@ -423,7 +423,7 @@ testSuite({
   async testGetPrimitiveBadVersion() {
     const version = 1;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setVersion(version);
 
@@ -442,7 +442,7 @@ testSuite({
   async testGetPrimitiveShortAesCtrKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getAesCtrKey().setKeyValue(new Uint8Array(keySize));
 
@@ -457,9 +457,9 @@ testSuite({
   },
 
   async testGetPrimitiveAesCtrKeySmallIvSize() {
-    const /** Array<number> */ ivSizeOutOfRange = [9, 19];
+    const /** !Array<number> */ ivSizeOutOfRange = [9, 19];
     const manager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
     for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
@@ -480,7 +480,7 @@ testSuite({
   async testGetPrimitiveShortHmacKey() {
     const keySize = 5;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().setKeyValue(new Uint8Array(keySize));
 
@@ -498,7 +498,7 @@ testSuite({
 
   async testGetPrimitiveHmacKeyUnsupportedHashType() {
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setHash(PbHashType.UNKNOWN_HASH);
 
@@ -514,7 +514,7 @@ testSuite({
   async testGetPrimitiveHmacKeySmallTagSize() {
     const SMALL_TAG_SIZE = 9;
     const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     key.getHmacKey().getParams().setTagSize(SMALL_TAG_SIZE);
 
@@ -538,7 +538,7 @@ testSuite({
     ];
     const manager = new AesCtrHmacAeadKeyManager();
 
-    let /** PbAesCtrHmacAeadKey */ key = createTestKey();
+    let /** !PbAesCtrHmacAeadKey */ key = createTestKey();
 
     const tagSizesLength = tagSizes.length;
     for (let i = 0; i < tagSizesLength; i++) {
@@ -564,7 +564,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
+    const /** !Aead */ primitive = await aeadKeyManager.getPrimitive(Aead, key);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
 
@@ -577,7 +577,7 @@ testSuite({
     const plaintext = Random.randBytes(8);
     const aad = Random.randBytes(8);
 
-    const /** Aead */ primitive =
+    const /** !Aead */ primitive =
         await aeadKeyManager.getPrimitive(Aead, keyData);
     const ciphertext = await primitive.encrypt(plaintext, aad);
     const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AesCtrHmacAeadKeyManagerTest');
 goog.setTestOnly('tink.aead.AesCtrHmacAeadKeyManagerTest');
 

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.js
@@ -248,7 +248,7 @@ testSuite({
   },
 
   async testNewKeyBigTagSizeForHashType() {
-    const tagSizes = [
+    const /** !Array<{hashType: number, tagSize: number}> */tagSizes = [
       {'hashType': PbHashType.SHA1, 'tagSize': 22},
       {'hashType': PbHashType.SHA256, 'tagSize': 34},
       {'hashType': PbHashType.SHA512, 'tagSize': 66},

--- a/javascript/aead/aes_gcm_key_manager.js
+++ b/javascript/aead/aes_gcm_key_manager.js
@@ -92,7 +92,7 @@ class AesGcmKeyFactory {
     let /** !PbAesGcmKeyFormat */ keyFormatProto;
     try {
       keyFormatProto = PbAesGcmKeyFormat.deserializeBinary(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Could not parse the input as a serialized proto of ' +
           AesGcmKeyManager.KEY_TYPE + ' key format.');
@@ -107,7 +107,7 @@ class AesGcmKeyFactory {
 }
 
 /**
- * @implements {KeyManager.KeyManager<Aead>}
+ * @implements {KeyManager.KeyManager<!Aead>}
  * @final
  */
 class AesGcmKeyManager {
@@ -201,10 +201,10 @@ class AesGcmKeyManager {
           AesGcmKeyManager.KEY_TYPE + '.');
     }
 
-    let /** PbAesGcmKey */ deserializedKey;
+    let /** !PbAesGcmKey */ deserializedKey;
     try {
       deserializedKey = PbAesGcmKey.deserializeBinary(keyData.getValue());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Could not parse the input as a ' +
           'serialized proto of ' + AesGcmKeyManager.KEY_TYPE + ' key.');

--- a/javascript/aead/aes_gcm_key_manager_test.js
+++ b/javascript/aead/aes_gcm_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.aead.AesGcmKeyManagerTest');
 goog.setTestOnly('tink.aead.AesGcmKeyManagerTest');
@@ -46,7 +46,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey(keyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidKeyFormat(), e.toString());
     }
   },
@@ -58,7 +58,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey(keyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -77,7 +77,7 @@ testSuite({
       try {
         manager.getKeyFactory().newKey(keyFormat);
         fail('An exception should be thrown.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.unsupportedKeySize(keySize), e.toString());
       }
     }
@@ -136,7 +136,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -149,7 +149,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -164,7 +164,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -182,7 +182,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, key);
         fail('An exception should be thrown');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.unsupportedKeySize(keySize), e.toString());
       }
     }
@@ -196,7 +196,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -208,7 +208,7 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, keyData);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -220,7 +220,7 @@ testSuite({
     const key = createTestKey();
 
     // Get the primitive from key manager.
-    const /** !Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
+    const /** Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
 
     // Test the returned primitive.
     const plaintext = Random.randBytes(8);
@@ -236,7 +236,7 @@ testSuite({
     const keyData = createTestKeyData();
 
     // Get primitive.
-    const /** !Aead */ primitive =
+    const /** Aead */ primitive =
         await manager.getPrimitive(PRIMITIVE, keyData);
 
     // Test the returned primitive.
@@ -321,9 +321,6 @@ class ExceptionText {
         KEY_TYPE + ' key.';
   }
 
-  /**
-   * @return {string}
-   */
   static invalidSerializedKeyFormat() {
     return 'CustomError: Could not parse the input as a serialized proto of ' +
         KEY_TYPE + ' key format.';

--- a/javascript/aead/aes_gcm_key_manager_test.js
+++ b/javascript/aead/aes_gcm_key_manager_test.js
@@ -42,7 +42,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey(keyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidKeyFormat(), e.toString());
     }
   },
@@ -54,7 +54,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey(keyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -73,7 +73,7 @@ testSuite({
       try {
         manager.getKeyFactory().newKey(keyFormat);
         fail('An exception should be thrown.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.unsupportedKeySize(keySize), e.toString());
       }
     }
@@ -132,7 +132,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -145,7 +145,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -160,7 +160,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -178,7 +178,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, key);
         fail('An exception should be thrown');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.unsupportedKeySize(keySize), e.toString());
       }
     }
@@ -192,7 +192,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -204,7 +204,7 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, keyData);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -216,7 +216,7 @@ testSuite({
     const key = createTestKey();
 
     // Get the primitive from key manager.
-    const /** Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
+    const /** !Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
 
     // Test the returned primitive.
     const plaintext = Random.randBytes(8);
@@ -232,7 +232,7 @@ testSuite({
     const keyData = createTestKeyData();
 
     // Get primitive.
-    const /** Aead */ primitive =
+    const /** !Aead */ primitive =
         await manager.getPrimitive(PRIMITIVE, keyData);
 
     // Test the returned primitive.

--- a/javascript/aead/aes_gcm_key_manager_test.js
+++ b/javascript/aead/aes_gcm_key_manager_test.js
@@ -220,7 +220,7 @@ testSuite({
     const key = createTestKey();
 
     // Get the primitive from key manager.
-    const /** Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
+    const /** !Aead */ primitive = await manager.getPrimitive(PRIMITIVE, key);
 
     // Test the returned primitive.
     const plaintext = Random.randBytes(8);
@@ -236,7 +236,7 @@ testSuite({
     const keyData = createTestKeyData();
 
     // Get primitive.
-    const /** Aead */ primitive =
+    const /** !Aead */ primitive =
         await manager.getPrimitive(PRIMITIVE, keyData);
 
     // Test the returned primitive.

--- a/javascript/aead/aes_gcm_key_manager_test.js
+++ b/javascript/aead/aes_gcm_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.aead.AesGcmKeyManagerTest');
 goog.setTestOnly('tink.aead.AesGcmKeyManagerTest');
 
@@ -317,6 +321,9 @@ class ExceptionText {
         KEY_TYPE + ' key.';
   }
 
+  /**
+   * @return {string}
+   */
   static invalidSerializedKeyFormat() {
     return 'CustomError: Could not parse the input as a serialized proto of ' +
         KEY_TYPE + ' key format.';

--- a/javascript/binary_keyset_reader.js
+++ b/javascript/binary_keyset_reader.js
@@ -48,7 +48,7 @@ class BinaryKeysetReader {
     let /** !PbKeyset */ keyset;
     try {
       keyset = PbKeyset.deserializeBinary(this.serializedKeyset_);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Could not parse the given serialized proto as a keyset proto.');
     }

--- a/javascript/binary_keyset_reader_test.js
+++ b/javascript/binary_keyset_reader_test.js
@@ -30,7 +30,7 @@ testSuite({
     try {
       BinaryKeysetReader.withUint8Array(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullKeyset(), e.toString());
     }
   },
@@ -43,7 +43,7 @@ testSuite({
       try {
         reader.read();
         fail('An exception should be thrown.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerialization(), e.toString());
       }
     }
@@ -89,7 +89,7 @@ testSuite({
     try {
       reader.readEncrypted();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.notImplemented(), e.toString());
     }
   },

--- a/javascript/binary_keyset_reader_test.js
+++ b/javascript/binary_keyset_reader_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.BinaryKeysetReaderTest');
 goog.setTestOnly('tink.BinaryKeysetReaderTest');
 

--- a/javascript/binary_keyset_reader_test.js
+++ b/javascript/binary_keyset_reader_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.BinaryKeysetReaderTest');
 goog.setTestOnly('tink.BinaryKeysetReaderTest');
@@ -34,7 +34,7 @@ testSuite({
     try {
       BinaryKeysetReader.withUint8Array(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullKeyset(), e.toString());
     }
   },
@@ -47,7 +47,7 @@ testSuite({
       try {
         reader.read();
         fail('An exception should be thrown.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerialization(), e.toString());
       }
     }
@@ -93,7 +93,7 @@ testSuite({
     try {
       reader.readEncrypted();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.notImplemented(), e.toString());
     }
   },

--- a/javascript/binary_keyset_writer_test.js
+++ b/javascript/binary_keyset_writer_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes, reportUnknownTypes}
+ */
 goog.module('tink.BinaryKeysetWriterTest');
 goog.setTestOnly('tink.BinaryKeysetWriterTest');
 

--- a/javascript/cleartext_keyset_handle_test.js
+++ b/javascript/cleartext_keyset_handle_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.CleartextKeysetHandleTest');
 goog.setTestOnly();
 

--- a/javascript/cleartext_keyset_handle_test.js
+++ b/javascript/cleartext_keyset_handle_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.CleartextKeysetHandleTest');
 goog.setTestOnly();

--- a/javascript/config_test.js
+++ b/javascript/config_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.ConfigTest');
 goog.setTestOnly('tink.ConfigTest');
 

--- a/javascript/config_test.js
+++ b/javascript/config_test.js
@@ -65,7 +65,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.nonRegisteredCatalogue(catalogueName), e.toString());
     }
@@ -75,14 +75,14 @@ testSuite({
     try {
       Config.register();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.undefinedEntry(), e.toString());
     }
 
     try {
       Config.register(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.undefinedEntry(), e.toString());
     }
   },
@@ -97,7 +97,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.primitiveNameMissing(), e.toString());
     }
   },
@@ -112,7 +112,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.catalogueNameMissing(), e.toString());
     }
   },
@@ -127,7 +127,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.typeUrlMissing(), e.toString());
     }
   },
@@ -185,7 +185,7 @@ testSuite({
     try {
       await Registry.newKeyData(template);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.newKeyForbidden(typeUrl), e.toString());
     }
   },

--- a/javascript/config_test.js
+++ b/javascript/config_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.ConfigTest');
 goog.setTestOnly('tink.ConfigTest');
@@ -69,7 +69,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.nonRegisteredCatalogue(catalogueName), e.toString());
     }
@@ -79,14 +79,14 @@ testSuite({
     try {
       Config.register();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.undefinedEntry(), e.toString());
     }
 
     try {
       Config.register(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.undefinedEntry(), e.toString());
     }
   },
@@ -101,7 +101,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.primitiveNameMissing(), e.toString());
     }
   },
@@ -116,7 +116,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.catalogueNameMissing(), e.toString());
     }
   },
@@ -131,7 +131,7 @@ testSuite({
     try {
       Config.register(entry);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.typeUrlMissing(), e.toString());
     }
   },
@@ -189,7 +189,7 @@ testSuite({
     try {
       await Registry.newKeyData(template);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.newKeyForbidden(typeUrl), e.toString());
     }
   },

--- a/javascript/crypto_format.js
+++ b/javascript/crypto_format.js
@@ -31,7 +31,7 @@ class CryptoFormat {
    * Generates the prefix for the outputs handled by the given 'key'.
    * Throws an exception if the prefix type of 'key' is invalid.
    *
-   * @param {PbKeyset.Key} key
+   * @param {!PbKeyset.Key} key
    *
    * @return {!Uint8Array}
    */
@@ -63,7 +63,7 @@ class CryptoFormat {
    * @return {!Uint8Array}
    */
   static makeOutputPrefix_(keyId, keyTypeIdentifier) {
-    let /** Array */ res = [keyTypeIdentifier];
+    let /** !Array */ res = [keyTypeIdentifier];
     res = res.concat(CryptoFormat.numberAsBigEndian_(keyId));
     return new Uint8Array(res);
   }

--- a/javascript/crypto_format_test.js
+++ b/javascript/crypto_format_test.js
@@ -39,7 +39,7 @@ testSuite({
 
     try {
       CryptoFormat.getOutputPrefix(key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: Unsupported key prefix type.', e.toString());
       return;
     }
@@ -57,7 +57,7 @@ testSuite({
       key.setKeyId(invalidKeyIds[i]);
       try {
         CryptoFormat.getOutputPrefix(key);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals('CustomError: Number has to be unsigned 32-bit integer.',
             e.toString());
         continue;

--- a/javascript/crypto_format_test.js
+++ b/javascript/crypto_format_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.CryptoFormatTest');
 goog.setTestOnly('tink.CryptoFormatTest');
@@ -43,7 +43,7 @@ testSuite({
 
     try {
       CryptoFormat.getOutputPrefix(key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: Unsupported key prefix type.', e.toString());
       return;
     }
@@ -61,7 +61,7 @@ testSuite({
       key.setKeyId(invalidKeyIds[i]);
       try {
         CryptoFormat.getOutputPrefix(key);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals('CustomError: Number has to be unsigned 32-bit integer.',
             e.toString());
         continue;

--- a/javascript/crypto_format_test.js
+++ b/javascript/crypto_format_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.CryptoFormatTest');
 goog.setTestOnly('tink.CryptoFormatTest');
 

--- a/javascript/hybrid/BUILD.bazel
+++ b/javascript/hybrid/BUILD.bazel
@@ -6,7 +6,7 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
 
 closure_js_library(
     name = "hybrid",
@@ -23,6 +23,7 @@ closure_js_library(
 
 closure_js_library(
     name = "util_and_validators",
+    #lenient = True,
     srcs = [
         "ecies_aead_hkdf_util.js",
         "ecies_aead_hkdf_validators.js",
@@ -40,6 +41,7 @@ closure_js_library(
 
 closure_js_library(
     name = "registry_ecies_aead_hkdf_dem_helper",
+    #lenient = True,
     srcs = [
         "registry_ecies_aead_hkdf_dem_helper.js",
     ],
@@ -58,6 +60,7 @@ closure_js_library(
 
 closure_js_library(
     name = "ecies_aead_hkdf_key_managers",
+    #lenient = True,
     srcs = [
         "ecies_aead_hkdf_private_key_manager.js",
         "ecies_aead_hkdf_public_key_manager.js",
@@ -80,6 +83,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hybrid_catalogues",
+    #lenient = True,
     srcs = [
         "hybrid_decrypt_catalogue.js",
         "hybrid_encrypt_catalogue.js",
@@ -96,6 +100,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hybrid_config",
+    #lenient = True,
     srcs = [
         "hybrid_config.js",
     ],
@@ -113,6 +118,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hybrid_key_templates",
+    #lenient = True,
     srcs = [
         "hybrid_key_templates.js",
     ],
@@ -128,6 +134,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hybrid_wrappers",
+    #lenient = True,
     srcs = [
         "hybrid_decrypt_wrapper.js",
         "hybrid_encrypt_wrapper.js",
@@ -146,21 +153,44 @@ closure_js_library(
 
 # test
 
-closure_js_library(
+closure_js_test(
     name = "test_lib",
     testonly = 1,
+    #lenient = True,
     srcs = glob([
         "*_test.js",
     ]),
+    entry_points = {
+        "ecies_aead_hkdf_private_key_manager_test.js": ["tink.hybrid.EciesAeadHkdfPrivateKeyManagerTest"],
+        "ecies_aead_hkdf_public_key_manager_test.js": ["tink.hybrid.EciesAeadHkdfPublicKeyManagerTest"],
+        "ecies_aead_hkdf_util_test.js": ["tink.hybrid.EciesAeadHkdfUtilTest"],
+        "ecies_aead_hkdf_validators_test.js": ["tink.hybrid.EciesAeadHkdfValidatorsTest"],
+        "hybrid_config_test.js": ["tink.hybrid.HybridConfigTest"],
+        "hybrid_decrypt_catalogue_test.js": ["tink.hybrid.HybridDecryptCatalogueTest"],
+        "hybrid_decrypt_wrapper_test.js": ["tink.hybrid.HybridDecryptWrapperTest"],
+        "hybrid_encrypt_catalogue_test.js": ["tink.hybrid.HybridEncryptCatalogueTest"],
+        "hybrid_encrypt_wrapper_test.js": ["tink.hybrid.HybridEncryptWrapperTest"],
+        "hybrid_key_templates_test.js": ["tink.hybrid.HybridKeyTemplatesTest"],
+        "registry_ecies_aead_hkdf_dem_helper_test.js": ["tink.hybrid.RegistryEciesAeadHkdfDemHelperTest"],
+    },
     deps = [
+        "//javascript/aead",
+        "//javascript/exception",
+        "//javascript/hybrid",
+        "//javascript/subtle",
+        "//javascript:crypto_format",
+        "//javascript:keyset_handle",
+        "//javascript:key_manager",
+        "//javascript:primitive_set",
+        "//javascript:primitives",
+        "//javascript:registry",
+        "//javascript:util",
         "//proto:aes_ctr_closure_proto",
         "//proto:common_closure_proto",
         "//proto:ecies_aead_hkdf_closure_proto",
         "//proto:tink_closure_proto",
         "@io_bazel_rules_closure//closure/library",
-        "@io_bazel_rules_closure//closure/library/testing:asserts",
-        "@io_bazel_rules_closure//closure/library/testing:jsunit",
-        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+        "@io_bazel_rules_closure//closure/library:testing",
         "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager.js
@@ -161,7 +161,7 @@ class EciesAeadHkdfPrivateKeyFactory {
     let /** !PbEciesAeadHkdfKeyFormat */ keyFormatProto;
     try {
       keyFormatProto = PbEciesAeadHkdfKeyFormat.deserializeBinary(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' +
           EciesAeadHkdfPrivateKeyManager.KEY_TYPE + ' key format proto.');
@@ -279,10 +279,10 @@ class EciesAeadHkdfPrivateKeyManager {
    * @return {!PbEciesAeadHkdfPrivateKey}
    */
   static deserializePrivateKey_(serializedPrivateKey) {
-    let /** PbEciesAeadHkdfPrivateKey */ key;
+    let /** !PbEciesAeadHkdfPrivateKey */ key;
     try {
       key = PbEciesAeadHkdfPrivateKey.deserializeBinary(serializedPrivateKey);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' +
           EciesAeadHkdfPrivateKeyManager.KEY_TYPE + ' key-proto.');

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager.js
@@ -96,9 +96,9 @@ class EciesAeadHkdfPrivateKeyFactory {
     const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
 
     const jsonPublicKey =
-        await EllipticCurves.exportCryptoKey(/** @type {?} */ (keyPair).publicKey);
+        await EllipticCurves.exportCryptoKey((keyPair).publicKey);
     const jsonPrivateKey =
-        await EllipticCurves.exportCryptoKey(/** @type {?} */ (keyPair).privateKey);
+        await EllipticCurves.exportCryptoKey((keyPair).privateKey);
     return EciesAeadHkdfPrivateKeyFactory.jsonToProtoKey_(
         jsonPrivateKey, jsonPublicKey, params);
   }
@@ -177,7 +177,7 @@ class EciesAeadHkdfPrivateKeyFactory {
 
 
 /**
- * @implements {KeyManager.KeyManager<HybridDecrypt>}
+ * @implements {KeyManager.KeyManager<!HybridDecrypt>}
  * @final
  */
 class EciesAeadHkdfPrivateKeyManager {

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.EciesAeadHkdfPrivateKeyManagerTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfPrivateKeyManagerTest');
@@ -78,7 +78,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullKeyFormat(), e.toString());
     }
   },
@@ -90,7 +90,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -102,7 +102,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyFormat(), e.toString());
     }
   },
@@ -114,7 +114,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidKeyFormatMissingParams(), e.toString());
     }
   },
@@ -128,7 +128,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
     invalidFormat.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -138,7 +138,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     invalidFormat.getParams().setKemParams(createKemParams());
@@ -150,7 +150,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(templateTypeUrl), e.toString());
     }
@@ -181,7 +181,7 @@ testSuite({
         fail(
             'An exception should be thrown for the string: ' +
             serializedKeyFormats[i]);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
         continue;
       }
@@ -216,7 +216,7 @@ testSuite({
       const factory = /** @type {!KeyManager.PrivateKeyFactory} */ (
           manager.getKeyFactory());
       factory.getPublicKeyData(privateKey);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -252,7 +252,7 @@ testSuite({
     try {
       await manager.getPrimitive(HybridEncrypt, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -267,7 +267,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -280,7 +280,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -295,7 +295,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -311,7 +311,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getPublicKey().getParams().setKemParams(createKemParams());
@@ -323,7 +323,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(templateTypeUrl), e.toString());
     }
@@ -343,7 +343,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }
@@ -357,10 +357,10 @@ testSuite({
     for (let keyFormat of keyFormats) {
       const key = await privateKeyManager.getKeyFactory().newKey(keyFormat);
 
-      const /** !HybridEncrypt */ hybridEncrypt =
+      const /** HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, key.getPublicKey());
-      const /** !HybridDecrypt */ hybridDecrypt =
+      const /** HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, key);
 
@@ -385,10 +385,10 @@ testSuite({
           privateKeyManager.getKeyFactory());
       const publicKeyData = factory.getPublicKeyData(keyData.getValue_asU8());
 
-      const /** !HybridEncrypt */ hybridEncrypt =
+      const /** HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, publicKeyData);
-      const /** !HybridDecrypt */ hybridDecrypt =
+      const /** HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
 

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
@@ -357,10 +357,10 @@ testSuite({
     for (let keyFormat of keyFormats) {
       const key = await privateKeyManager.getKeyFactory().newKey(keyFormat);
 
-      const /** HybridEncrypt */ hybridEncrypt =
+      const /** !HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, key.getPublicKey());
-      const /** HybridDecrypt */ hybridDecrypt =
+      const /** !HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, key);
 
@@ -385,10 +385,10 @@ testSuite({
           privateKeyManager.getKeyFactory());
       const publicKeyData = factory.getPublicKeyData(keyData.getValue_asU8());
 
-      const /** HybridEncrypt */ hybridEncrypt =
+      const /** !HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, publicKeyData);
-      const /** HybridDecrypt */ hybridDecrypt =
+      const /** !HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
 

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
@@ -74,7 +74,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullKeyFormat(), e.toString());
     }
   },
@@ -86,7 +86,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -98,7 +98,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyFormat(), e.toString());
     }
   },
@@ -110,7 +110,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidKeyFormatMissingParams(), e.toString());
     }
   },
@@ -124,7 +124,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
     invalidFormat.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -134,7 +134,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     invalidFormat.getParams().setKemParams(createKemParams());
@@ -146,7 +146,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(templateTypeUrl), e.toString());
     }
@@ -177,7 +177,7 @@ testSuite({
         fail(
             'An exception should be thrown for the string: ' +
             serializedKeyFormats[i]);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
         continue;
       }
@@ -212,7 +212,7 @@ testSuite({
       const factory = /** @type {!KeyManager.PrivateKeyFactory} */ (
           manager.getKeyFactory());
       factory.getPublicKeyData(privateKey);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -248,7 +248,7 @@ testSuite({
     try {
       await manager.getPrimitive(HybridEncrypt, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -263,7 +263,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -276,7 +276,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -291,7 +291,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -307,7 +307,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getPublicKey().getParams().setKemParams(createKemParams());
@@ -319,7 +319,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(templateTypeUrl), e.toString());
     }
@@ -339,7 +339,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }
@@ -353,10 +353,10 @@ testSuite({
     for (let keyFormat of keyFormats) {
       const key = await privateKeyManager.getKeyFactory().newKey(keyFormat);
 
-      const /** HybridEncrypt */ hybridEncrypt =
+      const /** !HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, key.getPublicKey());
-      const /** HybridDecrypt */ hybridDecrypt =
+      const /** !HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, key);
 
@@ -381,10 +381,10 @@ testSuite({
           privateKeyManager.getKeyFactory());
       const publicKeyData = factory.getPublicKeyData(keyData.getValue_asU8());
 
-      const /** HybridEncrypt */ hybridEncrypt =
+      const /** !HybridEncrypt */ hybridEncrypt =
           await publicKeyManager.getPrimitive(
               PUBLIC_KEY_MANAGER_PRIMITIVE, publicKeyData);
-      const /** HybridDecrypt */ hybridDecrypt =
+      const /** !HybridDecrypt */ hybridDecrypt =
           await privateKeyManager.getPrimitive(
               PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
 

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.EciesAeadHkdfPrivateKeyManagerTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfPrivateKeyManagerTest');
 

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager.js
@@ -138,10 +138,10 @@ class EciesAeadHkdfPublicKeyManager {
           'manager supports ' + EciesAeadHkdfPublicKeyManager.KEY_TYPE + '.');
     }
 
-    let /** PbEciesAeadHkdfPublicKey */ key;
+    let /** !PbEciesAeadHkdfPublicKey */ key;
     try {
       key = PbEciesAeadHkdfPublicKey.deserializeBinary(keyData.getValue());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' +
           EciesAeadHkdfPublicKeyManager.KEY_TYPE + ' key-proto.');

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager.js
@@ -50,7 +50,7 @@ class EciesAeadHkdfPublicKeyFactory {
 
 
 /**
- * @implements {KeyManager.KeyManager<HybridEncrypt>}
+ * @implements {KeyManager.KeyManager<!HybridEncrypt>}
  * @final
  */
 class EciesAeadHkdfPublicKeyManager {

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.EciesAeadHkdfPublicKeyManagerTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfPublicKeyManagerTest');
@@ -71,7 +71,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -82,7 +82,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKeyData();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -94,20 +94,20 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
 
   async testGetPrimitive_unsupportedKeyDataType() {
     const manager = new EciesAeadHkdfPublicKeyManager();
-    const /** !PbKeyData */ keyData = await createKeyData();
+    const /** PbKeyData */ keyData = await createKeyData();
     keyData.setTypeUrl('unsupported_key_type_url');
 
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -120,7 +120,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -134,7 +134,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -147,7 +147,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingParams(), e.toString());
     }
   },
@@ -161,7 +161,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
     key.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -171,7 +171,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getParams().setKemParams(createKemParams());
@@ -182,7 +182,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyTemplate(typeUrl), e.toString());
     }
   },
@@ -195,7 +195,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
     key.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -205,7 +205,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getParams().setKemParams(createKemParams());
@@ -216,7 +216,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyTemplate(typeUrl), e.toString());
     }
   },
@@ -232,7 +232,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }
@@ -244,7 +244,7 @@ testSuite({
     const keys = await createTestSetOfKeys();
 
     for (let key of keys) {
-      const /** !HybridEncrypt */ primitive =
+      const /** HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -259,7 +259,7 @@ testSuite({
     const keyDatas = await createTestSetOfKeyDatas();
 
     for (let key of keyDatas) {
-      const /** !HybridEncrypt */ primitive =
+      const /** HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -489,7 +489,7 @@ const createTestSetOfKeys = async function() {
       [AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes256Gcm()];
   const pointFormats = [PbPointFormat.UNCOMPRESSED];
 
-  const /** !Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
+  const /** Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
   for (let curve of curveTypes) {
     for (let hkdfHash of hashTypes) {
       for (let keyTemplate of keyTemplates) {
@@ -510,7 +510,7 @@ const createTestSetOfKeys = async function() {
 const createTestSetOfKeyDatas = async function() {
   const keys = await createTestSetOfKeys();
 
-  const /** !Array<!PbKeyData> */ keyDatas = [];
+  const /** Array<!PbKeyData> */ keyDatas = [];
   for (let key of keys) {
     const keyData = await createKeyDataFromKey(key);
     keyDatas.push(keyData);

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
@@ -67,7 +67,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -78,7 +78,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKeyData();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -90,20 +90,20 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
 
   async testGetPrimitive_unsupportedKeyDataType() {
     const manager = new EciesAeadHkdfPublicKeyManager();
-    const /** PbKeyData */ keyData = await createKeyData();
+    const /** !PbKeyData */ keyData = await createKeyData();
     keyData.setTypeUrl('unsupported_key_type_url');
 
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -116,7 +116,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -130,7 +130,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -143,7 +143,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingParams(), e.toString());
     }
   },
@@ -157,7 +157,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
     key.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -167,7 +167,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getParams().setKemParams(createKemParams());
@@ -178,7 +178,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyTemplate(typeUrl), e.toString());
     }
   },
@@ -191,7 +191,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
     key.getParams().setEcPointFormat(PbPointFormat.UNCOMPRESSED);
@@ -201,7 +201,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
     key.getParams().setKemParams(createKemParams());
@@ -212,7 +212,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyTemplate(typeUrl), e.toString());
     }
   },
@@ -228,7 +228,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }
@@ -240,7 +240,7 @@ testSuite({
     const keys = await createTestSetOfKeys();
 
     for (let key of keys) {
-      const /** HybridEncrypt */ primitive =
+      const /** !HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -255,7 +255,7 @@ testSuite({
     const keyDatas = await createTestSetOfKeyDatas();
 
     for (let key of keyDatas) {
-      const /** HybridEncrypt */ primitive =
+      const /** !HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -485,7 +485,7 @@ const createTestSetOfKeys = async function() {
       [AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes256Gcm()];
   const pointFormats = [PbPointFormat.UNCOMPRESSED];
 
-  const /** Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
+  const /** !Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
   for (let curve of curveTypes) {
     for (let hkdfHash of hashTypes) {
       for (let keyTemplate of keyTemplates) {
@@ -506,7 +506,7 @@ const createTestSetOfKeys = async function() {
 const createTestSetOfKeyDatas = async function() {
   const keys = await createTestSetOfKeys();
 
-  const /** Array<!PbKeyData> */ keyDatas = [];
+  const /** !Array<!PbKeyData> */ keyDatas = [];
   for (let key of keys) {
     const keyData = await createKeyDataFromKey(key);
     keyDatas.push(keyData);

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.EciesAeadHkdfPublicKeyManagerTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfPublicKeyManagerTest');
 

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.js
@@ -101,7 +101,7 @@ testSuite({
 
   async testGetPrimitive_unsupportedKeyDataType() {
     const manager = new EciesAeadHkdfPublicKeyManager();
-    const /** PbKeyData */ keyData = await createKeyData();
+    const /** !PbKeyData */ keyData = await createKeyData();
     keyData.setTypeUrl('unsupported_key_type_url');
 
     try {
@@ -244,7 +244,7 @@ testSuite({
     const keys = await createTestSetOfKeys();
 
     for (let key of keys) {
-      const /** HybridEncrypt */ primitive =
+      const /** !HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -259,7 +259,7 @@ testSuite({
     const keyDatas = await createTestSetOfKeyDatas();
 
     for (let key of keyDatas) {
-      const /** HybridEncrypt */ primitive =
+      const /** !HybridEncrypt */ primitive =
           await manager.getPrimitive(PRIMITIVE, key);
 
       const plaintext = Random.randBytes(10);
@@ -489,7 +489,7 @@ const createTestSetOfKeys = async function() {
       [AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes256Gcm()];
   const pointFormats = [PbPointFormat.UNCOMPRESSED];
 
-  const /** Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
+  const /** !Array<!PbEciesAeadHkdfPublicKey> */ keys = [];
   for (let curve of curveTypes) {
     for (let hkdfHash of hashTypes) {
       for (let keyTemplate of keyTemplates) {
@@ -510,7 +510,7 @@ const createTestSetOfKeys = async function() {
 const createTestSetOfKeyDatas = async function() {
   const keys = await createTestSetOfKeys();
 
-  const /** Array<!PbKeyData> */ keyDatas = [];
+  const /** !Array<!PbKeyData> */ keyDatas = [];
   for (let key of keys) {
     const keyData = await createKeyDataFromKey(key);
     keyDatas.push(keyData);

--- a/javascript/hybrid/ecies_aead_hkdf_util_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_util_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.EciesAeadHkdfUtilTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfUtilTest');
@@ -117,7 +117,7 @@ testSuite({
     try {
       EciesAeadHkdfUtil.getJsonWebKeyFromProto(key.getPublicKey());
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Number needs more bytes to be represented.',
           e.toString());

--- a/javascript/hybrid/ecies_aead_hkdf_util_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_util_test.js
@@ -113,7 +113,7 @@ testSuite({
     try {
       EciesAeadHkdfUtil.getJsonWebKeyFromProto(key.getPublicKey());
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Number needs more bytes to be represented.',
           e.toString());

--- a/javascript/hybrid/ecies_aead_hkdf_util_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_util_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.EciesAeadHkdfUtilTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfUtilTest');
 

--- a/javascript/hybrid/ecies_aead_hkdf_validators_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_validators_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.EciesAeadHkdfValidatorsTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfValidatorsTest');
@@ -61,7 +61,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
   },
@@ -73,7 +73,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -86,7 +86,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownCurveType(), e.toString());
     }
   },
@@ -98,7 +98,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
   },
@@ -110,7 +110,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingAeadTemplate(), e.toString());
     }
   },
@@ -123,7 +123,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(unsupportedTypeUrl),
           e.toString());
@@ -137,7 +137,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
   },
@@ -180,7 +180,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingFormatParams(), e.toString());
     }
   },
@@ -195,7 +195,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
     invalidKeyFormat.getParams().setDemParams(createDemParams());
@@ -206,7 +206,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -217,7 +217,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKeyParams(), e.toString());
     }
   },
@@ -230,7 +230,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -239,7 +239,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -249,7 +249,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
   },
@@ -263,7 +263,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
     invalidPublicKey.getParams().setDemParams(createDemParams());
@@ -274,7 +274,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -288,7 +288,7 @@ testSuite({
       EciesAeadHkdfValidators.validatePublicKey(
           invalidPublicKey, managerVersion);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(managerVersion), e.toString());
     }
@@ -300,7 +300,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingPublicKey(), e.toString());
     }
   },
@@ -311,7 +311,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingKeyParams(), e.toString());
     }
   },
@@ -322,7 +322,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingPrivateKeyValue(), e.toString());
     }
   },
@@ -341,7 +341,7 @@ testSuite({
       EciesAeadHkdfValidators.validatePrivateKey(
           invalidPrivateKey, managerVersion, managerVersion);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(managerVersion), e.toString());
     }

--- a/javascript/hybrid/ecies_aead_hkdf_validators_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_validators_test.js
@@ -57,7 +57,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKemParams(), e.toString());
     }
   },
@@ -69,7 +69,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -82,7 +82,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownCurveType(), e.toString());
     }
   },
@@ -94,7 +94,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
   },
@@ -106,7 +106,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingAeadTemplate(), e.toString());
     }
   },
@@ -119,7 +119,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyTemplate(unsupportedTypeUrl),
           e.toString());
@@ -133,7 +133,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateParams(invalidParams);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownPointFormat(), e.toString());
     }
   },
@@ -176,7 +176,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingFormatParams(), e.toString());
     }
   },
@@ -191,7 +191,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
     invalidKeyFormat.getParams().setDemParams(createDemParams());
@@ -202,7 +202,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -213,7 +213,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKeyParams(), e.toString());
     }
   },
@@ -226,7 +226,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -235,7 +235,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -245,7 +245,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
   },
@@ -259,7 +259,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingDemParams(), e.toString());
     }
     invalidPublicKey.getParams().setDemParams(createDemParams());
@@ -270,7 +270,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHashType(), e.toString());
     }
   },
@@ -284,7 +284,7 @@ testSuite({
       EciesAeadHkdfValidators.validatePublicKey(
           invalidPublicKey, managerVersion);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(managerVersion), e.toString());
     }
@@ -296,7 +296,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingPublicKey(), e.toString());
     }
   },
@@ -307,7 +307,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingKeyParams(), e.toString());
     }
   },
@@ -318,7 +318,7 @@ testSuite({
     try {
       EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingPrivateKeyValue(), e.toString());
     }
   },
@@ -337,7 +337,7 @@ testSuite({
       EciesAeadHkdfValidators.validatePrivateKey(
           invalidPrivateKey, managerVersion, managerVersion);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(managerVersion), e.toString());
     }

--- a/javascript/hybrid/ecies_aead_hkdf_validators_test.js
+++ b/javascript/hybrid/ecies_aead_hkdf_validators_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.EciesAeadHkdfValidatorsTest');
 goog.setTestOnly('tink.hybrid.EciesAeadHkdfValidatorsTest');
 

--- a/javascript/hybrid/hybrid_config_test.js
+++ b/javascript/hybrid/hybrid_config_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridConfigTest');
 goog.setTestOnly('tink.hybrid.HybridConfigTest');
 

--- a/javascript/hybrid/hybrid_config_test.js
+++ b/javascript/hybrid/hybrid_config_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridConfigTest');
 goog.setTestOnly('tink.hybrid.HybridConfigTest');

--- a/javascript/hybrid/hybrid_decrypt_catalogue.js
+++ b/javascript/hybrid/hybrid_decrypt_catalogue.js
@@ -23,7 +23,7 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 /**
  * A catalogue of TINK key managers for hybrid decryption.
  *
- * @implements {Catalogue<HybridDecrypt>}
+ * @implements {Catalogue<!HybridDecrypt>}
  * @final
  */
 class HybridDecryptCatalogue {

--- a/javascript/hybrid/hybrid_decrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_decrypt_catalogue_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridDecryptCatalogueTest');
 goog.setTestOnly('tink.hybrid.HybridDecryptCatalogueTest');
 

--- a/javascript/hybrid/hybrid_decrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_decrypt_catalogue_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridDecryptCatalogueTest');
 goog.setTestOnly('tink.hybrid.HybridDecryptCatalogueTest');
@@ -36,7 +36,7 @@ testSuite({
           EciesAeadHkdfPrivateKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -51,7 +51,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -65,7 +65,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_decrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_decrypt_catalogue_test.js
@@ -32,7 +32,7 @@ testSuite({
           EciesAeadHkdfPrivateKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -47,7 +47,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -61,7 +61,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_decrypt_wrapper.js
+++ b/javascript/hybrid/hybrid_decrypt_wrapper.js
@@ -28,14 +28,14 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 class WrappedHybridDecrypt {
   // The constructor should be @private, but it is not supported by Closure
   // (see https://github.com/google/closure-compiler/issues/2761).
-  /** @param {!PrimitiveSet.PrimitiveSet} hybridDecryptPrimitiveSet */
+  /** @param {!PrimitiveSet.PrimitiveSet<!HybridDecrypt>} hybridDecryptPrimitiveSet */
   constructor(hybridDecryptPrimitiveSet) {
-    /** @private @const {!PrimitiveSet.PrimitiveSet} */
+    /** @private @const {!PrimitiveSet.PrimitiveSet<!HybridDecrypt>} */
     this.primitiveSet_ = hybridDecryptPrimitiveSet;
   }
 
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} hybridDecryptPrimitiveSet
+   * @param {!PrimitiveSet.PrimitiveSet<!HybridDecrypt>} hybridDecryptPrimitiveSet
    * @return {!HybridDecrypt}
    */
   static newHybridDecrypt(hybridDecryptPrimitiveSet) {
@@ -78,7 +78,7 @@ class WrappedHybridDecrypt {
    * returns the ciphertext decrypted by first primitive which succeed. It
    * throws an exception if no entry succeeds.
    *
-   * @param {!Array<!PrimitiveSet.Entry>} primitives
+   * @param {!Array<!PrimitiveSet.Entry<!HybridDecrypt>>} primitives
    * @param {!Uint8Array} ciphertext
    * @param {?Uint8Array=} opt_contextInfo
    *
@@ -106,7 +106,7 @@ class WrappedHybridDecrypt {
 }
 
 /**
- * @implements {PrimitiveWrapper<HybridDecrypt>}
+ * @implements {PrimitiveWrapper<!HybridDecrypt>}
  */
 class HybridDecryptWrapper {
   // The constructor should be @private, but it is not supported by Closure

--- a/javascript/hybrid/hybrid_decrypt_wrapper.js
+++ b/javascript/hybrid/hybrid_decrypt_wrapper.js
@@ -61,7 +61,7 @@ class WrappedHybridDecrypt {
       try {
         decryptedText = await this.tryDecryption_(
             primitives, rawCiphertext, opt_contextInfo);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
       }
 
       if (decryptedText) {
@@ -96,7 +96,7 @@ class WrappedHybridDecrypt {
       let decryptionResult;
       try {
         decryptionResult = await primitive.decrypt(ciphertext, opt_contextInfo);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         continue;
       }
       return decryptionResult;

--- a/javascript/hybrid/hybrid_decrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_decrypt_wrapper_test.js
@@ -34,7 +34,7 @@ testSuite({
     try {
       new HybridDecryptWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
     }
   },
@@ -50,7 +50,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('Should throw an exception');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
   },
@@ -146,7 +146,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
     const decryptedCiphertext =
@@ -175,7 +175,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
   },
@@ -188,7 +188,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullCiphertext(), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_decrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_decrypt_wrapper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridDecryptWrapperTest');
 goog.setTestOnly('tink.hybrid.HybridDecryptWrapperTest');
 

--- a/javascript/hybrid/hybrid_decrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_decrypt_wrapper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridDecryptWrapperTest');
 goog.setTestOnly('tink.hybrid.HybridDecryptWrapperTest');
@@ -38,7 +38,7 @@ testSuite({
     try {
       new HybridDecryptWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
     }
   },
@@ -54,7 +54,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('Should throw an exception');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
   },
@@ -150,7 +150,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
     const decryptedCiphertext =
@@ -179,7 +179,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.cannotBeDecrypted(), e.toString());
     }
   },
@@ -192,7 +192,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullCiphertext(), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_encrypt_catalogue.js
+++ b/javascript/hybrid/hybrid_encrypt_catalogue.js
@@ -23,7 +23,7 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 /**
  * A catalogue of TINK key managers for hybrid encryption.
  *
- * @implements {Catalogue<HybridEncrypt>}
+ * @implements {Catalogue<!HybridEncrypt>}
  * @final
  */
 class HybridEncryptCatalogue {

--- a/javascript/hybrid/hybrid_encrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_encrypt_catalogue_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridEncryptCatalogueTest');
 goog.setTestOnly('tink.hybrid.HybridEncryptCatalogueTest');
@@ -36,7 +36,7 @@ testSuite({
           EciesAeadHkdfPublicKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -51,7 +51,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -65,7 +65,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_encrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_encrypt_catalogue_test.js
@@ -32,7 +32,7 @@ testSuite({
           EciesAeadHkdfPublicKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -47,7 +47,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -61,7 +61,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_encrypt_catalogue_test.js
+++ b/javascript/hybrid/hybrid_encrypt_catalogue_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridEncryptCatalogueTest');
 goog.setTestOnly('tink.hybrid.HybridEncryptCatalogueTest');
 

--- a/javascript/hybrid/hybrid_encrypt_wrapper.js
+++ b/javascript/hybrid/hybrid_encrypt_wrapper.js
@@ -27,14 +27,14 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 class WrappedHybridEncrypt {
   // The constructor should be @private, but it is not supported by Closure
   // (see https://github.com/google/closure-compiler/issues/2761).
-  /** @param {!PrimitiveSet.PrimitiveSet} hybridEncryptPrimitiveSet */
+  /** @param {!PrimitiveSet.PrimitiveSet<!HybridEncrypt>} hybridEncryptPrimitiveSet */
   constructor(hybridEncryptPrimitiveSet) {
-    /** @private @const {!PrimitiveSet.PrimitiveSet} */
+    /** @private @const {!PrimitiveSet.PrimitiveSet<!HybridEncrypt>} */
     this.hybridEncryptPrimitiveSet_ = hybridEncryptPrimitiveSet;
   }
 
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} hybridEncryptPrimitiveSet
+   * @param {!PrimitiveSet.PrimitiveSet<!HybridEncrypt>} hybridEncryptPrimitiveSet
    * @return {!HybridEncrypt}
    */
   static newHybridEncrypt(hybridEncryptPrimitiveSet) {
@@ -62,7 +62,7 @@ class WrappedHybridEncrypt {
 }
 
 /**
- * @implements {PrimitiveWrapper<HybridEncrypt>}
+ * @implements {PrimitiveWrapper<!HybridEncrypt>}
  */
 class HybridEncryptWrapper {
   // The constructor should be @private, but it is not supported by Closure

--- a/javascript/hybrid/hybrid_encrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_encrypt_wrapper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridEncryptWrapperTest');
 goog.setTestOnly('tink.hybrid.HybridEncryptWrapperTest');
 

--- a/javascript/hybrid/hybrid_encrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_encrypt_wrapper_test.js
@@ -31,7 +31,7 @@ testSuite({
     try {
       new HybridEncryptWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
     }
   },
@@ -41,7 +41,7 @@ testSuite({
     try {
       new HybridEncryptWrapper().wrap(primitiveSet);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.primitiveSetWithoutPrimary(), e.toString());
     }
   },
@@ -59,7 +59,7 @@ testSuite({
     try {
       await hybridEncrypt.encrypt(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullPlaintext(), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_encrypt_wrapper_test.js
+++ b/javascript/hybrid/hybrid_encrypt_wrapper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridEncryptWrapperTest');
 goog.setTestOnly('tink.hybrid.HybridEncryptWrapperTest');
@@ -35,7 +35,7 @@ testSuite({
     try {
       new HybridEncryptWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullPrimitiveSet(), e.toString());
     }
   },
@@ -45,7 +45,7 @@ testSuite({
     try {
       new HybridEncryptWrapper().wrap(primitiveSet);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.primitiveSetWithoutPrimary(), e.toString());
     }
   },
@@ -63,7 +63,7 @@ testSuite({
     try {
       await hybridEncrypt.encrypt(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullPlaintext(), e.toString());
     }
   },

--- a/javascript/hybrid/hybrid_key_templates.js
+++ b/javascript/hybrid/hybrid_key_templates.js
@@ -89,7 +89,7 @@ class HybridKeyTemplates {
  * @param {PbEllipticCurveType} curveType
  * @param {PbHashType} hkdfHash
  * @param {PbPointFormat} pointFormat
- * @param {PbKeyTemplate} demKeyTemplate
+ * @param {!PbKeyTemplate} demKeyTemplate
  * @param {!Uint8Array} hkdfSalt
  *
  * @return {!PbKeyTemplate}
@@ -115,7 +115,7 @@ const createEciesAeadHkdfKeyTemplate_ = function(
  * @param {PbEllipticCurveType} curveType
  * @param {PbHashType} hkdfHash
  * @param {PbPointFormat} pointFormat
- * @param {PbKeyTemplate} demKeyTemplate
+ * @param {!PbKeyTemplate} demKeyTemplate
  * @param {!Uint8Array} hkdfSalt
  *
  * @return {!PbEciesAeadHkdfParams}

--- a/javascript/hybrid/hybrid_key_templates_test.js
+++ b/javascript/hybrid/hybrid_key_templates_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.HybridKeyTemplatesTest');
 goog.setTestOnly('tink.hybrid.HybridKeyTemplatesTest');
 

--- a/javascript/hybrid/hybrid_key_templates_test.js
+++ b/javascript/hybrid/hybrid_key_templates_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.HybridKeyTemplatesTest');
 goog.setTestOnly('tink.hybrid.HybridKeyTemplatesTest');

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper.js
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper.js
@@ -81,6 +81,7 @@ class RegistryEciesAeadHkdfDemHelper {
 
   /**
    * @override
+   * @suppress {reportUnknownTypes}
    */
   async getAead(symmetricKey) {
     if (symmetricKey.length != this.demKeySize_) {

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper.js
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper.js
@@ -111,7 +111,7 @@ class RegistryEciesAeadHkdfDemHelper {
     let /** @type{!PbAesGcmKeyFormat} */ keyFormat;
     try {
       keyFormat = PbAesGcmKeyFormat.deserializeBinary(keyTemplate.getValue());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Could not parse the given Uint8Array as a serialized proto of ' +
           AeadConfig.AES_GCM_TYPE_URL + '.');
@@ -136,7 +136,7 @@ class RegistryEciesAeadHkdfDemHelper {
     try {
       keyFormat =
           PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyTemplate.getValue());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Could not parse the given Uint8Array ' +
           'as a serialized proto of ' + AeadConfig.AES_CTR_HMAC_AEAD_TYPE_URL +

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.hybrid.RegistryEciesAeadHkdfDemHelperTest');
 goog.setTestOnly('tink.hybrid.RegistryEciesAeadHkdfDemHelperTest');
@@ -47,7 +47,7 @@ testSuite({
     try {
       new RegistryEciesAeadHkdfDemHelper(template);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedTypeUrl(template.getTypeUrl()),
           e.toString());
@@ -69,7 +69,7 @@ testSuite({
         try {
           new RegistryEciesAeadHkdfDemHelper(template);
           fail('An exception should be thrown.');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
           assertEquals(
               ExceptionText.invalidKeyFormat(template.getTypeUrl()),
               e.toString());
@@ -128,7 +128,7 @@ testSuite({
     try {
       await helper.getAead(new Uint8Array(keyLength));
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.invalidKeyLength(expectedKeyLength, keyLength),
           e.toString());

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
@@ -43,7 +43,7 @@ testSuite({
     try {
       new RegistryEciesAeadHkdfDemHelper(template);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedTypeUrl(template.getTypeUrl()),
           e.toString());
@@ -65,7 +65,7 @@ testSuite({
         try {
           new RegistryEciesAeadHkdfDemHelper(template);
           fail('An exception should be thrown.');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
           assertEquals(
               ExceptionText.invalidKeyFormat(template.getTypeUrl()),
               e.toString());
@@ -124,7 +124,7 @@ testSuite({
     try {
       await helper.getAead(new Uint8Array(keyLength));
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.invalidKeyLength(expectedKeyLength, keyLength),
           e.toString());

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.hybrid.RegistryEciesAeadHkdfDemHelperTest');
 goog.setTestOnly('tink.hybrid.RegistryEciesAeadHkdfDemHelperTest');
 

--- a/javascript/keyset_handle.js
+++ b/javascript/keyset_handle.js
@@ -151,6 +151,7 @@ class KeysetHandle {
    * @param {?KeyManager.KeyManager<P>=} opt_customKeyManager
    *
    * @return {!Promise<!P>}
+   * @suppress {reportUnknownTypes}
    */
   async getPrimitive(primitiveType, opt_customKeyManager) {
     if (!primitiveType) {
@@ -175,6 +176,7 @@ class KeysetHandle {
    * @param {?KeyManager.KeyManager<P>=} opt_customKeyManager
    *
    * @return {!Promise.<!PrimitiveSet.PrimitiveSet<P>>}
+   * @suppress {reportUnknownTypes}
    */
   async getPrimitiveSet_(primitiveType, opt_customKeyManager) {
     const primitiveSet = new PrimitiveSet.PrimitiveSet(primitiveType);

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -669,10 +669,10 @@ const createKeysetAndInitializeRegistry = function(
     // they are quite rarely added into the Keyset.
     const key = createKey(i, outputPrefix, keyType, /* enabled = */ i % 7 < 6);
     keyset.addKey(key);
+  }
 
     keyset.setPrimaryKeyId(1);
     return keyset;
-  }
 };
 
 /**

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.KeysetHandleTest');
 goog.setTestOnly('tink.KeysetHandleTest');
@@ -61,7 +61,7 @@ testSuite({
   async testConstructorNullKeyset() {
     try {
       new KeysetHandle(null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Keyset should be non null and must contain at least one key.',
           e.toString());
@@ -75,7 +75,7 @@ testSuite({
     keyset.setKeyList([]);
     try {
       new KeysetHandle(keyset);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Keyset should be non null and must contain at least one key.',
           e.toString());
@@ -105,7 +105,7 @@ testSuite({
   async testRead() {
     try {
       await KeysetHandle.read(null, null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: KeysetHandle -- read: Not implemented yet.',
           e.toString());
@@ -144,7 +144,7 @@ testSuite({
 
     try {
       await keysetHandle.write(null, null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: KeysetHandle -- write: Not implemented yet.',
           e.toString());
@@ -163,7 +163,7 @@ testSuite({
     try {
       await keysetHandle.getPrimitive(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: primitive type must be non-null', e.toString());
     }
@@ -254,7 +254,7 @@ testSuite({
     try {
       await aeadFromRegistry.decrypt(ciphertext);
       fail('An exception should be thrown here.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Decryption failed for the given ciphertext.',
           e.toString());
@@ -374,7 +374,7 @@ testSuite({
     try {
       await hybridDecryptFromRegistry.decrypt(ciphertext);
       fail('An exception should be thrown here.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Decryption failed for the given ciphertext.',
           e.toString());
@@ -412,7 +412,7 @@ testSuite({
     try {
       await keysetHandle.getPrimitive(Aead);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Requested primitive type which is not supported by ' +
               'this key manager.',
@@ -553,7 +553,7 @@ testSuite({
       try {
         KeysetHandle.readNoSecret(reader);
         fail('An exception should be thrown.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             'CustomError: Keyset contains secret key material.', e.toString());
       }

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes, reportUnknownTypes}
+ * @suppress {checkTypes, reportUnknownTypes, visibility}
  */
 goog.module('tink.KeysetHandleTest');
 goog.setTestOnly('tink.KeysetHandleTest');
@@ -671,8 +671,8 @@ const createKeysetAndInitializeRegistry = function(
     keyset.addKey(key);
   }
 
-    keyset.setPrimaryKeyId(1);
-    return keyset;
+  keyset.setPrimaryKeyId(1);
+  return keyset;
 };
 
 /**
@@ -799,11 +799,6 @@ class DummyKeyManager {
      * @private @const {!Object}
      */
     this.PRIMITIVE_ = primitive;
-
-    /**
-     * @private @const {!KeyManager.KeyFactory}
-     */
-    this.KEY_FACTORY_ = new DummyKeyFactory();
 
     /**
      * @private @const {!Object}

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -801,6 +801,12 @@ class DummyKeyManager {
     this.PRIMITIVE_ = primitive;
 
     /**
+     * @private @const {!KeyManager.KeyFactory}
+     * @suppress {unusedPrivateMembers}
+     */
+    this.KEY_FACTORY_ = new DummyKeyFactory();
+
+    /**
      * @private @const {!Object}
      */
     this.PRIMITIVE_TYPE_ = primitiveType;

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.KeysetHandleTest');
 goog.setTestOnly('tink.KeysetHandleTest');
 

--- a/javascript/keyset_handle_test.js
+++ b/javascript/keyset_handle_test.js
@@ -57,7 +57,7 @@ testSuite({
   async testConstructorNullKeyset() {
     try {
       new KeysetHandle(null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Keyset should be non null and must contain at least one key.',
           e.toString());
@@ -71,7 +71,7 @@ testSuite({
     keyset.setKeyList([]);
     try {
       new KeysetHandle(keyset);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Keyset should be non null and must contain at least one key.',
           e.toString());
@@ -101,7 +101,7 @@ testSuite({
   async testRead() {
     try {
       await KeysetHandle.read(null, null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: KeysetHandle -- read: Not implemented yet.',
           e.toString());
@@ -140,7 +140,7 @@ testSuite({
 
     try {
       await keysetHandle.write(null, null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: KeysetHandle -- write: Not implemented yet.',
           e.toString());
@@ -159,7 +159,7 @@ testSuite({
     try {
       await keysetHandle.getPrimitive(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: primitive type must be non-null', e.toString());
     }
@@ -250,7 +250,7 @@ testSuite({
     try {
       await aeadFromRegistry.decrypt(ciphertext);
       fail('An exception should be thrown here.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Decryption failed for the given ciphertext.',
           e.toString());
@@ -370,7 +370,7 @@ testSuite({
     try {
       await hybridDecryptFromRegistry.decrypt(ciphertext);
       fail('An exception should be thrown here.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Decryption failed for the given ciphertext.',
           e.toString());
@@ -408,7 +408,7 @@ testSuite({
     try {
       await keysetHandle.getPrimitive(Aead);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Requested primitive type which is not supported by ' +
               'this key manager.',
@@ -549,7 +549,7 @@ testSuite({
       try {
         KeysetHandle.readNoSecret(reader);
         fail('An exception should be thrown.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             'CustomError: Keyset contains secret key material.', e.toString());
       }

--- a/javascript/primitive_set.js
+++ b/javascript/primitive_set.js
@@ -33,6 +33,7 @@ class Entry {
    * @param {!Uint8Array} identifier
    * @param {!PbKeyStatusType} keyStatus
    * @param {!PbOutputPrefixType} outputPrefixType
+   * @suppress {reportUnknownTypes}
    */
   constructor(primitive, identifier, keyStatus, outputPrefixType) {
     /** @const @private {!P} */
@@ -47,6 +48,7 @@ class Entry {
 
   /**
    * @return {!P}
+   * @suppress {reportUnknownTypes}
    */
   getPrimitive() {
     return this.primitive_;
@@ -101,17 +103,17 @@ class PrimitiveSet {
    */
   constructor(primitiveType) {
     /**
-     * @private {!Object}
+     * @const @private {!Object}
      */
     this.primitiveType_ = primitiveType;
     /**
-     * @private {?Entry<P>}
+     * @private {?Entry<!P>}
      */
     this.primary_ = null;
     // Keys have to be stored as strings as two Uint8Arrays holding the same
     // digits are still different objects.
     /**
-     * @private {!Map<string, !Array<!Entry<P>>>}
+     * @const @private {!Map<string, !Array<!Entry<!P>>>}
      */
     this.identifierToPrimitivesMap_ = new Map();
   }
@@ -132,6 +134,7 @@ class PrimitiveSet {
    * @param {!PbKeyset.Key} key
    *
    * @return {!Entry<P>}
+   * @suppress {reportUnknownTypes}
    */
   addPrimitive(primitive, key) {
     if (!primitive) {

--- a/javascript/primitive_set_test.js
+++ b/javascript/primitive_set_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.PrimitiveSetTest');
 goog.setTestOnly('tink.PrimitiveSetTest');
@@ -40,7 +40,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownPrefixType(), e.toString());
       return;
     }
@@ -54,7 +54,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.addingNullPrimitive(), e.toString());
       return;
     }
@@ -67,7 +67,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.addingNullKey(), e.toString());
       return;
     }
@@ -76,8 +76,7 @@ testSuite({
 
   testAddPrimitiveMultipleTimesShouldWork() {
     const key = createKey();
-    const /** !PrimitiveSet.PrimitiveSet<!Aead> */ primitiveSet =
-      new PrimitiveSet.PrimitiveSet(Aead);
+    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
 
     for (let i = 0; i < 4; i++) {
       let primitive;
@@ -211,7 +210,7 @@ testSuite({
     const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
     try {
       primitiveSet.setPrimary(null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.setPrimaryToNull(), e.toString());
       return;
     }
@@ -226,7 +225,7 @@ testSuite({
 
     try {
       primitiveSet.setPrimary(entry);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.setPrimaryToMissingEntry(), e.toString());
       return;
     }
@@ -242,7 +241,7 @@ testSuite({
 
     try {
       primitiveSet.setPrimary(primary);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.setPrimaryToDisabled(), e.toString());
       return;
     }

--- a/javascript/primitive_set_test.js
+++ b/javascript/primitive_set_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.PrimitiveSetTest');
 goog.setTestOnly('tink.PrimitiveSetTest');
 
@@ -72,7 +76,8 @@ testSuite({
 
   testAddPrimitiveMultipleTimesShouldWork() {
     const key = createKey();
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+    const /** !PrimitiveSet.PrimitiveSet<!Aead> */ primitiveSet =
+      new PrimitiveSet.PrimitiveSet(Aead);
 
     for (let i = 0; i < 4; i++) {
       let primitive;

--- a/javascript/primitive_set_test.js
+++ b/javascript/primitive_set_test.js
@@ -36,7 +36,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownPrefixType(), e.toString());
       return;
     }
@@ -50,7 +50,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.addingNullPrimitive(), e.toString());
       return;
     }
@@ -63,7 +63,7 @@ testSuite({
 
     try {
       primitiveSet.addPrimitive(primitive, null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.addingNullKey(), e.toString());
       return;
     }
@@ -206,7 +206,7 @@ testSuite({
     const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
     try {
       primitiveSet.setPrimary(null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.setPrimaryToNull(), e.toString());
       return;
     }
@@ -221,7 +221,7 @@ testSuite({
 
     try {
       primitiveSet.setPrimary(entry);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.setPrimaryToMissingEntry(), e.toString());
       return;
     }
@@ -237,7 +237,7 @@ testSuite({
 
     try {
       primitiveSet.setPrimary(primary);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.setPrimaryToDisabled(), e.toString());
       return;
     }

--- a/javascript/proto_test.js
+++ b/javascript/proto_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.ProtoTest');
 goog.setTestOnly('tink.ProtoTest');

--- a/javascript/proto_test.js
+++ b/javascript/proto_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.ProtoTest');
 goog.setTestOnly('tink.ProtoTest');
 

--- a/javascript/registry.js
+++ b/javascript/registry.js
@@ -169,6 +169,7 @@ class Registry {
    * @param {?string=} opt_typeUrl -- key type
    *
    * @return {!Promise.<!P>}
+   * @suppress {reportUnknownTypes}
    */
   static async getPrimitive(primitiveType, key, opt_typeUrl) {
     if (key instanceof PbKeyData) {
@@ -229,6 +230,7 @@ class Registry {
    * @param {string} typeUrl
    * @param {!Uint8Array} serializedPrivateKey
    * @return {!PbKeyData}
+   * @suppress {reportUnknownTypes}
    */
   static getPublicKeyData(typeUrl, serializedPrivateKey) {
     const manager = Registry.getKeyManager(typeUrl);
@@ -316,8 +318,9 @@ class Registry {
    * @template P
    * @static
    *
-   * @param {!PrimitiveSet.PrimitiveSet<P>} primitiveSet
+   * @param {!PrimitiveSet.PrimitiveSet<!P>} primitiveSet
    * @return {!P}
+   * @suppress {reportUnknownTypes}
    */
   static wrap(primitiveSet) {
     if (!primitiveSet) {
@@ -334,24 +337,24 @@ class Registry {
 }
 // key managers maps
 /**
- * @static @private {!Map<string,!KeyManager.KeyManager>}
+ * @const @static @private {!Map<string,!KeyManager.KeyManager>}
  *
  */
 Registry.typeToManagerMap_ = new Map();
 /**
- * @static @private {!Map<string,boolean>}
+ * @const @static @private {!Map<string,boolean>}
  */
 Registry.typeToNewKeyAllowedMap_ = new Map();
 
 // catalogues maps
 /**
- * @static @private {!Map<string,!Catalogue>}
+ * @const @static @private {!Map<string,!Catalogue>}
  */
 Registry.nameToCatalogueMap_ = new Map();
 
 // primitive wrappers map
 /**
- * @static @private {!Map<!Object,!PrimitiveWrapper>}
+ * @const @static @private {!Map<!Object,!PrimitiveWrapper>}
  */
 Registry.primitiveTypeToWrapper_ = new Map();
 

--- a/javascript/registry_test.js
+++ b/javascript/registry_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.RegistryTest');
 goog.setTestOnly('tink.RegistryTest');
@@ -62,7 +62,7 @@ testSuite({
   testAddCatalogue_nullCatalogue() {
     try {
       Registry.addCatalogue('some catalogue', null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullCatalogue(), e.toString());
       return;
     }
@@ -72,7 +72,7 @@ testSuite({
   testAddCatalogue_emptyName() {
     try {
       Registry.addCatalogue('', new DummyCatalogue1());
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingCatalogueName(), e.toString());
       return;
     }
@@ -83,7 +83,7 @@ testSuite({
     try {
       Registry.addCatalogue('some catalogue', new DummyCatalogue1());
       Registry.addCatalogue('some catalogue', new DummyCatalogue2());
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.overwrittingCatalogueAttempt(), e.toString());
       return;
     }
@@ -105,7 +105,7 @@ testSuite({
 
     try {
       Registry.getCatalogue(name);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.catalogueMissing(name), e.toString());
       return;
     }
@@ -133,7 +133,7 @@ testSuite({
     try {
       Registry.registerPrimitiveWrapper(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: primitive wrapper cannot be null', e.toString());
     }
@@ -157,7 +157,7 @@ testSuite({
       Registry.registerPrimitiveWrapper(
           new DummyPrimitiveWrapper2(primitive, primitiveType));
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: primitive wrapper for type ' + primitiveType +
               ' has already been registered and cannot be overwritten',
@@ -191,7 +191,7 @@ testSuite({
     try {
       Registry.wrap(new PrimitiveSet.PrimitiveSet(primitiveType));
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: no primitive wrapper found for type ' + primitiveType,
           e.toString());
@@ -203,7 +203,7 @@ testSuite({
   testRegisterKeyManager_emptyManager() {
     try {
       Registry.registerKeyManager(null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullKeyManager(), e.toString());
       return;
     }
@@ -216,7 +216,7 @@ testSuite({
     try {
       Registry.registerKeyManager(new DummyKeyManager1(keyType));
       Registry.registerKeyManager(new DummyKeyManager2(keyType));
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.keyManagerOverwrittingAttempt(keyType), e.toString());
       return;
@@ -240,7 +240,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1, false);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.newKeyForbidden(keyType), e.toString());
       return;
     }
@@ -261,7 +261,7 @@ testSuite({
     try {
       Registry.registerKeyManager(keyManager1);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.prohibitedChangeToLessRestricted(
               keyManager1.getKeyType()),
@@ -269,7 +269,7 @@ testSuite({
     }
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.newKeyForbidden(keyType), e.toString());
       return;
     }
@@ -306,7 +306,7 @@ testSuite({
 
     try {
       Registry.getKeyManager(keyType);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(keyType), e.toString());
       return;
@@ -325,7 +325,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(differentKeyType),
           e.toString());
@@ -342,7 +342,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1, false);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.newKeyForbidden(keyManager1.getKeyType()),
           e.toString());
@@ -352,7 +352,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyAllowed() {
-    const /** !Array<string> */ keyTypes = [];
+    const /** Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -371,7 +371,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyIsAllowedAutomatically() {
-    const /** !Array<string> */ keyTypes = [];
+    const /** Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -424,7 +424,7 @@ testSuite({
     try {
       await Registry.newKey(keyTemplate);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(notRegisteredKeyType),
           e.toString());
@@ -440,15 +440,15 @@ testSuite({
     try {
       await Registry.newKey(keyTemplate);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.newKeyForbidden(keyManager.getKeyType()), e.toString());
     }
   },
 
   async testNewKey_shouldWork() {
-    const /** !Array<string> */ keyTypes = [];
-    const /** !Array<Uint8Array> */ newKeyMethodResult = [];
+    const /** Array<string> */ keyTypes = [];
+    const /** Array<Uint8Array> */ newKeyMethodResult = [];
     const keyTypesLength = 10;
 
     // Add some keys to Registry.
@@ -513,7 +513,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(null, keyData, anotherType);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.keyTypesAreNotMatching(keyDataType, anotherType),
           e.toString());
@@ -527,7 +527,7 @@ testSuite({
     try {
       await Registry.getPrimitive(null, new PbMessage);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.keyTypeNotDefined(), e.toString());
     }
   },
@@ -539,7 +539,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(null, keyData);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(keyDataType), e.toString());
       return;
@@ -579,7 +579,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(Mac, key, keyData.getTypeUrl());
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertTrue(
           e.toString().includes(ExceptionText.getPrimitiveBadPrimitive()));
       return;
@@ -598,7 +598,7 @@ testSuite({
       try {
         Registry.getPublicKeyData(notPrivateTypeUrl, new Uint8Array(8));
         fail('An exception should be thrown.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(
             ExceptionText.notPrivateKeyFactory(notPrivateTypeUrl),
             e.toString());
@@ -611,7 +611,7 @@ testSuite({
       try {
         Registry.getPublicKeyData(typeUrl, new Uint8Array(10));
         fail('An exception should be thrown.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.couldNotParse(typeUrl), e.toString());
       }
     },
@@ -903,7 +903,7 @@ class DummyKeyFactory {
    * @override
    */
   newKeyData(serializedKeyFormat) {
-    let /** !PbKeyData */ keyData = new PbKeyData();
+    let /** PbKeyData */ keyData = new PbKeyData();
 
     keyData.setTypeUrl(this.KEY_TYPE_);
     keyData.setValue(this.NEW_KEY_METHOD_RESULT_);

--- a/javascript/registry_test.js
+++ b/javascript/registry_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.RegistryTest');
 goog.setTestOnly('tink.RegistryTest');
 

--- a/javascript/registry_test.js
+++ b/javascript/registry_test.js
@@ -352,7 +352,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyAllowed() {
-    const /** Array<string> */ keyTypes = [];
+    const /** !Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -371,7 +371,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyIsAllowedAutomatically() {
-    const /** Array<string> */ keyTypes = [];
+    const /** !Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -447,8 +447,8 @@ testSuite({
   },
 
   async testNewKey_shouldWork() {
-    const /** Array<string> */ keyTypes = [];
-    const /** Array<Uint8Array> */ newKeyMethodResult = [];
+    const /** !Array<string> */ keyTypes = [];
+    const /** !Array<!Uint8Array> */ newKeyMethodResult = [];
     const keyTypesLength = 10;
 
     // Add some keys to Registry.
@@ -903,7 +903,7 @@ class DummyKeyFactory {
    * @override
    */
   newKeyData(serializedKeyFormat) {
-    let /** PbKeyData */ keyData = new PbKeyData();
+    let /** !PbKeyData */ keyData = new PbKeyData();
 
     keyData.setTypeUrl(this.KEY_TYPE_);
     keyData.setValue(this.NEW_KEY_METHOD_RESULT_);

--- a/javascript/registry_test.js
+++ b/javascript/registry_test.js
@@ -58,7 +58,7 @@ testSuite({
   testAddCatalogue_nullCatalogue() {
     try {
       Registry.addCatalogue('some catalogue', null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullCatalogue(), e.toString());
       return;
     }
@@ -68,7 +68,7 @@ testSuite({
   testAddCatalogue_emptyName() {
     try {
       Registry.addCatalogue('', new DummyCatalogue1());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingCatalogueName(), e.toString());
       return;
     }
@@ -79,7 +79,7 @@ testSuite({
     try {
       Registry.addCatalogue('some catalogue', new DummyCatalogue1());
       Registry.addCatalogue('some catalogue', new DummyCatalogue2());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.overwrittingCatalogueAttempt(), e.toString());
       return;
     }
@@ -101,7 +101,7 @@ testSuite({
 
     try {
       Registry.getCatalogue(name);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.catalogueMissing(name), e.toString());
       return;
     }
@@ -129,7 +129,7 @@ testSuite({
     try {
       Registry.registerPrimitiveWrapper(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: primitive wrapper cannot be null', e.toString());
     }
@@ -153,7 +153,7 @@ testSuite({
       Registry.registerPrimitiveWrapper(
           new DummyPrimitiveWrapper2(primitive, primitiveType));
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: primitive wrapper for type ' + primitiveType +
               ' has already been registered and cannot be overwritten',
@@ -187,7 +187,7 @@ testSuite({
     try {
       Registry.wrap(new PrimitiveSet.PrimitiveSet(primitiveType));
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: no primitive wrapper found for type ' + primitiveType,
           e.toString());
@@ -199,7 +199,7 @@ testSuite({
   testRegisterKeyManager_emptyManager() {
     try {
       Registry.registerKeyManager(null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullKeyManager(), e.toString());
       return;
     }
@@ -212,7 +212,7 @@ testSuite({
     try {
       Registry.registerKeyManager(new DummyKeyManager1(keyType));
       Registry.registerKeyManager(new DummyKeyManager2(keyType));
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.keyManagerOverwrittingAttempt(keyType), e.toString());
       return;
@@ -236,7 +236,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1, false);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.newKeyForbidden(keyType), e.toString());
       return;
     }
@@ -257,7 +257,7 @@ testSuite({
     try {
       Registry.registerKeyManager(keyManager1);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.prohibitedChangeToLessRestricted(
               keyManager1.getKeyType()),
@@ -265,7 +265,7 @@ testSuite({
     }
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.newKeyForbidden(keyType), e.toString());
       return;
     }
@@ -302,7 +302,7 @@ testSuite({
 
     try {
       Registry.getKeyManager(keyType);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(keyType), e.toString());
       return;
@@ -321,7 +321,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(differentKeyType),
           e.toString());
@@ -338,7 +338,7 @@ testSuite({
     Registry.registerKeyManager(keyManager1, false);
     try {
       await Registry.newKeyData(keyTemplate);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.newKeyForbidden(keyManager1.getKeyType()),
           e.toString());
@@ -348,7 +348,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyAllowed() {
-    const /** Array<string> */ keyTypes = [];
+    const /** !Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -367,7 +367,7 @@ testSuite({
   },
 
   async testNewKeyData_newKeyIsAllowedAutomatically() {
-    const /** Array<string> */ keyTypes = [];
+    const /** !Array<string> */ keyTypes = [];
     for (let i = 0; i < 10; i++) {
       keyTypes.push('someKeyType' + i.toString());
     }
@@ -420,7 +420,7 @@ testSuite({
     try {
       await Registry.newKey(keyTemplate);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(notRegisteredKeyType),
           e.toString());
@@ -436,15 +436,15 @@ testSuite({
     try {
       await Registry.newKey(keyTemplate);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.newKeyForbidden(keyManager.getKeyType()), e.toString());
     }
   },
 
   async testNewKey_shouldWork() {
-    const /** Array<string> */ keyTypes = [];
-    const /** Array<Uint8Array> */ newKeyMethodResult = [];
+    const /** !Array<string> */ keyTypes = [];
+    const /** !Array<Uint8Array> */ newKeyMethodResult = [];
     const keyTypesLength = 10;
 
     // Add some keys to Registry.
@@ -509,7 +509,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(null, keyData, anotherType);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.keyTypesAreNotMatching(keyDataType, anotherType),
           e.toString());
@@ -523,7 +523,7 @@ testSuite({
     try {
       await Registry.getPrimitive(null, new PbMessage);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.keyTypeNotDefined(), e.toString());
     }
   },
@@ -535,7 +535,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(null, keyData);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.notRegisteredKeyType(keyDataType), e.toString());
       return;
@@ -575,7 +575,7 @@ testSuite({
 
     try {
       await Registry.getPrimitive(Mac, key, keyData.getTypeUrl());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertTrue(
           e.toString().includes(ExceptionText.getPrimitiveBadPrimitive()));
       return;
@@ -594,7 +594,7 @@ testSuite({
       try {
         Registry.getPublicKeyData(notPrivateTypeUrl, new Uint8Array(8));
         fail('An exception should be thrown.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(
             ExceptionText.notPrivateKeyFactory(notPrivateTypeUrl),
             e.toString());
@@ -607,7 +607,7 @@ testSuite({
       try {
         Registry.getPublicKeyData(typeUrl, new Uint8Array(10));
         fail('An exception should be thrown.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.couldNotParse(typeUrl), e.toString());
       }
     },
@@ -899,7 +899,7 @@ class DummyKeyFactory {
    * @override
    */
   newKeyData(serializedKeyFormat) {
-    let /** PbKeyData */ keyData = new PbKeyData();
+    let /** !PbKeyData */ keyData = new PbKeyData();
 
     keyData.setTypeUrl(this.KEY_TYPE_);
     keyData.setValue(this.NEW_KEY_METHOD_RESULT_);

--- a/javascript/signature/BUILD.bazel
+++ b/javascript/signature/BUILD.bazel
@@ -6,7 +6,7 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
 
 closure_js_library(
     name = "signature",
@@ -22,6 +22,7 @@ closure_js_library(
 
 closure_js_library(
     name = "utils",
+    #lenient = True,
     srcs = [
         "ecdsa_util.js",
     ],
@@ -37,6 +38,7 @@ closure_js_library(
 
 closure_js_library(
     name = "ecdsa_key_managers",
+    #lenient = True,
     srcs = [
         "ecdsa_private_key_manager.js",
         "ecdsa_public_key_manager.js",
@@ -58,6 +60,7 @@ closure_js_library(
 
 closure_js_library(
     name = "wrappers",
+    #lenient = True,
     srcs = [
         "public_key_sign_wrapper.js",
         "public_key_verify_wrapper.js",
@@ -76,6 +79,7 @@ closure_js_library(
 
 closure_js_library(
     name = "catalogues",
+    #lenient = True,
     srcs = [
         "public_key_sign_catalogue.js",
         "public_key_verify_catalogue.js",
@@ -92,6 +96,7 @@ closure_js_library(
 
 closure_js_library(
     name = "config",
+    #lenient = True,
     srcs = [
         "signature_config.js",
     ],
@@ -109,6 +114,7 @@ closure_js_library(
 
 closure_js_library(
     name = "key_templates",
+    #lenient = True,
     srcs = [
         "signature_key_templates.js",
     ],
@@ -123,20 +129,38 @@ closure_js_library(
 
 # test
 
-closure_js_library(
+closure_js_test(
     name = "test_lib",
     testonly = 1,
+    #lenient = True,
     srcs = glob([
         "*_test.js",
     ]),
+    entry_points = {
+        "ecdsa_private_key_manager_test.js": ["tink.signature.EcdsaPrivateKeyManagerTest"],
+        "ecdsa_public_key_manager_test.js": ["tink.signature.EcdsaPublicKeyManagerTest"],
+        "public_key_sign_catalogue_test.js": ["tink.signature.PublicKeySignCatalogueTest"],
+        "public_key_sign_wrapper_test.js": ["tink.signature.PublicKeySignWrapperTest"],
+        "public_key_verify_catalogue_test.js": ["tink.signature.PublicKeyVerifyCatalogueTest"],
+        "public_key_verify_wrapper_test.js": ["tink.signature.PublicKeyVerifyWrapperTest"],
+        "signature_config_test.js": ["tink.signature.SignatureConfigTest"],
+        "signature_key_templates_test.js": ["tink.signature.SignatureKeyTemplatesTest"],
+    },
     deps = [
+        "//javascript/signature",
+        "//javascript/subtle",
+        "//javascript:crypto_format",
+        "//javascript:keyset_handle",
+        "//javascript:key_manager",
+        "//javascript:primitive_set",
+        "//javascript:primitives",
+        "//javascript:registry",
+        "//javascript:util",
         "//proto:common_closure_proto",
         "//proto:ecdsa_closure_proto",
         "//proto:tink_closure_proto",
         "@io_bazel_rules_closure//closure/library",
-        "@io_bazel_rules_closure//closure/library/testing:asserts",
-        "@io_bazel_rules_closure//closure/library/testing:jsunit",
-        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+        "@io_bazel_rules_closure//closure/library:testing",
         "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )

--- a/javascript/signature/ecdsa_private_key_manager.js
+++ b/javascript/signature/ecdsa_private_key_manager.js
@@ -157,7 +157,7 @@ class EcdsaPrivateKeyFactory {
     let /** !PbEcdsaKeyFormat */ keyFormatProto;
     try {
       keyFormatProto = PbEcdsaKeyFormat.deserializeBinary(keyFormat);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' + EcdsaPrivateKeyManager.KEY_TYPE +
           ' key format proto.');
@@ -269,7 +269,7 @@ class EcdsaPrivateKeyManager {
     let /** !PbEcdsaPrivateKey */ key;
     try {
       key = PbEcdsaPrivateKey.deserializeBinary(serializedPrivateKey);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' + EcdsaPrivateKeyManager.KEY_TYPE +
           ' key-proto.');

--- a/javascript/signature/ecdsa_private_key_manager.js
+++ b/javascript/signature/ecdsa_private_key_manager.js
@@ -92,9 +92,9 @@ class EcdsaPrivateKeyFactory {
     const keyPair = await EllipticCurves.generateKeyPair('ECDSA', curveName);
 
     const jsonPublicKey =
-        await EllipticCurves.exportCryptoKey(/** @type {?} */ (keyPair).publicKey);
+        await EllipticCurves.exportCryptoKey((keyPair).publicKey);
     const jsonPrivateKey =
-        await EllipticCurves.exportCryptoKey(/** @type {?} */ (keyPair).privateKey);
+        await EllipticCurves.exportCryptoKey((keyPair).privateKey);
     return EcdsaPrivateKeyFactory.jsonToProtoKey_(
         jsonPrivateKey, jsonPublicKey, params);
   }
@@ -173,7 +173,7 @@ class EcdsaPrivateKeyFactory {
 
 
 /**
- * @implements {KeyManager.KeyManager<PublicKeySign>}
+ * @implements {KeyManager.KeyManager<!PublicKeySign>}
  * @final
  */
 class EcdsaPrivateKeyManager {

--- a/javascript/signature/ecdsa_private_key_manager_test.js
+++ b/javascript/signature/ecdsa_private_key_manager_test.js
@@ -66,7 +66,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.nullKeyFormat(), e.toString());
     }
   },
@@ -78,7 +78,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -90,7 +90,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyFormat(), e.toString());
     }
   },
@@ -102,7 +102,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidKeyFormatMissingParams(), e.toString());
     }
   },
@@ -117,7 +117,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     invalidFormat.getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -127,7 +127,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     invalidFormat.getParams().setHashType(PbHashType.SHA256);
@@ -137,7 +137,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -146,7 +146,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -156,7 +156,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -188,7 +188,7 @@ testSuite({
         fail(
             'An exception should be thrown for the string: ' +
             serializedKeyFormats[i]);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
         continue;
       }
@@ -222,7 +222,7 @@ testSuite({
       const factory = /** @type {!KeyManager.PrivateKeyFactory} */ (
           manager.getKeyFactory());
       factory.getPublicKeyData(privateKey);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -258,7 +258,7 @@ testSuite({
     try {
       await manager.getPrimitive(PublicKeyVerify, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -273,7 +273,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -286,7 +286,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -301,7 +301,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -317,7 +317,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     key.getPublicKey().getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -327,7 +327,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     key.getPublicKey().getParams().setHashType(PbHashType.SHA256);
@@ -337,7 +337,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -346,7 +346,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -356,7 +356,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -377,7 +377,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }

--- a/javascript/signature/ecdsa_private_key_manager_test.js
+++ b/javascript/signature/ecdsa_private_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.EcdsaPrivateKeyManagerTest');
 goog.setTestOnly('tink.signature.EcdsaPrivateKeyManagerTest');
 

--- a/javascript/signature/ecdsa_private_key_manager_test.js
+++ b/javascript/signature/ecdsa_private_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.EcdsaPrivateKeyManagerTest');
 goog.setTestOnly('tink.signature.EcdsaPrivateKeyManagerTest');
@@ -70,7 +70,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.nullKeyFormat(), e.toString());
     }
   },
@@ -82,7 +82,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
     }
   },
@@ -94,7 +94,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyFormat(), e.toString());
     }
   },
@@ -106,7 +106,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidKeyFormatMissingParams(), e.toString());
     }
   },
@@ -121,7 +121,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     invalidFormat.getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -131,7 +131,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     invalidFormat.getParams().setHashType(PbHashType.SHA256);
@@ -141,7 +141,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -150,7 +150,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -160,7 +160,7 @@ testSuite({
     try {
       await manager.getKeyFactory().newKey(invalidFormat);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -192,7 +192,7 @@ testSuite({
         fail(
             'An exception should be thrown for the string: ' +
             serializedKeyFormats[i]);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKeyFormat(), e.toString());
         continue;
       }
@@ -226,7 +226,7 @@ testSuite({
       const factory = /** @type {!KeyManager.PrivateKeyFactory} */ (
           manager.getKeyFactory());
       factory.getPublicKeyData(privateKey);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
     }
   },
@@ -262,7 +262,7 @@ testSuite({
     try {
       await manager.getPrimitive(PublicKeyVerify, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -277,7 +277,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -290,7 +290,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -305,7 +305,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -321,7 +321,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     key.getPublicKey().getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -331,7 +331,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     key.getPublicKey().getParams().setHashType(PbHashType.SHA256);
@@ -341,7 +341,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -350,7 +350,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -360,7 +360,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -381,7 +381,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }

--- a/javascript/signature/ecdsa_public_key_manager.js
+++ b/javascript/signature/ecdsa_public_key_manager.js
@@ -47,7 +47,7 @@ class EcdsaPublicKeyFactory {
 
 
 /**
- * @implements {KeyManager.KeyManager<PublicKeyVerify>}
+ * @implements {KeyManager.KeyManager<!PublicKeyVerify>}
  * @final
  */
 class EcdsaPublicKeyManager {

--- a/javascript/signature/ecdsa_public_key_manager.js
+++ b/javascript/signature/ecdsa_public_key_manager.js
@@ -130,7 +130,7 @@ class EcdsaPublicKeyManager {
     let /** !PbEcdsaPublicKey */ key;
     try {
       key = PbEcdsaPublicKey.deserializeBinary(keyData.getValue());
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(
           'Input cannot be parsed as ' + EcdsaPublicKeyManager.KEY_TYPE +
           ' key-proto.');

--- a/javascript/signature/ecdsa_public_key_manager_test.js
+++ b/javascript/signature/ecdsa_public_key_manager_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.EcdsaPublicKeyManagerTest');
 goog.setTestOnly('tink.signature.EcdsaPublicKeyManagerTest');
 

--- a/javascript/signature/ecdsa_public_key_manager_test.js
+++ b/javascript/signature/ecdsa_public_key_manager_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.EcdsaPublicKeyManagerTest');
 goog.setTestOnly('tink.signature.EcdsaPublicKeyManagerTest');
@@ -62,7 +62,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -73,7 +73,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKeyData();
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -85,7 +85,7 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -98,7 +98,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -111,7 +111,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -125,7 +125,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -138,7 +138,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingParams(), e.toString());
     }
   },
@@ -152,7 +152,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     key.getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -162,7 +162,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     key.getParams().setHashType(PbHashType.SHA256);
@@ -172,7 +172,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -181,7 +181,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -191,7 +191,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -207,7 +207,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -216,7 +216,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
   },
@@ -232,7 +232,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }

--- a/javascript/signature/ecdsa_public_key_manager_test.js
+++ b/javascript/signature/ecdsa_public_key_manager_test.js
@@ -58,7 +58,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKey();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -69,7 +69,7 @@ testSuite({
     try {
       manager.getKeyFactory().newKeyData();
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.notSupported(), e.toString());
     }
   },
@@ -81,7 +81,7 @@ testSuite({
     try {
       await manager.getPrimitive(Mac, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedPrimitive(), e.toString());
     }
   },
@@ -94,7 +94,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, keyData);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.unsupportedKeyType(keyData.getTypeUrl()), e.toString());
     }
@@ -107,7 +107,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unsupportedKeyType(), e.toString());
     }
   },
@@ -121,7 +121,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.versionOutOfBounds(), e.toString());
     }
   },
@@ -134,7 +134,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingParams(), e.toString());
     }
   },
@@ -148,7 +148,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownEncoding(), e.toString());
     }
     key.getParams().setEncoding(PbEcdsaSignatureEncoding.DER);
@@ -158,7 +158,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownHash(), e.toString());
     }
     key.getParams().setHashType(PbHashType.SHA256);
@@ -168,7 +168,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownCurve(), e.toString());
     }
 
@@ -177,7 +177,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -187,7 +187,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -203,7 +203,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
 
@@ -212,7 +212,7 @@ testSuite({
     try {
       await manager.getPrimitive(PRIMITIVE, key);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.missingXY(), e.toString());
     }
   },
@@ -228,7 +228,7 @@ testSuite({
       try {
         await manager.getPrimitive(PRIMITIVE, keyData);
         fail('An exception should be thrown ' + i.toString());
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals(ExceptionText.invalidSerializedKey(), e.toString());
       }
     }

--- a/javascript/signature/public_key_sign_catalogue.js
+++ b/javascript/signature/public_key_sign_catalogue.js
@@ -23,7 +23,7 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 /**
  * A catalogue of TINK key managers for digital signatures.
  *
- * @implements {Catalogue<PublicKeySign>}
+ * @implements {Catalogue<!PublicKeySign>}
  * @final
  */
 class PublicKeySignCatalogue {

--- a/javascript/signature/public_key_sign_catalogue_test.js
+++ b/javascript/signature/public_key_sign_catalogue_test.js
@@ -32,7 +32,7 @@ testSuite({
           EcdsaPrivateKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -47,7 +47,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -61,7 +61,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/signature/public_key_sign_catalogue_test.js
+++ b/javascript/signature/public_key_sign_catalogue_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.PublicKeySignCatalogueTest');
 goog.setTestOnly('tink.signature.PublicKeySignCatalogueTest');
 

--- a/javascript/signature/public_key_sign_catalogue_test.js
+++ b/javascript/signature/public_key_sign_catalogue_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.PublicKeySignCatalogueTest');
 goog.setTestOnly('tink.signature.PublicKeySignCatalogueTest');
@@ -36,7 +36,7 @@ testSuite({
           EcdsaPrivateKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -51,7 +51,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -65,7 +65,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/signature/public_key_sign_wrapper.js
+++ b/javascript/signature/public_key_sign_wrapper.js
@@ -28,14 +28,14 @@ const Validators = goog.require('tink.subtle.Validators');
 class WrappedPublicKeySign {
   // The constructor should be @private, but it is not supported by Closure
   // (see https://github.com/google/closure-compiler/issues/2761).
-  /** @param {!PrimitiveSet.PrimitiveSet} primitiveSet */
+  /** @param {!PrimitiveSet.PrimitiveSet<!PublicKeySign>} primitiveSet */
   constructor(primitiveSet) {
-    /** @private @const {!PrimitiveSet.PrimitiveSet} */
+    /** @private @const {!PrimitiveSet.PrimitiveSet<!PublicKeySign>} */
     this.primitiveSet_ = primitiveSet;
   }
 
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} primitiveSet
+   * @param {!PrimitiveSet.PrimitiveSet<!PublicKeySign>} primitiveSet
    * @return {!PublicKeySign}
    */
   static newPublicKeySign(primitiveSet) {
@@ -61,7 +61,7 @@ class WrappedPublicKeySign {
 }
 
 /**
- * @implements {PrimitiveWrapper<PublicKeySign>}
+ * @implements {PrimitiveWrapper<!PublicKeySign>}
  */
 class PublicKeySignWrapper {
   // The constructor should be @private, but it is not supported by Closure

--- a/javascript/signature/public_key_sign_wrapper_test.js
+++ b/javascript/signature/public_key_sign_wrapper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.PublicKeySignWrapperTest');
 goog.setTestOnly('tink.signature.PublicKeySignWrapperTest');
@@ -34,7 +34,7 @@ testSuite({
     try {
       new PublicKeySignWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Primitive set has to be non-null.', e.toString());
     }
@@ -45,7 +45,7 @@ testSuite({
     try {
       new PublicKeySignWrapper().wrap(primitiveSet);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: Primary has to be non-null.', e.toString());
     }
   },
@@ -63,7 +63,7 @@ testSuite({
     try {
       await publicKeySign.sign(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/signature/public_key_sign_wrapper_test.js
+++ b/javascript/signature/public_key_sign_wrapper_test.js
@@ -30,7 +30,7 @@ testSuite({
     try {
       new PublicKeySignWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Primitive set has to be non-null.', e.toString());
     }
@@ -41,7 +41,7 @@ testSuite({
     try {
       new PublicKeySignWrapper().wrap(primitiveSet);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: Primary has to be non-null.', e.toString());
     }
   },
@@ -59,7 +59,7 @@ testSuite({
     try {
       await publicKeySign.sign(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/signature/public_key_sign_wrapper_test.js
+++ b/javascript/signature/public_key_sign_wrapper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.PublicKeySignWrapperTest');
 goog.setTestOnly('tink.signature.PublicKeySignWrapperTest');
 

--- a/javascript/signature/public_key_verify_catalogue.js
+++ b/javascript/signature/public_key_verify_catalogue.js
@@ -23,7 +23,7 @@ const SecurityException = goog.require('tink.exception.SecurityException');
 /**
  * A catalogue of TINK key managers for digital signature verification.
  *
- * @implements {Catalogue<PublicKeyVerify>}
+ * @implements {Catalogue<!PublicKeyVerify>}
  * @final
  */
 class PublicKeyVerifyCatalogue {

--- a/javascript/signature/public_key_verify_catalogue_test.js
+++ b/javascript/signature/public_key_verify_catalogue_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.PublicKeyVerifyCatalogueTest');
 goog.setTestOnly('tink.signature.PublicKeyVerifyCatalogueTest');
 

--- a/javascript/signature/public_key_verify_catalogue_test.js
+++ b/javascript/signature/public_key_verify_catalogue_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.PublicKeyVerifyCatalogueTest');
 goog.setTestOnly('tink.signature.PublicKeyVerifyCatalogueTest');
@@ -36,7 +36,7 @@ testSuite({
           EcdsaPublicKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -51,7 +51,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -65,7 +65,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/signature/public_key_verify_catalogue_test.js
+++ b/javascript/signature/public_key_verify_catalogue_test.js
@@ -32,7 +32,7 @@ testSuite({
           EcdsaPublicKeyManager.KEY_TYPE, anotherPrimitiveName,
           /* minVersion = */ 0);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.wrongPrimitive(anotherPrimitiveName), e.toString());
     }
@@ -47,7 +47,7 @@ testSuite({
       catalogue.getKeyManager(
           manager.getKeyType(), SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.versionOutOfBounds(manager.getVersion()), e.toString());
     }
@@ -61,7 +61,7 @@ testSuite({
     try {
       catalogue.getKeyManager(keyType, SUPPORTED_PRIMITIVE_NAME, version);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.unknownKeyType(keyType), e.toString());
     }
   },

--- a/javascript/signature/public_key_verify_wrapper.js
+++ b/javascript/signature/public_key_verify_wrapper.js
@@ -29,14 +29,14 @@ const Validators = goog.require('tink.subtle.Validators');
 class WrappedPublicKeyVerify {
   // The constructor should be @private, but it is not supported by Closure
   // (see https://github.com/google/closure-compiler/issues/2761).
-  /** @param {!PrimitiveSet.PrimitiveSet} primitiveSet */
+  /** @param {!PrimitiveSet.PrimitiveSet<!PublicKeyVerify>} primitiveSet */
   constructor(primitiveSet) {
-    /** @private @const {!PrimitiveSet.PrimitiveSet} */
+    /** @private @const {!PrimitiveSet.PrimitiveSet<!PublicKeyVerify>} */
     this.primitiveSet_ = primitiveSet;
   }
 
   /**
-   * @param {!PrimitiveSet.PrimitiveSet} primitiveSet
+   * @param {!PrimitiveSet.PrimitiveSet<!PublicKeyVerify>} primitiveSet
    * @return {!PublicKeyVerify}
    */
   static newPublicKeyVerify(primitiveSet) {
@@ -77,7 +77,7 @@ class WrappedPublicKeyVerify {
    * Tries to verify the signature using each entry in primitives. It
    * returns false if no entry succeeds.
    *
-   * @param {!Array<!PrimitiveSet.Entry>} primitives
+   * @param {!Array<!PrimitiveSet.Entry<!PublicKeyVerify>>} primitives
    * @param {!Uint8Array} signature
    * @param {!Uint8Array} data
    *

--- a/javascript/signature/public_key_verify_wrapper.js
+++ b/javascript/signature/public_key_verify_wrapper.js
@@ -60,7 +60,7 @@ class WrappedPublicKeyVerify {
       let /** @type {boolean} */ isValid;
       try {
         isValid = await this.tryVerification_(primitives, rawSignature, data);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         // Ignored.
       }
 
@@ -95,7 +95,7 @@ class WrappedPublicKeyVerify {
       let /** @type {boolean} */ isValid;
       try {
         isValid = await primitive.verify(signature, data);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         continue;
       }
       if (isValid) {

--- a/javascript/signature/public_key_verify_wrapper.js
+++ b/javascript/signature/public_key_verify_wrapper.js
@@ -107,7 +107,7 @@ class WrappedPublicKeyVerify {
 }
 
 /**
- * @implements {PrimitiveWrapper<PublicKeyVerify>}
+ * @implements {PrimitiveWrapper<!PublicKeyVerify>}
  */
 class PublicKeyVerifyWrapper {
   // The constructor should be @private, but it is not supported by Closure

--- a/javascript/signature/public_key_verify_wrapper_test.js
+++ b/javascript/signature/public_key_verify_wrapper_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.PublicKeyVerifyWrapperTest');
 goog.setTestOnly('tink.signature.PublicKeyVerifyWrapperTest');
 

--- a/javascript/signature/public_key_verify_wrapper_test.js
+++ b/javascript/signature/public_key_verify_wrapper_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.PublicKeyVerifyWrapperTest');
 goog.setTestOnly('tink.signature.PublicKeyVerifyWrapperTest');
@@ -36,7 +36,7 @@ testSuite({
     try {
       new PublicKeyVerifyWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Primitive set has to be non-null.', e.toString());
     }
@@ -50,7 +50,7 @@ testSuite({
     try {
       await publicKeyVerify.verify(null, Random.randBytes(10));
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -64,7 +64,7 @@ testSuite({
     try {
       await publicKeyVerify.verify(Random.randBytes(10), null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/signature/public_key_verify_wrapper_test.js
+++ b/javascript/signature/public_key_verify_wrapper_test.js
@@ -32,7 +32,7 @@ testSuite({
     try {
       new PublicKeyVerifyWrapper().wrap(null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Primitive set has to be non-null.', e.toString());
     }
@@ -46,7 +46,7 @@ testSuite({
     try {
       await publicKeyVerify.verify(null, Random.randBytes(10));
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -60,7 +60,7 @@ testSuite({
     try {
       await publicKeyVerify.verify(Random.randBytes(10), null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/signature/signature_config_test.js
+++ b/javascript/signature/signature_config_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.SignatureConfigTest');
 goog.setTestOnly('tink.signature.SignatureConfigTest');
 

--- a/javascript/signature/signature_config_test.js
+++ b/javascript/signature/signature_config_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.SignatureConfigTest');
 goog.setTestOnly('tink.signature.SignatureConfigTest');

--- a/javascript/signature/signature_key_templates_test.js
+++ b/javascript/signature/signature_key_templates_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.signature.SignatureKeyTemplatesTest');
 goog.setTestOnly('tink.signature.SignatureKeyTemplatesTest');

--- a/javascript/signature/signature_key_templates_test.js
+++ b/javascript/signature/signature_key_templates_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.signature.SignatureKeyTemplatesTest');
 goog.setTestOnly('tink.signature.SignatureKeyTemplatesTest');
 

--- a/javascript/subtle/BUILD.bazel
+++ b/javascript/subtle/BUILD.bazel
@@ -4,10 +4,11 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
 
 closure_js_library(
     name = "subtle",
+    #lenient = True,
     srcs = [
         "bytes.js",
         "ecies_aead_hkdf_dem_helper.js",
@@ -26,6 +27,7 @@ closure_js_library(
 
 closure_js_library(
     name = "aead",
+    #lenient = True,
     srcs = [
         "aes_ctr.js",
         "aes_gcm.js",
@@ -43,6 +45,7 @@ closure_js_library(
 
 closure_js_library(
     name = "mac",
+    #lenient = True,
     srcs = [
         "hmac.js",
     ],
@@ -57,6 +60,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hkdf",
+    #lenient = True,
     srcs = [
         "hkdf.js",
     ],
@@ -70,6 +74,7 @@ closure_js_library(
 
 closure_js_library(
     name = "hybrid",
+    #lenient = True,
     srcs = [
         "ecies_aead_hkdf_hybrid_decrypt.js",
         "ecies_aead_hkdf_hybrid_encrypt.js",
@@ -87,6 +92,7 @@ closure_js_library(
 
 closure_js_library(
     name = "signature",
+    #lenient = True,
     srcs = [
         "ecdsa_sign.js",
         "ecdsa_verify.js",
@@ -101,21 +107,53 @@ closure_js_library(
 
 # test
 
-closure_js_library(
+closure_js_test(
     name = "test_lib",
     testonly = 1,
+    #lenient = True,
     srcs = glob([
         "*_test.js",
-    ]) + [
+    ]),
+    entry_points = {
+        "aes_ctr_test.js": ["tink.subtle.AesCtrTest"],
+        "aes_gcm_test.js": ["tink.subtle.AesGcmTest"],
+        "bytes_test.js": ["tink.subtle.BytesTest"],
+        "ecdsa_sign_test.js": ["tink.subtle.EcdsaSignTest"],
+        "ecdsa_verify_test.js": ["tink.subtle.EcdsaVerifyTest"],
+        "ecies_aead_hkdf_hybrid_decrypt_test.js": ["tink.subtle.EciesAeadHkdfHybridDecryptTest"],
+        "ecies_aead_hkdf_hybrid_encrypt_test.js": ["tink.subtle.EciesAeadHkdfHybridEncryptTest"],
+        "ecies_hkdf_kem_recipient_test.js": ["tink.subtle.EciesHkdfKemRecipientTest"],
+        "ecies_hkdf_kem_sender_test.js": ["tink.subtle.EciesHkdfKemSenderTest"],
+        "elliptic_curves_test.js": ["tink.subtle.EllipticCurvesTest"],
+        "encrypt_then_authenticate_test.js": ["tink.subtle.EncryptThenAuthenticateTest"],
+        "hkdf_test.js": ["tink.subtle.HkdfTest"],
+        "hmac_test.js": ["tink.subtle.HmacTest"],
+    },
+    deps = [
+        ":wycheproof_testvectors",
+        "//javascript/aead",
+        "//javascript/hybrid",
+        "//javascript:primitives",
+        "//javascript:registry",
+        ":aead",
+        ":hybrid",
+        ":hkdf",
+        ":mac",
+        ":subtle",
+        ":signature",
+        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library:testing",
+        "@io_bazel_rules_closure//closure/library/useragent",
+    ],
+)
+
+closure_js_library(
+    name = "wycheproof_testvectors",
+    testonly = 1,
+    #lenient = True,
+    srcs = [
         ":wycheproof_ecdh_testvectors",
         ":wycheproof_ecdsa_testvectors",
-    ],
-    deps = [
-        "@io_bazel_rules_closure//closure/library",
-        "@io_bazel_rules_closure//closure/library/testing:asserts",
-        "@io_bazel_rules_closure//closure/library/testing:jsunit",
-        "@io_bazel_rules_closure//closure/library/testing:testsuite",
-        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )
 

--- a/javascript/subtle/aes_ctr.js
+++ b/javascript/subtle/aes_ctr.js
@@ -82,7 +82,7 @@ class AesCtr {
             ['encrypt', 'decrypt']);
 
         return new AesCtr(cryptoKey, ivSize);
-      } catch (error) {
+      } catch (/** @type {!Object} */error) {
         // CTR might be unsupported in this browser. Fall back to Pure JS.
       }
     }

--- a/javascript/subtle/aes_ctr_test.js
+++ b/javascript/subtle/aes_ctr_test.js
@@ -172,7 +172,7 @@ testSuite({
 
   async testWithTestVectors() {
     // Test data from NIST SP 800-38A pp 55.
-    const NIST_TEST_VECTORS = [
+    const /** !Array<{key: string, message: string, ciphertext: string, iv: string}> */ NIST_TEST_VECTORS = [
       {
         'key': '2b7e151628aed2a6abf7158809cf4f3c',
         'message':

--- a/javascript/subtle/aes_ctr_test.js
+++ b/javascript/subtle/aes_ctr_test.js
@@ -62,14 +62,14 @@ testSuite({
     try {
       await AesCtr.newInstance(123, 16);  // IV size too short
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await AesCtr.newInstance(Random.randBytes(16), 11);  // IV size too short
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -77,7 +77,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 17);  // IV size too long
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -86,7 +86,7 @@ testSuite({
       await AesCtr.newInstance(
           Random.randBytes(24), 12);  // 192-bit keys not supported
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: unsupported AES key size: 24', e.toString());
     }
   },
@@ -95,7 +95,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), NaN);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -103,7 +103,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), undefined);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -111,7 +111,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 12.5);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -119,7 +119,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 0);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -130,7 +130,7 @@ testSuite({
     try {
       await AesCtr.newInstance('blah', 12);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -139,28 +139,28 @@ testSuite({
     try {
       await cipher.encrypt('blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.encrypt(123);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.decrypt('blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.decrypt(123);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/subtle/aes_ctr_test.js
+++ b/javascript/subtle/aes_ctr_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.AesCtrTest');
 goog.setTestOnly('tink.subtle.AesCtrTest');
 

--- a/javascript/subtle/aes_ctr_test.js
+++ b/javascript/subtle/aes_ctr_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.AesCtrTest');
 goog.setTestOnly('tink.subtle.AesCtrTest');
@@ -66,14 +66,14 @@ testSuite({
     try {
       await AesCtr.newInstance(123, 16);  // IV size too short
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await AesCtr.newInstance(Random.randBytes(16), 11);  // IV size too short
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -81,7 +81,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 17);  // IV size too long
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -90,7 +90,7 @@ testSuite({
       await AesCtr.newInstance(
           Random.randBytes(24), 12);  // 192-bit keys not supported
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: unsupported AES key size: 24', e.toString());
     }
   },
@@ -99,7 +99,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), NaN);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -107,7 +107,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), undefined);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -115,7 +115,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 12.5);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be an integer', e.toString());
     }
@@ -123,7 +123,7 @@ testSuite({
     try {
       await AesCtr.newInstance(Random.randBytes(16), 0);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid IV length, must be at least 12 and at most 16',
           e.toString());
@@ -134,7 +134,7 @@ testSuite({
     try {
       await AesCtr.newInstance('blah', 12);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -143,28 +143,28 @@ testSuite({
     try {
       await cipher.encrypt('blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.encrypt(123);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.decrypt('blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await cipher.decrypt(123);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -172,7 +172,7 @@ testSuite({
 
   async testWithTestVectors() {
     // Test data from NIST SP 800-38A pp 55.
-    const /** !Array<{key: string, message: string, ciphertext: string, iv: string}> */ NIST_TEST_VECTORS = [
+    const NIST_TEST_VECTORS = [
       {
         'key': '2b7e151628aed2a6abf7158809cf4f3c',
         'message':

--- a/javascript/subtle/aes_gcm.js
+++ b/javascript/subtle/aes_gcm.js
@@ -115,7 +115,7 @@ class AesGcm {
       return new Uint8Array(await self.crypto.subtle.decrypt(
           alg, this.key_,
           new Uint8Array(ciphertext.subarray(IV_SIZE_IN_BYTES))));
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       throw new SecurityException(e.toString());
     }
   }

--- a/javascript/subtle/aes_gcm_test.js
+++ b/javascript/subtle/aes_gcm_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.AesGcmTest');
 goog.setTestOnly('tink.subtle.AesGcmTest');
@@ -29,7 +29,7 @@ const userAgent = goog.require('goog.userAgent');
 /**
  * Asserts that an exception is the result of a Web Crypto error.
  *
- * @param {!Object} exception A thrown exception.
+ * @param {*} exception A thrown exception.
  */
 function assertCryptoError(exception) {
   const message = exception.toString();
@@ -92,7 +92,7 @@ testSuite({
     try {
       await AesGcm.newInstance('blah');
       fail('expected AesGcm.newInstance to fail');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -101,28 +101,28 @@ testSuite({
     try {
       await aead.encrypt('blah');
       fail('expected aead.encrypt to fail');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.encrypt(Random.randBytes(20), 'blah');
       fail('expected aead.encrypt to fail');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt('blah');
       fail('expected aead.decrypt to fail');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt(Random.randBytes(32), 'blah');
       fail('expected aead.decrypt to fail');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -140,7 +140,7 @@ testSuite({
         try {
           await aead.decrypt(c1, aad);
           fail('expected aead.decrypt to fail');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
           assertCryptoError(e);
         }
       }
@@ -159,7 +159,7 @@ testSuite({
         try {
           await aead.decrypt(ciphertext, aad1);
           fail('expected aead.decrypt to fail');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
           assertCryptoError(e);
         }
       }
@@ -176,7 +176,7 @@ testSuite({
       try {
         await aead.decrypt(c1, aad);
         fail('expected aead.decrypt to fail');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         if (c1.length < 12 /* iv */ + 16 /* tag */) {
           assertEquals('CustomError: ciphertext too short', e.toString());
         } else {
@@ -189,7 +189,7 @@ testSuite({
   async testWithNistTestVectors() {
     // Download from
     // https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES.
-    const /** !Array<{Key: string, IV: string, PT: string, AAD: string, CT: string, Tag: string}> */ NIST_TEST_VECTORS =
+    const NIST_TEST_VECTORS =
         [
           {
             'Key':
@@ -689,7 +689,7 @@ testSuite({
       try {
         const plaintext = await aead.decrypt(ciphertext, aad);
         assertEquals(Bytes.toHex(plaintext), testVector['PT']);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         fail(e);
       }
     }

--- a/javascript/subtle/aes_gcm_test.js
+++ b/javascript/subtle/aes_gcm_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.AesGcmTest');
 goog.setTestOnly('tink.subtle.AesGcmTest');
 

--- a/javascript/subtle/aes_gcm_test.js
+++ b/javascript/subtle/aes_gcm_test.js
@@ -29,7 +29,7 @@ const userAgent = goog.require('goog.userAgent');
 /**
  * Asserts that an exception is the result of a Web Crypto error.
  *
- * @param {*} exception A thrown exception.
+ * @param {!Object} exception A thrown exception.
  */
 function assertCryptoError(exception) {
   const message = exception.toString();
@@ -189,7 +189,7 @@ testSuite({
   async testWithNistTestVectors() {
     // Download from
     // https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES.
-    const NIST_TEST_VECTORS =
+    const /** !Array<{Key: string, IV: string, PT: string, AAD: string, CT: string, Tag: string}> */ NIST_TEST_VECTORS =
         [
           {
             'Key':

--- a/javascript/subtle/aes_gcm_test.js
+++ b/javascript/subtle/aes_gcm_test.js
@@ -88,7 +88,7 @@ testSuite({
     try {
       await AesGcm.newInstance('blah');
       fail('expected AesGcm.newInstance to fail');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -97,28 +97,28 @@ testSuite({
     try {
       await aead.encrypt('blah');
       fail('expected aead.encrypt to fail');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.encrypt(Random.randBytes(20), 'blah');
       fail('expected aead.encrypt to fail');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt('blah');
       fail('expected aead.decrypt to fail');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt(Random.randBytes(32), 'blah');
       fail('expected aead.decrypt to fail');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -136,7 +136,7 @@ testSuite({
         try {
           await aead.decrypt(c1, aad);
           fail('expected aead.decrypt to fail');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
           assertCryptoError(e);
         }
       }
@@ -155,7 +155,7 @@ testSuite({
         try {
           await aead.decrypt(ciphertext, aad1);
           fail('expected aead.decrypt to fail');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
           assertCryptoError(e);
         }
       }
@@ -172,7 +172,7 @@ testSuite({
       try {
         await aead.decrypt(c1, aad);
         fail('expected aead.decrypt to fail');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         if (c1.length < 12 /* iv */ + 16 /* tag */) {
           assertEquals('CustomError: ciphertext too short', e.toString());
         } else {
@@ -685,7 +685,7 @@ testSuite({
       try {
         const plaintext = await aead.decrypt(ciphertext, aad);
         assertEquals(Bytes.toHex(plaintext), testVector['PT']);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         fail(e);
       }
     }

--- a/javascript/subtle/bytes.js
+++ b/javascript/subtle/bytes.js
@@ -39,16 +39,16 @@ const isEqual = function(ba1, ba2) {
  * @param {...!Uint8Array} var_args
  * @return {!Uint8Array}
  */
-const concat = function(var_args) {
+const concat = function(...var_args) {
   let length = 0;
-  for (let i = 0; i < arguments.length; i++) {
-    length += arguments[i].length;
+  for (let i = 0; i < var_args.length; i++) {
+    length += var_args[i].length;
   }
   let result = new Uint8Array(length);
   let curOffset = 0;
-  for (let i = 0; i < arguments.length; i++) {
-    result.set(arguments[i], curOffset);
-    curOffset += arguments[i].length;
+  for (let i = 0; i < var_args.length; i++) {
+    result.set(var_args[i], curOffset);
+    curOffset += var_args[i].length;
   }
   return result;
 };

--- a/javascript/subtle/bytes_test.js
+++ b/javascript/subtle/bytes_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.BytesTest');
 goog.setTestOnly('tink.subtle.BytesTest');

--- a/javascript/subtle/bytes_test.js
+++ b/javascript/subtle/bytes_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.BytesTest');
 goog.setTestOnly('tink.subtle.BytesTest');
 

--- a/javascript/subtle/ecdsa_sign_test.js
+++ b/javascript/subtle/ecdsa_sign_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EcdsaSignTest');
 goog.setTestOnly('tink.subtle.EcdsaSignTest');
 

--- a/javascript/subtle/ecdsa_sign_test.js
+++ b/javascript/subtle/ecdsa_sign_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EcdsaSignTest');
 goog.setTestOnly('tink.subtle.EcdsaSignTest');
@@ -111,7 +111,7 @@ testSuite({
     try {
       await EcdsaSign.newInstance(null, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: private key has to be non-null', e.toString());
     }
   },
@@ -122,7 +122,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-1');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-256 (because curve is P-256) but ' +
               'got SHA-1',
@@ -134,7 +134,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -145,7 +145,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -159,7 +159,7 @@ testSuite({
       jwk.crv = 'blah';
       await EcdsaSign.newInstance(jwk, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: unsupported curve: blah', e.toString());
     }
   },

--- a/javascript/subtle/ecdsa_sign_test.js
+++ b/javascript/subtle/ecdsa_sign_test.js
@@ -107,7 +107,7 @@ testSuite({
     try {
       await EcdsaSign.newInstance(null, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: private key has to be non-null', e.toString());
     }
   },
@@ -118,7 +118,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-1');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-256 (because curve is P-256) but ' +
               'got SHA-1',
@@ -130,7 +130,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -141,7 +141,7 @@ testSuite({
       await EcdsaSign.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.privateKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -155,7 +155,7 @@ testSuite({
       jwk.crv = 'blah';
       await EcdsaSign.newInstance(jwk, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: unsupported curve: blah', e.toString());
     }
   },

--- a/javascript/subtle/ecdsa_verify_test.js
+++ b/javascript/subtle/ecdsa_verify_test.js
@@ -198,7 +198,7 @@ testSuite({
  * string or a text describing the failure.
  *
  * @param {!EcdsaVerify} verifier
- * @param {!Object} test - JSON object with test data
+ * @param {{sig: string, msg: string, tcId: string, result: string}} test - JSON object with test data
  * @return {!Promise<string>}
  */
 const runWycheproofTest = async function(verifier, test) {

--- a/javascript/subtle/ecdsa_verify_test.js
+++ b/javascript/subtle/ecdsa_verify_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EcdsaVerifyTest');
 goog.setTestOnly('tink.subtle.EcdsaVerifyTest');
 

--- a/javascript/subtle/ecdsa_verify_test.js
+++ b/javascript/subtle/ecdsa_verify_test.js
@@ -78,7 +78,7 @@ testSuite({
     try {
       await EcdsaVerify.newInstance(null, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: public key has to be non-null', e.toString());
     }
   },
@@ -89,7 +89,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-1');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-256 (because curve is P-256) but got SHA-1',
           e.toString());
@@ -100,7 +100,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -111,7 +111,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -125,7 +125,7 @@ testSuite({
       jwk.crv = 'blah';
       await EcdsaVerify.newInstance(jwk, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: unsupported curve: blah', e.toString());
     }
   },
@@ -171,7 +171,7 @@ testSuite({
       try {
         Validators.validateEcdsaParams(
             testGroup['jwk']['crv'], testGroup['sha']);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         // Tink does not support this config.
         continue;
       }
@@ -211,7 +211,7 @@ const runWycheproofTest = async function(verifier, test) {
         return 'valid signature rejected on test ' + test['tcId'] + '\n';
       }
     }
-  } catch (e) {
+  } catch (/** @type {!Object} */e) {
     if (test['result'] === 'valid') {
       return 'valid signature rejected on test ' + test['tcId'] +
           ': unexpected exception \"' + e.toString() + '\".\n';

--- a/javascript/subtle/ecdsa_verify_test.js
+++ b/javascript/subtle/ecdsa_verify_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EcdsaVerifyTest');
 goog.setTestOnly('tink.subtle.EcdsaVerifyTest');
@@ -82,7 +82,7 @@ testSuite({
     try {
       await EcdsaVerify.newInstance(null, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: public key has to be non-null', e.toString());
     }
   },
@@ -93,7 +93,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-1');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-256 (because curve is P-256) but got SHA-1',
           e.toString());
@@ -104,7 +104,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256',
           e.toString());
@@ -115,7 +115,7 @@ testSuite({
       await EcdsaVerify.newInstance(
           await EllipticCurves.exportCryptoKey(keyPair.publicKey), 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: expected SHA-512 (because curve is P-521) but got SHA-256',
           e.toString());
@@ -129,7 +129,7 @@ testSuite({
       jwk.crv = 'blah';
       await EcdsaVerify.newInstance(jwk, 'SHA-256');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: unsupported curve: blah', e.toString());
     }
   },
@@ -175,7 +175,7 @@ testSuite({
       try {
         Validators.validateEcdsaParams(
             testGroup['jwk']['crv'], testGroup['sha']);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         // Tink does not support this config.
         continue;
       }
@@ -198,7 +198,7 @@ testSuite({
  * string or a text describing the failure.
  *
  * @param {!EcdsaVerify} verifier
- * @param {{sig: string, msg: string, tcId: string, result: string}} test - JSON object with test data
+ * @param {!Object} test - JSON object with test data
  * @return {!Promise<string>}
  */
 const runWycheproofTest = async function(verifier, test) {
@@ -215,7 +215,7 @@ const runWycheproofTest = async function(verifier, test) {
         return 'valid signature rejected on test ' + test['tcId'] + '\n';
       }
     }
-  } catch (/** @type {!Object} */e) {
+  } catch (e) {
     if (test['result'] === 'valid') {
       return 'valid signature rejected on test ' + test['tcId'] +
           ': unexpected exception \"' + e.toString() + '\".\n';

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EciesAeadHkdfHybridDecryptTest');
 goog.setTestOnly('tink.subtle.EciesAeadHkdfHybridDecryptTest');
 

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EciesAeadHkdfHybridDecryptTest');
 goog.setTestOnly('tink.subtle.EciesAeadHkdfHybridDecryptTest');
@@ -62,7 +62,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           null, recipient, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Recipient private key has to be non-null.',
           e.toString());
@@ -72,7 +72,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, null, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: KEM recipient has to be non-null.', e.toString());
     }
@@ -81,7 +81,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, null, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: HKDF hash algorithm has to be non-null.', e.toString());
     }
@@ -90,7 +90,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, hkdfHash, null, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -99,7 +99,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, hkdfHash, pointFormat, null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },
@@ -126,7 +126,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           null, hkdfHash, pointFormat, demHelper);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Recipient private key has to be non-null.',
           e.toString());
@@ -135,7 +135,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, null, pointFormat, demHelper);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: HKDF hash algorithm has to be non-null.', e.toString());
     }
@@ -143,7 +143,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, hkdfHash, null, demHelper);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -151,7 +151,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, hkdfHash, pointFormat, null);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },
@@ -180,7 +180,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext.slice(0, curveEncodingSize - 1));
       fail('Should throw an exception');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: Ciphertext is too short.', e.toString());
     }
   },

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.js
@@ -58,7 +58,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           null, recipient, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Recipient private key has to be non-null.',
           e.toString());
@@ -68,7 +68,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, null, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: KEM recipient has to be non-null.', e.toString());
     }
@@ -77,7 +77,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, null, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: HKDF hash algorithm has to be non-null.', e.toString());
     }
@@ -86,7 +86,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, hkdfHash, null, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -95,7 +95,7 @@ testSuite({
       new EciesAeadHkdfHybridDecrypt(
           privateKey, recipient, hkdfHash, pointFormat, null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },
@@ -122,7 +122,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           null, hkdfHash, pointFormat, demHelper);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Recipient private key has to be non-null.',
           e.toString());
@@ -131,7 +131,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, null, pointFormat, demHelper);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: HKDF hash algorithm has to be non-null.', e.toString());
     }
@@ -139,7 +139,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, hkdfHash, null, demHelper);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -147,7 +147,7 @@ testSuite({
     try {
       await EciesAeadHkdfHybridDecrypt.newInstance(
           privateKey, hkdfHash, pointFormat, null);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },
@@ -176,7 +176,7 @@ testSuite({
     try {
       await hybridDecrypt.decrypt(ciphertext.slice(0, curveEncodingSize - 1));
       fail('Should throw an exception');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: Ciphertext is too short.', e.toString());
     }
   },

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt.js
@@ -116,7 +116,7 @@ class EciesAeadHkdfHybridEncrypt {
     const aead = await this.demHelper_.getAead(kemKey['key']);
 
     const ciphertextBody = await aead.encrypt(plaintext);
-    const header = kemKey['token'];
+    const /** !Uint8Array */ header = kemKey['token'];
 
     return Bytes.concat(header, ciphertextBody);
   }

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EciesAeadHkdfHybridEncryptTest');
 goog.setTestOnly('tink.subtle.EciesAeadHkdfHybridEncryptTest');
@@ -71,7 +71,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           null, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Recipient public key has to be non-null.',
           e.toString());
@@ -81,7 +81,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, null, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: HMAC algorithm has to be non-null.', e.toString());
     }
@@ -90,7 +90,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, hkdfHash, null, demHelper);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -99,7 +99,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, hkdfHash, pointFormat, null);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
@@ -67,7 +67,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           null, hkdfHash, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Recipient public key has to be non-null.',
           e.toString());
@@ -77,7 +77,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, null, pointFormat, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: HMAC algorithm has to be non-null.', e.toString());
     }
@@ -86,7 +86,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, hkdfHash, null, demHelper);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Point format has to be non-null.', e.toString());
     }
@@ -95,7 +95,7 @@ testSuite({
       await EciesAeadHkdfHybridEncrypt.newInstance(
           publicKey, hkdfHash, pointFormat, null);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: DEM helper has to be non-null.', e.toString());
     }
   },

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EciesAeadHkdfHybridEncryptTest');
 goog.setTestOnly('tink.subtle.EciesAeadHkdfHybridEncryptTest');
 

--- a/javascript/subtle/ecies_hkdf_kem_recipient_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_recipient_test.js
@@ -325,8 +325,7 @@ class TestVector {
 //
 // Token (i.e. sender public key) and privateKeyPoint values are in UNCOMPRESSED
 // EcPoint encoding (i.e. it has prefix '04' followed by x and y values).
-/** {!Array<!TestVector>} */
-const TEST_VECTORS = [
+const /** !Array<!TestVector> */ TEST_VECTORS = [
   new TestVector(
       EllipticCurves.CurveType.P256, 'SHA-256',
       EllipticCurves.PointFormatType.UNCOMPRESSED,

--- a/javascript/subtle/ecies_hkdf_kem_recipient_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_recipient_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EciesHkdfKemRecipientTest');
 goog.setTestOnly('tink.subtle.EciesHkdfKemRecipientTest');
 

--- a/javascript/subtle/ecies_hkdf_kem_recipient_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_recipient_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EciesHkdfKemRecipientTest');
 goog.setTestOnly('tink.subtle.EciesHkdfKemRecipientTest');
@@ -87,7 +87,7 @@ testSuite({
       await recipient.decapsulate(
           kemKeyToken['token'], NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
@@ -96,7 +96,7 @@ testSuite({
           kemKeyToken['token'], undefined, pointFormat, hkdfHash, hkdfInfo,
           hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
@@ -104,7 +104,7 @@ testSuite({
       await recipient.decapsulate(
           kemKeyToken['token'], 1.8, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
   },
@@ -115,7 +115,7 @@ testSuite({
     try {
       await EciesHkdfKemRecipient.newInstance(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
 
     // Test newInstance with public key instead private key.
@@ -124,14 +124,14 @@ testSuite({
     try {
       await EciesHkdfKemRecipient.newInstance(publicKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
 
     // Test newInstance with CryptoKey instead of JSON key.
     try {
       await EciesHkdfKemRecipient.newInstance(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
   },
 
@@ -158,7 +158,7 @@ testSuite({
         output = await recipient.decapsulate(
             Bytes.fromHex(testVector.token), testVector.outputLength,
             testVector.pointFormat, testVector.hashType, hkdfInfo, salt);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         // Everything works properly if exception was thrown.
         return;
       }
@@ -173,7 +173,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Private key has to be non-null.', e.toString());
     }
@@ -183,7 +183,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Expected crypto key of type: private.', e.toString());
     }
@@ -193,7 +193,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(privateKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
   },
 
@@ -256,7 +256,7 @@ testSuite({
           await recipient.decapsulate(
               token, keySizeInBytes, pointFormat, hashType, hkdfInfo, hkdfSalt);
           fail('Should throw an exception');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
         }
       }
     }
@@ -325,7 +325,8 @@ class TestVector {
 //
 // Token (i.e. sender public key) and privateKeyPoint values are in UNCOMPRESSED
 // EcPoint encoding (i.e. it has prefix '04' followed by x and y values).
-const /** !Array<!TestVector> */ TEST_VECTORS = [
+/** {!Array<!TestVector>} */
+const TEST_VECTORS = [
   new TestVector(
       EllipticCurves.CurveType.P256, 'SHA-256',
       EllipticCurves.PointFormatType.UNCOMPRESSED,

--- a/javascript/subtle/ecies_hkdf_kem_recipient_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_recipient_test.js
@@ -83,7 +83,7 @@ testSuite({
       await recipient.decapsulate(
           kemKeyToken['token'], NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
@@ -92,7 +92,7 @@ testSuite({
           kemKeyToken['token'], undefined, pointFormat, hkdfHash, hkdfInfo,
           hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
@@ -100,7 +100,7 @@ testSuite({
       await recipient.decapsulate(
           kemKeyToken['token'], 1.8, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
   },
@@ -111,7 +111,7 @@ testSuite({
     try {
       await EciesHkdfKemRecipient.newInstance(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
 
     // Test newInstance with public key instead private key.
@@ -120,14 +120,14 @@ testSuite({
     try {
       await EciesHkdfKemRecipient.newInstance(publicKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
 
     // Test newInstance with CryptoKey instead of JSON key.
     try {
       await EciesHkdfKemRecipient.newInstance(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
   },
 
@@ -154,7 +154,7 @@ testSuite({
         output = await recipient.decapsulate(
             Bytes.fromHex(testVector.token), testVector.outputLength,
             testVector.pointFormat, testVector.hashType, hkdfInfo, salt);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         // Everything works properly if exception was thrown.
         return;
       }
@@ -169,7 +169,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Private key has to be non-null.', e.toString());
     }
@@ -179,7 +179,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Expected crypto key of type: private.', e.toString());
     }
@@ -189,7 +189,7 @@ testSuite({
     try {
       new EciesHkdfKemRecipient(privateKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
   },
 
@@ -252,7 +252,7 @@ testSuite({
           await recipient.decapsulate(
               token, keySizeInBytes, pointFormat, hashType, hkdfInfo, hkdfSalt);
           fail('Should throw an exception');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
         }
       }
     }

--- a/javascript/subtle/ecies_hkdf_kem_sender.js
+++ b/javascript/subtle/ecies_hkdf_kem_sender.js
@@ -60,17 +60,18 @@ class EciesHkdfKemSender {
    *     information (can be a zero-length array).
    * @param {!Uint8Array=} opt_hkdfSalt Salt value (a non-secret random
    *     value). If not provided, it is set to a string of hash length zeros.
-   * @return {!Promise.<!{key:!Uint8Array, token:!Uint8Array}>} The KEM key and
+   * @return {!Promise<{key:!Uint8Array, token:!Uint8Array}>} The KEM key and
    *     token.
+   * @suppress {reportUnknownTypes}
    */
   async encapsulate(
       keySizeInBytes, pointFormat, hkdfHash, hkdfInfo, opt_hkdfSalt) {
     const ephemeralKeyPair = await EllipticCurves.generateKeyPair(
         'ECDH', this.publicKey_.algorithm['namedCurve']);
     const sharedSecret = await EllipticCurves.computeEcdhSharedSecret(
-        /** @type {!Object} */ (ephemeralKeyPair).privateKey, this.publicKey_);
+        /** @type {?} */ (ephemeralKeyPair).privateKey, this.publicKey_);
     const jwk = await EllipticCurves.exportCryptoKey(
-        /** @type {!Object} */ (ephemeralKeyPair).publicKey);
+        /** @type {?} */ (ephemeralKeyPair).publicKey);
     const kemToken = EllipticCurves.pointEncode(jwk.crv, pointFormat, jwk);
     const hkdfIkm = Bytes.concat(kemToken, sharedSecret);
     const kemKey = await Hkdf.compute(

--- a/javascript/subtle/ecies_hkdf_kem_sender.js
+++ b/javascript/subtle/ecies_hkdf_kem_sender.js
@@ -60,7 +60,7 @@ class EciesHkdfKemSender {
    *     information (can be a zero-length array).
    * @param {!Uint8Array=} opt_hkdfSalt Salt value (a non-secret random
    *     value). If not provided, it is set to a string of hash length zeros.
-   * @return {!Promise.<{key:!Uint8Array, token:!Uint8Array}>} The KEM key and
+   * @return {!Promise.<!{key:!Uint8Array, token:!Uint8Array}>} The KEM key and
    *     token.
    */
   async encapsulate(
@@ -68,9 +68,9 @@ class EciesHkdfKemSender {
     const ephemeralKeyPair = await EllipticCurves.generateKeyPair(
         'ECDH', this.publicKey_.algorithm['namedCurve']);
     const sharedSecret = await EllipticCurves.computeEcdhSharedSecret(
-        /** @type {?} */ (ephemeralKeyPair).privateKey, this.publicKey_);
+        /** @type {!Object} */ (ephemeralKeyPair).privateKey, this.publicKey_);
     const jwk = await EllipticCurves.exportCryptoKey(
-        /** @type {?} */ (ephemeralKeyPair).publicKey);
+        /** @type {!Object} */ (ephemeralKeyPair).publicKey);
     const kemToken = EllipticCurves.pointEncode(jwk.crv, pointFormat, jwk);
     const hkdfIkm = Bytes.concat(kemToken, sharedSecret);
     const kemKey = await Hkdf.compute(

--- a/javascript/subtle/ecies_hkdf_kem_sender_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_sender_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EciesHkdfKemSenderTest');
 goog.setTestOnly('tink.subtle.EciesHkdfKemSenderTest');
 

--- a/javascript/subtle/ecies_hkdf_kem_sender_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_sender_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EciesHkdfKemSenderTest');
 goog.setTestOnly('tink.subtle.EciesHkdfKemSenderTest');
@@ -65,20 +65,20 @@ testSuite({
     try {
       await sender.encapsulate(NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
     try {
       await sender.encapsulate(
           undefined, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
     try {
       await sender.encapsulate(0, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
   },
@@ -88,7 +88,7 @@ testSuite({
     try {
       await EciesHkdfKemSender.newInstance(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
 
     // Test newInstance with public key instead private key.
@@ -97,14 +97,14 @@ testSuite({
     try {
       await EciesHkdfKemSender.newInstance(privateKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
 
     // Test newInstance with CryptoKey instead of JSON key.
     try {
       await EciesHkdfKemSender.newInstance(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
     }
   },
 
@@ -129,7 +129,7 @@ testSuite({
             EllipticCurves.PointFormatType.UNCOMPRESSED,
             /* hkdfHash = */ 'SHA-256', hkdfInfo, salt);
         fail('Should throw an exception.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
       }
     }
   },
@@ -139,7 +139,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(null);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Recipient public key has to be non-null.',
           e.toString());
@@ -150,7 +150,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(keyPair.privateKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Expected Crypto key of type: public.', e.toString());
     }
@@ -160,7 +160,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(publicKey);
       fail('An exception should be thrown.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: Expected Crypto key of type: public.', e.toString());
     }

--- a/javascript/subtle/ecies_hkdf_kem_sender_test.js
+++ b/javascript/subtle/ecies_hkdf_kem_sender_test.js
@@ -61,20 +61,20 @@ testSuite({
     try {
       await sender.encapsulate(NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
     try {
       await sender.encapsulate(
           undefined, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
     try {
       await sender.encapsulate(0, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
   },
@@ -84,7 +84,7 @@ testSuite({
     try {
       await EciesHkdfKemSender.newInstance(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
 
     // Test newInstance with public key instead private key.
@@ -93,14 +93,14 @@ testSuite({
     try {
       await EciesHkdfKemSender.newInstance(privateKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
 
     // Test newInstance with CryptoKey instead of JSON key.
     try {
       await EciesHkdfKemSender.newInstance(keyPair.publicKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
     }
   },
 
@@ -125,7 +125,7 @@ testSuite({
             EllipticCurves.PointFormatType.UNCOMPRESSED,
             /* hkdfHash = */ 'SHA-256', hkdfInfo, salt);
         fail('Should throw an exception.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
       }
     }
   },
@@ -135,7 +135,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(null);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Recipient public key has to be non-null.',
           e.toString());
@@ -146,7 +146,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(keyPair.privateKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Expected Crypto key of type: public.', e.toString());
     }
@@ -156,7 +156,7 @@ testSuite({
     try {
       new EciesHkdfKemSender(publicKey);
       fail('An exception should be thrown.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: Expected Crypto key of type: public.', e.toString());
     }

--- a/javascript/subtle/elliptic_curves_test.js
+++ b/javascript/subtle/elliptic_curves_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EllipticCurvesTest');
 goog.setTestOnly('tink.subtle.EllipticCurvesTest');
 

--- a/javascript/subtle/elliptic_curves_test.js
+++ b/javascript/subtle/elliptic_curves_test.js
@@ -406,7 +406,7 @@ testSuite({
  * Runs the test with test vector given as an input and returns either empty
  * string or a text describing the failure.
  *
- * @param {!Object} test - JSON object with test data
+ * @param {{private: !webCrypto.JsonWebKey, public: !webCrypto.JsonWebKey, result: string, shared: string, tcId: string}} test - JSON object with test data
  * @return {!Promise<string>}
  */
 const runWycheproofTest = async function(test) {

--- a/javascript/subtle/elliptic_curves_test.js
+++ b/javascript/subtle/elliptic_curves_test.js
@@ -293,7 +293,7 @@ testSuite({
     try {
       EllipticCurves.pointEncode(point['crv'], format, point);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: invalid format', e.toString());
     }
   },
@@ -310,7 +310,7 @@ testSuite({
       try {
         EllipticCurves.pointDecode(curveTypeString, format, point);
         fail('Should throw an exception.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals('CustomError: invalid point', e.toString());
       }
     }
@@ -324,7 +324,7 @@ testSuite({
     try {
       EllipticCurves.pointDecode(curve, format, point);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: invalid format', e.toString());
     }
   },
@@ -337,7 +337,7 @@ testSuite({
     try {
       EllipticCurves.pointDecode(curve, format, point);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertTrue(e.toString().includes('unknown curve'));
     }
   },
@@ -379,7 +379,7 @@ testSuite({
       try {
         EllipticCurves.ecdsaDer2Ieee(
             Bytes.fromHex(test), 1 /* ieeeLength, ignored */);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         assertEquals('CustomError: invalid DER signature', e.toString());
       }
     }
@@ -422,13 +422,13 @@ const runWycheproofTest = async function(test) {
         return 'Fail on test ' + test['tcId'] + ': unexpected result was \"' +
             sharedSecretHex + '\".\n';
       }
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       if (test['result'] === 'valid') {
         return 'Fail on test ' + test['tcId'] + ': unexpected exception \"' +
             e.toString() + '\".\n';
       }
     }
-  } catch (e) {
+  } catch (/** @type {!Object} */e) {
     if (test['result'] === 'valid') {
       if (test['private']['crv'] == "P-256K") {
         // P-256K doesn't have to be supported. Hence failing to import the

--- a/javascript/subtle/elliptic_curves_test.js
+++ b/javascript/subtle/elliptic_curves_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EllipticCurvesTest');
 goog.setTestOnly('tink.subtle.EllipticCurvesTest');
@@ -297,7 +297,7 @@ testSuite({
     try {
       EllipticCurves.pointEncode(point['crv'], format, point);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: invalid format', e.toString());
     }
   },
@@ -314,7 +314,7 @@ testSuite({
       try {
         EllipticCurves.pointDecode(curveTypeString, format, point);
         fail('Should throw an exception.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals('CustomError: invalid point', e.toString());
       }
     }
@@ -328,7 +328,7 @@ testSuite({
     try {
       EllipticCurves.pointDecode(curve, format, point);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: invalid format', e.toString());
     }
   },
@@ -341,7 +341,7 @@ testSuite({
     try {
       EllipticCurves.pointDecode(curve, format, point);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertTrue(e.toString().includes('unknown curve'));
     }
   },
@@ -383,7 +383,7 @@ testSuite({
       try {
         EllipticCurves.ecdsaDer2Ieee(
             Bytes.fromHex(test), 1 /* ieeeLength, ignored */);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         assertEquals('CustomError: invalid DER signature', e.toString());
       }
     }
@@ -406,7 +406,7 @@ testSuite({
  * Runs the test with test vector given as an input and returns either empty
  * string or a text describing the failure.
  *
- * @param {{private: !webCrypto.JsonWebKey, public: !webCrypto.JsonWebKey, result: string, shared: string, tcId: string}} test - JSON object with test data
+ * @param {!Object} test - JSON object with test data
  * @return {!Promise<string>}
  */
 const runWycheproofTest = async function(test) {
@@ -426,13 +426,13 @@ const runWycheproofTest = async function(test) {
         return 'Fail on test ' + test['tcId'] + ': unexpected result was \"' +
             sharedSecretHex + '\".\n';
       }
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       if (test['result'] === 'valid') {
         return 'Fail on test ' + test['tcId'] + ': unexpected exception \"' +
             e.toString() + '\".\n';
       }
     }
-  } catch (/** @type {!Object} */e) {
+  } catch (e) {
     if (test['result'] === 'valid') {
       if (test['private']['crv'] == "P-256K") {
         // P-256K doesn't have to be supported. Hence failing to import the

--- a/javascript/subtle/encrypt_then_authenticate.js
+++ b/javascript/subtle/encrypt_then_authenticate.js
@@ -47,13 +47,13 @@ class EncryptThenAuthenticate {
    * @throws {InvalidArgumentsException}
    */
   constructor(cipher, ivSize, mac, tagSize) {
-    /** @const @private {IndCpaCipher} */
+    /** @const @private {!IndCpaCipher} */
     this.cipher_ = cipher;
 
     /** @const @private {number} */
     this.ivSize_ = ivSize;
 
-    /** @const @private {Mac} */
+    /** @const @private {!Mac} */
     this.mac_ = mac;
 
     /** @const @private {number} */

--- a/javascript/subtle/encrypt_then_authenticate_test.js
+++ b/javascript/subtle/encrypt_then_authenticate_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.EncryptThenAuthenticateTest');
 goog.setTestOnly('tink.subtle.EncryptThenAuthenticateTest');
@@ -78,7 +78,7 @@ testSuite({
           'blah' /* aesKey */, 12 /* ivSize */, 'SHA-256',
           Random.randBytes(16) /* hmacKey */, 10 /* tagSize */);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -87,7 +87,7 @@ testSuite({
           Random.randBytes(16) /* aesKey */, 12 /* ivSize */, 'SHA-256',
           'blah' /* hmacKey */, 10 /* tagSize */);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -98,28 +98,28 @@ testSuite({
     try {
       await aead.encrypt('blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.encrypt(Random.randBytes(20), 'blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt('blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt(Random.randBytes(32), 'blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -139,7 +139,7 @@ testSuite({
         try {
           await aead.decrypt(c1, aad);
           fail('Should throw an exception.');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
           assertEquals('CustomError: invalid MAC', e.toString());
         }
       }
@@ -160,7 +160,7 @@ testSuite({
         try {
           await aead.decrypt(ciphertext, aad1);
           fail('Should throw an exception.');
-        } catch (/** @type {!Object} */e) {
+        } catch (e) {
           assertEquals('CustomError: invalid MAC', e.toString());
         }
       }
@@ -179,7 +179,7 @@ testSuite({
       try {
         await aead.decrypt(c1, aad);
         fail('Should throw an exception.');
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         if (c1.length < 32) {
           assertEquals('CustomError: ciphertext too short', e.toString());
         } else {
@@ -195,8 +195,7 @@ testSuite({
     // use CTR while RFC uses CBC mode, it's not possible to compare plaintexts.
     // However, the test is still valueable to make sure that we correcly
     // compute HMAC over ciphertext and aad.
-    const /** !Array<{macKey: string, encryptionKey: string, ciphertext: string,
-      aad: string, hashAlgoName: string, ivSize: number, tagSize: number}> */RFC_TEST_VECTORS = [
+    const RFC_TEST_VECTORS = [
       {
         'macKey': '000102030405060708090a0b0c0d0e0f',
         'encryptionKey': '101112131415161718191a1b1c1d1e1f',
@@ -252,7 +251,7 @@ testSuite({
       const aad = Bytes.fromHex(testVector['aad']);
       try {
         await aead.decrypt(ciphertext, aad);
-      } catch (/** @type {!Object} */e) {
+      } catch (e) {
         fail(e);
       }
     }

--- a/javascript/subtle/encrypt_then_authenticate_test.js
+++ b/javascript/subtle/encrypt_then_authenticate_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.EncryptThenAuthenticateTest');
 goog.setTestOnly('tink.subtle.EncryptThenAuthenticateTest');
 

--- a/javascript/subtle/encrypt_then_authenticate_test.js
+++ b/javascript/subtle/encrypt_then_authenticate_test.js
@@ -195,7 +195,8 @@ testSuite({
     // use CTR while RFC uses CBC mode, it's not possible to compare plaintexts.
     // However, the test is still valueable to make sure that we correcly
     // compute HMAC over ciphertext and aad.
-    const RFC_TEST_VECTORS = [
+    const /** !Array<{macKey: string, encryptionKey: string, ciphertext: string,
+      aad: string, hashAlgoName: string, ivSize: number, tagSize: number}> */RFC_TEST_VECTORS = [
       {
         'macKey': '000102030405060708090a0b0c0d0e0f',
         'encryptionKey': '101112131415161718191a1b1c1d1e1f',

--- a/javascript/subtle/encrypt_then_authenticate_test.js
+++ b/javascript/subtle/encrypt_then_authenticate_test.js
@@ -74,7 +74,7 @@ testSuite({
           'blah' /* aesKey */, 12 /* ivSize */, 'SHA-256',
           Random.randBytes(16) /* hmacKey */, 10 /* tagSize */);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -83,7 +83,7 @@ testSuite({
           Random.randBytes(16) /* aesKey */, 12 /* ivSize */, 'SHA-256',
           'blah' /* hmacKey */, 10 /* tagSize */);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -94,28 +94,28 @@ testSuite({
     try {
       await aead.encrypt('blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.encrypt(Random.randBytes(20), 'blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt('blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await aead.decrypt(Random.randBytes(32), 'blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -135,7 +135,7 @@ testSuite({
         try {
           await aead.decrypt(c1, aad);
           fail('Should throw an exception.');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
           assertEquals('CustomError: invalid MAC', e.toString());
         }
       }
@@ -156,7 +156,7 @@ testSuite({
         try {
           await aead.decrypt(ciphertext, aad1);
           fail('Should throw an exception.');
-        } catch (e) {
+        } catch (/** @type {!Object} */e) {
           assertEquals('CustomError: invalid MAC', e.toString());
         }
       }
@@ -175,7 +175,7 @@ testSuite({
       try {
         await aead.decrypt(c1, aad);
         fail('Should throw an exception.');
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         if (c1.length < 32) {
           assertEquals('CustomError: ciphertext too short', e.toString());
         } else {
@@ -247,7 +247,7 @@ testSuite({
       const aad = Bytes.fromHex(testVector['aad']);
       try {
         await aead.decrypt(ciphertext, aad);
-      } catch (e) {
+      } catch (/** @type {!Object} */e) {
         fail(e);
       }
     }

--- a/javascript/subtle/hkdf_test.js
+++ b/javascript/subtle/hkdf_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.HkdfTest');
 goog.setTestOnly('tink.subtle.HkdfTest');
@@ -31,14 +31,14 @@ testSuite({
     try {
       await Hkdf.compute(0, 'SHA-256', ikm, info);  // 0 output size
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
 
     try {
       await Hkdf.compute(-1, 'SHA-256', ikm, info);  // negative output size
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
 
@@ -47,7 +47,7 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 20) + 1, 'SHA-1', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
@@ -56,7 +56,7 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 32) + 1, 'SHA-256', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
@@ -65,14 +65,14 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 64) + 1, 'SHA-512', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
     try {
       await Hkdf.compute(1, 'SHA-256', 'blah', info);  // wrong type
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -80,7 +80,7 @@ testSuite({
     try {
       await Hkdf.compute(1, 'SHA-256', ikm, 'blah');  // wrong type
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -88,7 +88,7 @@ testSuite({
     try {
       await Hkdf.compute(1, 'SHA-256', ikm, info, 'blah');  // size too large
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -100,29 +100,28 @@ testSuite({
     try {
       await Hkdf.compute(NaN, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
     try {
       await Hkdf.compute(undefined, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
     try {
       await Hkdf.compute(1.5, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
   },
 
   async testWithTestVectors() {
     // Test cases are specified in Appendix A of RFC 5869.
-    const /** !Array<{hash: string, output: string, outputSize: number,
-      ikm: string, salt: string, info: string}> */TEST_VECTORS = [
+    const TEST_VECTORS = [
       {
         'hash': 'SHA-256',
         'output':

--- a/javascript/subtle/hkdf_test.js
+++ b/javascript/subtle/hkdf_test.js
@@ -27,14 +27,14 @@ testSuite({
     try {
       await Hkdf.compute(0, 'SHA-256', ikm, info);  // 0 output size
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
 
     try {
       await Hkdf.compute(-1, 'SHA-256', ikm, info);  // negative output size
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be positive', e.toString());
     }
 
@@ -43,7 +43,7 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 20) + 1, 'SHA-1', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
@@ -52,7 +52,7 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 32) + 1, 'SHA-256', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
@@ -61,14 +61,14 @@ testSuite({
           /** 255 * digestSize + 1 */ (255 * 64) + 1, 'SHA-512', ikm,
           info);  // size too large
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size too large', e.toString());
     }
 
     try {
       await Hkdf.compute(1, 'SHA-256', 'blah', info);  // wrong type
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -76,7 +76,7 @@ testSuite({
     try {
       await Hkdf.compute(1, 'SHA-256', ikm, 'blah');  // wrong type
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -84,7 +84,7 @@ testSuite({
     try {
       await Hkdf.compute(1, 'SHA-256', ikm, info, 'blah');  // size too large
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -96,21 +96,21 @@ testSuite({
     try {
       await Hkdf.compute(NaN, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
     try {
       await Hkdf.compute(undefined, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
 
     try {
       await Hkdf.compute(1.5, 'SHA-256', ikm, info);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: size must be an integer', e.toString());
     }
   },

--- a/javascript/subtle/hkdf_test.js
+++ b/javascript/subtle/hkdf_test.js
@@ -12,6 +12,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.HkdfTest');
 goog.setTestOnly('tink.subtle.HkdfTest');
 

--- a/javascript/subtle/hkdf_test.js
+++ b/javascript/subtle/hkdf_test.js
@@ -16,10 +16,6 @@
  * @fileoverview
  * @suppress {checkTypes}
  */
-/**
- * @fileoverview
- * @suppress {checkTypes}
- */
 goog.module('tink.subtle.HkdfTest');
 goog.setTestOnly('tink.subtle.HkdfTest');
 
@@ -125,7 +121,8 @@ testSuite({
 
   async testWithTestVectors() {
     // Test cases are specified in Appendix A of RFC 5869.
-    const TEST_VECTORS = [
+    const /** !Array<{hash: string, output: string, outputSize: number,
+      ikm: string, salt: string, info: string}> */TEST_VECTORS = [
       {
         'hash': 'SHA-256',
         'output':

--- a/javascript/subtle/hmac_test.js
+++ b/javascript/subtle/hmac_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.subtle.HmacTest');
 goog.setTestOnly('tink.subtle.HmacTest');
 

--- a/javascript/subtle/hmac_test.js
+++ b/javascript/subtle/hmac_test.js
@@ -35,7 +35,7 @@ testSuite({
       await Hmac.newInstance(
           'blah', Random.randBytes(16), 16);  // invalid HMAC algo name
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals('CustomError: blah is not supported', e.toString());
     }
 
@@ -43,7 +43,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -53,7 +53,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -62,7 +62,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(16), 21);  // tag size too long
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 20 bytes',
           e.toString());
@@ -72,7 +72,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -82,7 +82,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -92,7 +92,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(16), 33);  // tag size too long
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 32 bytes',
           e.toString());
@@ -102,7 +102,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -112,7 +112,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -122,7 +122,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(16), 65);  // tag size too long
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 64 bytes',
           e.toString());
@@ -133,7 +133,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), NaN);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -141,7 +141,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), undefined);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -149,7 +149,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), 12.5);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -159,14 +159,14 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-1', 'blah', 10);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await Hmac.newInstance('SHA-1', 123, 10);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -175,42 +175,42 @@ testSuite({
     try {
       await hmac.computeMac('blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.computeMac('123');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac('blah', Random.randBytes(20));
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(123, Random.randBytes(20));
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(Random.randBytes(20), 'blah');
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(Random.randBytes(20), 123);
       fail('Should throw an exception.');
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }

--- a/javascript/subtle/hmac_test.js
+++ b/javascript/subtle/hmac_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.subtle.HmacTest');
 goog.setTestOnly('tink.subtle.HmacTest');
@@ -39,7 +39,7 @@ testSuite({
       await Hmac.newInstance(
           'blah', Random.randBytes(16), 16);  // invalid HMAC algo name
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals('CustomError: blah is not supported', e.toString());
     }
 
@@ -47,7 +47,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -57,7 +57,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -66,7 +66,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-1', Random.randBytes(16), 21);  // tag size too long
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 20 bytes',
           e.toString());
@@ -76,7 +76,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -86,7 +86,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -96,7 +96,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-256', Random.randBytes(16), 33);  // tag size too long
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 32 bytes',
           e.toString());
@@ -106,7 +106,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(15), 16);  // invalid key size
       // TODO(b/115974209): This case does not throw an exception.
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: key too short, must be at least 16 bytes',
           e.toString());
@@ -116,7 +116,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(16), 9);  // tag size too short
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too short, must be at least 10 bytes',
           e.toString());
@@ -126,7 +126,7 @@ testSuite({
       await Hmac.newInstance(
           'SHA-512', Random.randBytes(16), 65);  // tag size too long
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: tag too long, must not be larger than 64 bytes',
           e.toString());
@@ -137,7 +137,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), NaN);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -145,7 +145,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), undefined);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -153,7 +153,7 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-512', Random.randBytes(16), 12.5);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: invalid tag size, must be an integer', e.toString());
     }
@@ -163,14 +163,14 @@ testSuite({
     try {
       await Hmac.newInstance('SHA-1', 'blah', 10);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await Hmac.newInstance('SHA-1', 123, 10);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -179,42 +179,42 @@ testSuite({
     try {
       await hmac.computeMac('blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.computeMac('123');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac('blah', Random.randBytes(20));
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(123, Random.randBytes(20));
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(Random.randBytes(20), 'blah');
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
     try {
       await hmac.verifyMac(Random.randBytes(20), 123);
       fail('Should throw an exception.');
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           'CustomError: input must be a non null Uint8Array', e.toString());
     }
@@ -245,7 +245,7 @@ testSuite({
   async testWithTestVectors() {
     // Test data from
     // http://csrc.nist.gov/groups/STM/cavp/message-authentication.html#testing.
-    const /** !Array<{algo: string, key: string, message: string, tag: string}> */NIST_TEST_VECTORS = [
+    const NIST_TEST_VECTORS = [
       {
         'algo': 'SHA-1',
         'key':

--- a/javascript/subtle/hmac_test.js
+++ b/javascript/subtle/hmac_test.js
@@ -245,7 +245,7 @@ testSuite({
   async testWithTestVectors() {
     // Test data from
     // http://csrc.nist.gov/groups/STM/cavp/message-authentication.html#testing.
-    const NIST_TEST_VECTORS = [
+    const /** !Array<{algo: string, key: string, message: string, tag: string}> */NIST_TEST_VECTORS = [
       {
         'algo': 'SHA-1',
         'key':

--- a/javascript/subtle/purejs/BUILD.bazel
+++ b/javascript/subtle/purejs/BUILD.bazel
@@ -11,6 +11,7 @@ closure_js_library(
     srcs = [
         "aes_ctr.js",
     ],
+    #lenient = True,
     deps = [
         "//javascript:primitives",
         "//javascript/exception",
@@ -26,6 +27,7 @@ closure_js_library(
     srcs = [
         "hmac.js",
     ],
+    #lenient = True,
     deps = [
         "//javascript:primitives",
         "//javascript/exception",

--- a/javascript/subtle/purejs/aes_ctr.js
+++ b/javascript/subtle/purejs/aes_ctr.js
@@ -45,7 +45,7 @@ class AesCtr {
     /** @const @private {number} */
     this.ivSize_ = ivSize;
 
-    /** @const @private {Ctr} */
+    /** @const @private {!Ctr} */
     this.ctr_ = new Ctr(new Aes(Array.from(key)));
   }
 

--- a/javascript/subtle/purejs/hmac.js
+++ b/javascript/subtle/purejs/hmac.js
@@ -41,7 +41,7 @@ class Hmac {
     /** @const @private {number} */
     this.tagSize_ = tagSize;
 
-    /** @private {GoogHmac} */
+    /** @private {!GoogHmac} */
     this.hmac_;
 
     switch (hash) {

--- a/javascript/subtle/random.js
+++ b/javascript/subtle/random.js
@@ -34,7 +34,9 @@ const randBytes = function(n) {
   }
   const result = new Uint8Array(n);
   if (n) {  // Edge can't handle an empty array
-    const crypto = goog.global['crypto'] || goog.global['msCrypto'];
+    const crypto = /** @type {?webCrypto.Crypto} */(
+      goog.global['crypto']) || /** @type {!webCrypto.Crypto} */(
+        goog.global['msCrypto']);
     crypto.getRandomValues(result);
   }
   return result;

--- a/javascript/util_test.js
+++ b/javascript/util_test.js
@@ -12,6 +12,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @fileoverview
+ * @suppress {checkTypes}
+ */
 goog.module('tink.UtilTest');
 goog.setTestOnly('tink.UtilTest');
 

--- a/javascript/util_test.js
+++ b/javascript/util_test.js
@@ -39,7 +39,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.InvalidKeyMissingKeyData(key.getKeyId()), e.toString());
       return;
@@ -53,7 +53,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownPrefix(key.getKeyId()), e.toString());
       return;
@@ -67,7 +67,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()), e.toString());
       return;
@@ -89,7 +89,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.InvalidKeysetMissingKeys(), e.toString());
       return;
     }
@@ -104,7 +104,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(ExceptionText.InvalidKeysetDisabledPrimary(), e.toString());
       return;
     }
@@ -121,7 +121,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.InvalidKeysetMultiplePrimaries(), e.toString());
       return;
@@ -138,7 +138,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (e) {
+    } catch (/** @type {!Object} */e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()), e.toString());
       return;

--- a/javascript/util_test.js
+++ b/javascript/util_test.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview
- * @suppress {checkTypes}
+ * @suppress {checkTypes, reportUnknownTypes}
  */
 goog.module('tink.UtilTest');
 goog.setTestOnly('tink.UtilTest');
@@ -43,7 +43,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.InvalidKeyMissingKeyData(key.getKeyId()), e.toString());
       return;
@@ -57,7 +57,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownPrefix(key.getKeyId()), e.toString());
       return;
@@ -71,7 +71,7 @@ testSuite({
 
     try {
       await Util.validateKey(key);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()), e.toString());
       return;
@@ -93,7 +93,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.InvalidKeysetMissingKeys(), e.toString());
       return;
     }
@@ -108,7 +108,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(ExceptionText.InvalidKeysetDisabledPrimary(), e.toString());
       return;
     }
@@ -125,7 +125,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.InvalidKeysetMultiplePrimaries(), e.toString());
       return;
@@ -142,7 +142,7 @@ testSuite({
 
     try {
       await Util.validateKeyset(keyset);
-    } catch (/** @type {!Object} */e) {
+    } catch (e) {
       assertEquals(
           ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()), e.toString());
       return;


### PR DESCRIPTION
Bazel rules now work for the Javascript, but the closure compiler throws an internal compiler error on the definition of `SecurityException` in `javascript/exception/securityexception.js`.

More work is needed, but this is a starting point, and I want to make sure there are no regressions in the rest of Tink.

#189 advice was followed to rearrange the order of `WORKSPACE`, but perhaps more can be done.

More advice is appreciated.
