### PR TITLE
go: Add JSONReader and JSONWriter

### DIFF
--- a/go/keyset/json_io.go
+++ b/go/keyset/json_io.go
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package keyset
+
+import (
+	"io"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+)
+
+// JSONReader deserializes a keyset from jsonpb format.
+type JSONReader struct {
+	r io.Reader
+}
+
+// NewJSONReader returns new JSONReader that will read from r.
+func NewJSONReader(r io.Reader) *JSONReader {
+	return &JSONReader{r: r}
+}
+
+// Read parses a (cleartext) keyset from the underlying io.Reader.
+func (jkr *JSONReader) Read() (*tinkpb.Keyset, error) {
+	keyset := &tinkpb.Keyset{}
+
+	if err := jsonpb.Unmarshal(jkr.r, keyset); err != nil {
+		return nil, err
+	}
+	return keyset, nil
+}
+
+// ReadEncrypted parses an EncryptedKeyset from the underlying io.Reader.
+func (jkr *JSONReader) ReadEncrypted() (*tinkpb.EncryptedKeyset, error) {
+	keyset := &tinkpb.EncryptedKeyset{}
+
+	if err := jsonpb.Unmarshal(jkr.r, keyset); err != nil {
+		return nil, err
+	}
+	return keyset, nil
+}
+
+// JSONWriter serializes a keyset into jsonpb format.
+type JSONWriter struct {
+	w      io.Writer
+	Indent string
+}
+
+// NewJSONWriter returns a new JSONWriter that will write to w.
+func NewJSONWriter(w io.Writer) *JSONWriter {
+	return &JSONWriter{w: w}
+}
+
+// Write writes the keyset to the underlying io.Writer.
+func (jkw *JSONWriter) Write(keyset *tinkpb.Keyset) error {
+	return jkw.writeJSON(jkw.w, keyset)
+}
+
+// WriteEncrypted writes the encrypted keyset to the underlying io.Writer.
+func (jkw *JSONWriter) WriteEncrypted(keyset *tinkpb.EncryptedKeyset) error {
+	return jkw.writeJSON(jkw.w, keyset)
+}
+
+func (jkw *JSONWriter) writeJSON(w io.Writer, msg proto.Message) error {
+	m := &jsonpb.Marshaler{Indent: jkw.Indent}
+	return m.Marshal(w, msg)
+}

--- a/go/keyset/json_io_test.go
+++ b/go/keyset/json_io_test.go
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package keyset_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/testkeyset"
+	"github.com/google/tink/go/testutil"
+
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+)
+
+func TestJSONIOUnencrypted(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := keyset.NewJSONWriter(buf)
+	r := keyset.NewJSONReader(buf)
+
+	manager := testutil.NewHMACKeysetManager()
+	h, err := manager.Handle()
+	if h == nil || err != nil {
+		t.Fatalf("cannot get keyset handle: %v", err)
+	}
+
+	ks1 := testkeyset.KeysetMaterial(h)
+	if err := w.Write(ks1); err != nil {
+		t.Fatalf("cannot write keyset: %v", err)
+	}
+
+	ks2, err := r.Read()
+	if err != nil {
+		t.Fatalf("cannot read keyset: %v", err)
+	}
+
+	if !proto.Equal(ks1, ks2) {
+		t.Errorf("written keyset (%s) doesn't match read keyset (%s)", ks1, ks2)
+	}
+}
+
+func TestJSONIOEncrypted(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := keyset.NewJSONWriter(buf)
+	r := keyset.NewJSONReader(buf)
+
+	kse1 := &tinkpb.EncryptedKeyset{EncryptedKeyset: []byte(strings.Repeat("A", 32))}
+
+	if err := w.WriteEncrypted(kse1); err != nil {
+		t.Fatalf("cannot write encrypted keyset: %v", err)
+	}
+
+	kse2, err := r.ReadEncrypted()
+	if err != nil {
+		t.Fatalf("cannot read encryped keyset: %v", err)
+	}
+
+	if !proto.Equal(kse1, kse2) {
+		t.Errorf("written encryped keyset (%s) doesn't match read encryped keyset (%s)", kse1, kse2)
+	}
+}


### PR DESCRIPTION
Adds a JSONReader and JSONWriter that uses `jsonpb` to marshal/unmarshal keysets according to proto3 JSON format https://developers.google.com/protocol-buffers/docs/proto3#json