### PR TITLE
Add kmsclient#setKeyUri works with tinkey

### DIFF
--- a/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
+++ b/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
@@ -115,6 +115,7 @@ public final class AwsKmsClient implements KmsClient {
       this.provider = provider;
       return this;
     }
+
     @Override
     public Aead getAead(String uri) throws GeneralSecurityException {
       if (this.keyUri != null && !this.keyUri.equals(uri)) {

--- a/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
+++ b/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
@@ -123,17 +123,18 @@ public final class AwsKmsClient implements KmsClient {
             String.format(
                 "this client is bound to %s, cannot load keys bound to %s", this.keyUri, uri));
       }
-    try {
-      String keyUri = Validators.validateKmsKeyUriAndRemovePrefix(PREFIX, uri);
-      String[] tokens = keyUri.split(":");
-      AWSKMS client =
-            AWSKMSClientBuilder.standard()
-                .withCredentials(provider)
-                .withRegion(Regions.fromName(tokens[4]))
-                .build();
-        return new AwsKmsAead(client, keyUri);
-      } catch (AmazonServiceException e) {
-        throw new GeneralSecurityException("cannot load credentials from provider", e);
-      }
+
+      try {
+        String keyUri = Validators.validateKmsKeyUriAndRemovePrefix(PREFIX, uri);
+        String[] tokens = keyUri.split(":");
+        AWSKMS client =
+              AWSKMSClientBuilder.standard()
+                  .withCredentials(provider)
+                  .withRegion(Regions.fromName(tokens[4]))
+                  .build();
+          return new AwsKmsAead(client, keyUri);
+        } catch (AmazonServiceException e) {
+          throw new GeneralSecurityException("cannot load credentials from provider", e);
+        }
     }
 }

--- a/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
+++ b/java/src/main/java/com/google/crypto/tink/integration/awskms/AwsKmsClient.java
@@ -41,6 +41,7 @@ public final class AwsKmsClient implements KmsClient {
 
   private AWSKMS client;
   private String keyUri;
+  private AWSCredentialsProvider provider;
 
   /** Constructs a generic AwsKmsClient that is not bound to any specific key. */
   public AwsKmsClient() {}


### PR DESCRIPTION
`tinkey` command uses ServiceLoader but it didn't initialize `keyUri` member in `KmsClient`, then it caused NullPointerException  from such as `#withCredentialsProvider` method.