### PR TITLE
enhance(golang): enhance Encrypt, ComputeMAC and Sign memory allocation 

### DIFF
--- a/go/aead/aead_factory.go
+++ b/go/aead/aead_factory.go
@@ -62,7 +62,7 @@ func (a *primitiveSet) Encrypt(pt, ad []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ret []byte
+	ret := make([]byte, 0, len(primary.Prefix) + len(ct))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, ct...)
 	return ret, nil

--- a/go/daead/daead_factory.go
+++ b/go/daead/daead_factory.go
@@ -59,7 +59,7 @@ func (d *primitiveSet) EncryptDeterministically(pt, aad []byte) ([]byte, error) 
 		return nil, err
 	}
 
-	var ret []byte
+	ret := make([]byte, 0, len(primary.Prefix) + len(ct))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, ct...)
 	return ret, nil

--- a/go/hybrid/hybrid_encrypt_factory.go
+++ b/go/hybrid/hybrid_encrypt_factory.go
@@ -60,7 +60,7 @@ func (a *encryptPrimitiveSet) Encrypt(pt, ad []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ret []byte
+	ret := make([]byte, 0, len(primary.Prefix) + len(ct))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, ct...)
 	return ret, nil

--- a/go/mac/mac_factory.go
+++ b/go/mac/mac_factory.go
@@ -62,7 +62,7 @@ func (m *primitiveSet) ComputeMAC(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ret []byte
+	ret := make([]byte, 0, len(primary.Prefix) + len(mac))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, mac...)
 	return ret, nil

--- a/go/signature/signer_factory.go
+++ b/go/signature/signer_factory.go
@@ -69,7 +69,7 @@ func (s *signerSet) Sign(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ret []byte
+	ret := make([]byte, 0, len(primary.Prefix) + len(signature))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, signature...)
 	return ret, nil

--- a/go/subtle/aead/aes_gcm.go
+++ b/go/subtle/aead/aes_gcm.go
@@ -67,7 +67,7 @@ func (a *AESGCM) Encrypt(pt, aad []byte) ([]byte, error) {
 	}
 	iv := a.newIV()
 	ct := cipher.Seal(nil, iv, pt, aad)
-	var ret []byte
+	ret := make([]byte, 0, len(iv) + len(ct))
 	ret = append(ret, iv...)
 	ret = append(ret, ct...)
 	return ret, nil

--- a/go/subtle/aead/chacha20poly1305.go
+++ b/go/subtle/aead/chacha20poly1305.go
@@ -52,7 +52,7 @@ func (ca *ChaCha20Poly1305) Encrypt(pt []byte, aad []byte) ([]byte, error) {
 
 	n := ca.newNonce()
 	ct := c.Seal(nil, n, pt, aad)
-	var ret []byte
+	ret := make([]byte, 0, len(n) + len(ct))
 	ret = append(ret, n...)
 	ret = append(ret, ct...)
 	return ret, nil


### PR DESCRIPTION
Use make function to allocate the slice with a specific capacity  as we already know the size of the slice which is length of primary.Prefix + the length of ct.

https://play.golang.org/p/EffLlzZaw-9