### PR TITLE
feat: Go: Add signature key templates WithoutPrefix

### DIFF
--- a/go/hybrid/hybrid_factory_test.go
+++ b/go/hybrid/hybrid_factory_test.go
@@ -95,7 +95,7 @@ func TestHybridFactoryTest(t *testing.T) {
 			t.Error(err)
 		}
 		if !bytes.Equal(pt, gotpt) {
-			t.Error(err)
+			t.Error("expected pt:", pt, " not equal to decrypted pt:", gotpt)
 		}
 	}
 }

--- a/go/signature/signature_key_templates.go
+++ b/go/signature/signature_key_templates.go
@@ -28,35 +28,81 @@ import (
 //   - Hash function: SHA256
 //   - Curve: NIST P-256
 //   - Signature encoding: DER
+//   - Output prefix type: TINK
 func ECDSAP256KeyTemplate() *tinkpb.KeyTemplate {
 	return createECDSAKeyTemplate(commonpb.HashType_SHA256,
 		commonpb.EllipticCurveType_NIST_P256,
-		ecdsapb.EcdsaSignatureEncoding_DER)
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_TINK)
+}
+
+// ECDSAP256KeyWithoutPrefixTemplate is a KeyTemplate that generates a new ECDSA private key with the following
+// parameters:
+//   - Hash function: SHA256
+//   - Curve: NIST P-256
+//   - Signature encoding: DER
+//   - Output prefix type: RAW
+func ECDSAP256KeyWithoutPrefixTemplate() *tinkpb.KeyTemplate {
+	return createECDSAKeyTemplate(commonpb.HashType_SHA256,
+		commonpb.EllipticCurveType_NIST_P256,
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_RAW)
 }
 
 // ECDSAP384KeyTemplate is a KeyTemplate that generates a new ECDSA private key with the following parameters:
 //   - Hash function: SHA512
 //   - Curve: NIST P-384
 //   - Signature encoding: DER
+//   - Output prefix type: TINK
 func ECDSAP384KeyTemplate() *tinkpb.KeyTemplate {
 	return createECDSAKeyTemplate(commonpb.HashType_SHA512,
 		commonpb.EllipticCurveType_NIST_P384,
-		ecdsapb.EcdsaSignatureEncoding_DER)
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_TINK)
+}
+
+// ECDSAP384KeyWithoutPrefixTemplate is a KeyTemplate that generates a new ECDSA private key with the following
+// parameters:
+//   - Hash function: SHA512
+//   - Curve: NIST P-384
+//   - Signature encoding: DER
+//   - Output prefix type: RAW
+func ECDSAP384KeyWithoutPrefixTemplate() *tinkpb.KeyTemplate {
+	return createECDSAKeyTemplate(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P384,
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_RAW)
 }
 
 // ECDSAP521KeyTemplate is a KeyTemplate that generates a new ECDSA private key with the following parameters:
 //   - Hash function: SHA512
 //   - Curve: NIST P-521
 //   - Signature encoding: DER
+//   - Output prefix type: TINK
 func ECDSAP521KeyTemplate() *tinkpb.KeyTemplate {
 	return createECDSAKeyTemplate(commonpb.HashType_SHA512,
 		commonpb.EllipticCurveType_NIST_P521,
-		ecdsapb.EcdsaSignatureEncoding_DER)
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_TINK)
+}
+
+// ECDSAP521KeyWithoutPrefixTemplate is a KeyTemplate that generates a new ECDSA private key with the following
+// parameters:
+//   - Hash function: SHA512
+//   - Curve: NIST P-521
+//   - Signature encoding: DER
+//   - Output prefix type: TINK
+func ECDSAP521KeyWithoutPrefixTemplate() *tinkpb.KeyTemplate {
+	return createECDSAKeyTemplate(commonpb.HashType_SHA512,
+		commonpb.EllipticCurveType_NIST_P521,
+		ecdsapb.EcdsaSignatureEncoding_DER,
+		tinkpb.OutputPrefixType_RAW)
 }
 
 // createECDSAKeyTemplate creates a KeyTemplate containing a EcdasKeyFormat
 // with the given parameters.
-func createECDSAKeyTemplate(hashType commonpb.HashType, curve commonpb.EllipticCurveType, encoding ecdsapb.EcdsaSignatureEncoding) *tinkpb.KeyTemplate {
+func createECDSAKeyTemplate(hashType commonpb.HashType, curve commonpb.EllipticCurveType,
+	encoding ecdsapb.EcdsaSignatureEncoding, prefixType tinkpb.OutputPrefixType) *tinkpb.KeyTemplate {
 	params := &ecdsapb.EcdsaParams{
 		HashType: hashType,
 		Curve:    curve,
@@ -65,14 +111,24 @@ func createECDSAKeyTemplate(hashType commonpb.HashType, curve commonpb.EllipticC
 	format := &ecdsapb.EcdsaKeyFormat{Params: params}
 	serializedFormat, _ := proto.Marshal(format)
 	return &tinkpb.KeyTemplate{
-		TypeUrl: ecdsaSignerTypeURL,
-		Value:   serializedFormat,
+		TypeUrl:          ecdsaSignerTypeURL,
+		Value:            serializedFormat,
+		OutputPrefixType: prefixType,
 	}
 }
 
 // ED25519KeyTemplate is a KeyTemplate that generates a new ED25519 private key.
 func ED25519KeyTemplate() *tinkpb.KeyTemplate {
 	return &tinkpb.KeyTemplate{
-		TypeUrl: ed25519SignerTypeURL,
+		TypeUrl:          ed25519SignerTypeURL,
+		OutputPrefixType: tinkpb.OutputPrefixType_TINK,
+	}
+}
+
+// ED25519KeyWithoutPrefixTemplate is a KeyTemplate that generates a new ED25519 private key.
+func ED25519KeyWithoutPrefixTemplate() *tinkpb.KeyTemplate {
+	return &tinkpb.KeyTemplate{
+		TypeUrl:          ed25519SignerTypeURL,
+		OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 	}
 }

--- a/go/signature/signature_key_templates_test.go
+++ b/go/signature/signature_key_templates_test.go
@@ -27,57 +27,162 @@ import (
 )
 
 func TestECDSAKeyTemplates(t *testing.T) {
-	var template *tinkpb.KeyTemplate
-	var err error
-	// ECDSA P-256
-	template = signature.ECDSAP256KeyTemplate()
-	err = checkECDSAKeyTemplate(template,
-		commonpb.HashType_SHA256,
-		commonpb.EllipticCurveType_NIST_P256,
-		ecdsapb.EcdsaSignatureEncoding_DER)
-	if err != nil {
-		t.Errorf("invalid ECDSA P-256 key template: %s", err)
+	var flagTests = []struct {
+		tcName      string
+		typeURL     string
+		sigTemplate *tinkpb.KeyTemplate
+		curveType   commonpb.EllipticCurveType
+		hashType    commonpb.HashType
+		sigEncoding ecdsapb.EcdsaSignatureEncoding
+		prefixType  tinkpb.OutputPrefixType
+	}{
+		{
+			tcName:      "P-256 with SHA256, DER format and TINK output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP256KeyTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P256,
+			hashType:    commonpb.HashType_SHA256,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_TINK,
+		},
+		{
+			tcName:      "P-384 with SHA512, DER format and TINK output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP384KeyTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P384,
+			hashType:    commonpb.HashType_SHA512,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_TINK,
+		},
+		{
+			tcName:      "P-521 with SHA512, DER format and TINK output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP521KeyTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P521,
+			hashType:    commonpb.HashType_SHA512,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_TINK,
+		},
+		{
+			tcName:      "P-256 with SHA256, DER format and RAW output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P256,
+			hashType:    commonpb.HashType_SHA256,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_RAW,
+		},
+		{
+			tcName:      "P-384 with SHA512, DER format and RAW output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P384,
+			hashType:    commonpb.HashType_SHA512,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_RAW,
+		},
+		{
+			tcName:      "P-521 with SHA512, DER format and RAW output prefix",
+			typeURL:     testutil.ECDSASignerTypeURL,
+			sigTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate(),
+			curveType:   commonpb.EllipticCurveType_NIST_P521,
+			hashType:    commonpb.HashType_SHA512,
+			sigEncoding: ecdsapb.EcdsaSignatureEncoding_DER,
+			prefixType:  tinkpb.OutputPrefixType_RAW,
+		},
 	}
-	// ECDSA P-384
-	template = signature.ECDSAP384KeyTemplate()
-	err = checkECDSAKeyTemplate(template,
-		commonpb.HashType_SHA512,
-		commonpb.EllipticCurveType_NIST_P384,
-		ecdsapb.EcdsaSignatureEncoding_DER)
-	if err != nil {
-		t.Errorf("invalid ECDSA P-384 key template: %s", err)
+
+	for _, tt := range flagTests {
+		t.Run("test ECDSA - "+tt.tcName, func(t *testing.T) {
+			err := checkECDSAKeyTemplate(tt.sigTemplate,
+				tt.typeURL,
+				tt.hashType,
+				tt.curveType,
+				tt.sigEncoding,
+				tt.prefixType)
+			if err != nil {
+				t.Errorf("failed %s: %s", tt.tcName, err)
+			}
+		})
 	}
-	// ECDSA P-521
-	template = signature.ECDSAP521KeyTemplate()
-	err = checkECDSAKeyTemplate(template,
-		commonpb.HashType_SHA512,
-		commonpb.EllipticCurveType_NIST_P521,
-		ecdsapb.EcdsaSignatureEncoding_DER)
-	if err != nil {
-		t.Errorf("invalid ECDSA P-521 key template: %s", err)
+}
+
+func TestED25519KeyTemplates(t *testing.T) {
+	var flagTests = []struct {
+		tcName      string
+		typeURL     string
+		sigTemplate *tinkpb.KeyTemplate
+		prefixType  tinkpb.OutputPrefixType
+	}{
+		{
+			tcName:      "ED25519 with TINK output prefix",
+			typeURL:     testutil.ED25519SignerTypeURL,
+			sigTemplate: signature.ED25519KeyTemplate(),
+			prefixType:  tinkpb.OutputPrefixType_TINK,
+		},
+		{
+			tcName:      "ED25519 with RAW output prefix",
+			typeURL:     testutil.ED25519SignerTypeURL,
+			sigTemplate: signature.ED25519KeyWithoutPrefixTemplate(),
+			prefixType:  tinkpb.OutputPrefixType_RAW,
+		},
+	}
+
+	for _, tt := range flagTests {
+		t.Run("Test ED25519 - "+tt.tcName, func(t *testing.T) {
+			err := checkKeyTypeAndOutputPrefix(tt.sigTemplate,
+				tt.typeURL,
+				tt.prefixType)
+			if err != nil {
+				t.Errorf("failed %s: %s", tt.tcName, err)
+			}
+		})
 	}
 }
 
 func checkECDSAKeyTemplate(template *tinkpb.KeyTemplate,
+	typeURL string,
 	hashType commonpb.HashType,
 	curve commonpb.EllipticCurveType,
-	encoding ecdsapb.EcdsaSignatureEncoding) error {
-	if template.TypeUrl != testutil.ECDSASignerTypeURL {
-		return fmt.Errorf("incorrect typeurl: expect %s, got %s", testutil.ECDSASignerTypeURL, template.TypeUrl)
+	encoding ecdsapb.EcdsaSignatureEncoding,
+	prefixType tinkpb.OutputPrefixType) error {
+	err := checkKeyTypeAndOutputPrefix(template, typeURL, prefixType)
+	if err != nil {
+		return err
 	}
+
 	format := new(ecdsapb.EcdsaKeyFormat)
-	if err := proto.Unmarshal(template.Value, format); err != nil {
+	err = proto.Unmarshal(template.Value, format)
+	if err != nil {
 		return fmt.Errorf("cannot unmarshak key format: %s", err)
 	}
+
 	params := format.Params
 	if params.HashType != hashType {
 		return fmt.Errorf("incorrect hash type: expect %d, got %d", hashType, params.HashType)
 	}
+
 	if params.Curve != curve {
 		return fmt.Errorf("incorrect curve: expect %d, got %d", curve, params.Curve)
 	}
+
 	if params.Encoding != encoding {
 		return fmt.Errorf("incorrect encoding: expect %d, got %d", encoding, params.Encoding)
 	}
+
+	return nil
+}
+
+func checkKeyTypeAndOutputPrefix(template *tinkpb.KeyTemplate,
+	typeURL string,
+	prefixType tinkpb.OutputPrefixType) error {
+	if template.TypeUrl != typeURL {
+		return fmt.Errorf("incorrect typeurl: expect %s, got %s", typeURL, template.TypeUrl)
+	}
+
+	if template.OutputPrefixType != prefixType {
+		return fmt.Errorf("incorrect outputPrefixType: expect: %v, got %v", prefixType, template.OutputPrefixType)
+	}
+
 	return nil
 }


### PR DESCRIPTION
To support using imported keys from raw key bytes, Tink
users must use signing key templates without prefix to
both sign and verify signatures.

This patch also fixes some `go import` formatting of some
files.

closes #325

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>