### PR TITLE
Make `withCredentials` public

### DIFF
--- a/java/src/main/java/com/google/crypto/tink/integration/gcpkms/GcpKmsClient.java
+++ b/java/src/main/java/com/google/crypto/tink/integration/gcpkms/GcpKmsClient.java
@@ -108,7 +108,7 @@ public final class GcpKmsClient implements KmsClient {
   }
 
   /** Loads the provided credential. */
-  private KmsClient withCredentials(GoogleCredential credential) {
+  public KmsClient withCredentials(GoogleCredential credential) {
     if (credential.createScopedRequired()) {
       credential = credential.createScoped(CloudKMSScopes.all());
     }


### PR DESCRIPTION
This allows to instantiate a new KMSClient using GoogleCredential used elsewhere in the app.

Related to #241 