### PR TITLE
Java: Remove e.printStracktrace() in favor of a cause

### DIFF
--- a/java/src/main/java/com/google/crypto/tink/subtle/EngineFactory.java
+++ b/java/src/main/java/com/google/crypto/tink/subtle/EngineFactory.java
@@ -155,28 +155,23 @@ public final class EngineFactory<T_WRAPPER extends EngineWrapper<T_ENGINE>, T_EN
   }
 
   public T_ENGINE getInstance(String algorithm) throws GeneralSecurityException {
-    for (Provider p : this.policy) {
-      if (tryProvider(algorithm, p)) {
-        return this.instanceBuilder.getInstance(algorithm, p);
+    Exception cause = null;
+    for (Provider provider : this.policy) {
+      try {
+        return this.instanceBuilder.getInstance(algorithm, provider);
+      } catch (Exception e) {
+        if (cause == null) {
+          cause = e;
+        }
       }
     }
     if (letFallback) {
       return this.instanceBuilder.getInstance(algorithm, null);
     }
-    throw new GeneralSecurityException("No good Provider found.");
+    throw new GeneralSecurityException("No good Provider found.", cause);
   }
 
   private T_WRAPPER instanceBuilder;
   private List<Provider> policy;
   private boolean letFallback;
-
-  private boolean tryProvider(String algorithm, Provider provider) {
-    try {
-      this.instanceBuilder.getInstance(algorithm, provider);
-      return true;
-    } catch (Exception e) { // Don't care which one specifically.
-      e.printStackTrace();
-      return false;
-    }
-  }
 }


### PR DESCRIPTION
I haven't tested this, but using `e.printStacktrace()` seemed like a code smell while browsing the code.