### PR TITLE
fix: Go - avoid panic on wrong *keyset.Handle

### DIFF
--- a/go/aead/BUILD.bazel
+++ b/go/aead/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//core/cryptofmt:go_default_library",
         "//core/registry:go_default_library",
         "//keyset:go_default_library",
+        "//signature:go_default_library",
         "//proto:aes_ctr_hmac_aead_go_proto",
         "//proto:aes_gcm_go_proto",
         "//proto:chacha20_poly1305_go_proto",

--- a/go/aead/aead_factory_test.go
+++ b/go/aead/aead_factory_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/tink/go/aead"
 	"github.com/google/tink/go/core/cryptofmt"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/subtle/random"
 	"github.com/google/tink/go/testkeyset"
 	"github.com/google/tink/go/testutil"
@@ -135,4 +137,28 @@ func validateAEADFactoryCipher(encryptCipher tink.AEAD,
 		return fmt.Errorf("lengths of plaintext and ciphertext don't match with short plaintext")
 	}
 	return nil
+}
+
+func TestFactoryWithInvalidPrimitiveSetType(t *testing.T) {
+	wrongKH, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = aead.New(wrongKH)
+	if err == nil {
+		t.Fatalf("calling New() with wrong *keyset.Handle should fail")
+	}
+}
+
+func TestFactoryWithValidPrimitiveSetType(t *testing.T) {
+	goodKH, err := keyset.NewHandle(aead.AES128GCMKeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = aead.New(goodKH)
+	if err != nil {
+		t.Fatalf("calling New() with good *keyset.Handle failed: %s", err)
+	}
 }

--- a/go/daead/BUILD.bazel
+++ b/go/daead/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//keyset:go_default_library",
         "//proto:aes_siv_go_proto",
         "//proto:tink_go_proto",
+        "//signature:go_default_library",
         "//subtle/random:go_default_library",
         "//testkeyset:go_default_library",
         "//testutil:go_default_library",

--- a/go/daead/daead_factory_test.go
+++ b/go/daead/daead_factory_test.go
@@ -20,8 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/tink/go/daead"
 	"github.com/google/tink/go/core/cryptofmt"
+	"github.com/google/tink/go/daead"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/subtle/random"
 	"github.com/google/tink/go/testkeyset"
 	"github.com/google/tink/go/testutil"
@@ -132,4 +134,28 @@ func validateDAEADFactoryCipher(encryptCipher, decryptCipher tink.DeterministicA
 		return fmt.Errorf("incorrect prefix with short plaintext")
 	}
 	return nil
+}
+
+func TestFactoryWithInvalidPrimitiveSetType(t *testing.T) {
+	wrongKH, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = daead.New(wrongKH)
+	if err == nil {
+		t.Fatal("calling New() with wrong *keyset.Handle should fail")
+	}
+}
+
+func TestFactoryWithValidPrimitiveSetType(t *testing.T) {
+	goodKH, err := keyset.NewHandle(daead.AESSIVKeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = daead.New(goodKH)
+	if err != nil {
+		t.Fatalf("calling New() with good *keyset.Handle failed: %s", err)
+	}
 }

--- a/go/hybrid/hybrid_encrypt_factory.go
+++ b/go/hybrid/hybrid_encrypt_factory.go
@@ -34,7 +34,8 @@ func NewHybridEncryptWithKeyManager(h *keyset.Handle, km registry.KeyManager) (t
 	if err != nil {
 		return nil, fmt.Errorf("hybrid_factory: cannot obtain primitive set: %s", err)
 	}
-	return newEncryptPrimitiveSet(ps), nil
+
+	return newEncryptPrimitiveSet(ps)
 }
 
 // encryptPrimitiveSet is an HybridEncrypt implementation that uses the underlying primitive set for encryption.
@@ -45,23 +46,42 @@ type wrappedHybridEncrypt struct {
 // Asserts that primitiveSet implements the HybridEncrypt interface.
 var _ tink.HybridEncrypt = (*wrappedHybridEncrypt)(nil)
 
-func newEncryptPrimitiveSet(ps *primitiveset.PrimitiveSet) *wrappedHybridEncrypt {
+func newEncryptPrimitiveSet(ps *primitiveset.PrimitiveSet) (*wrappedHybridEncrypt, error) {
+	if _, ok := (ps.Primary.Primitive).(tink.HybridEncrypt); !ok {
+		return nil, fmt.Errorf("hybrid_factory: not a HybridEncrypt primitive")
+	}
+
+	for _, primitives := range ps.Entries {
+		for _, p := range primitives {
+			if _, ok := (p.Primitive).(tink.HybridEncrypt); !ok {
+				return nil, fmt.Errorf("hybrid_factory: not a HybridEncrypt primitive")
+			}
+		}
+	}
+
 	ret := new(wrappedHybridEncrypt)
 	ret.ps = ps
-	return ret
+
+	return ret, nil
 }
 
 // Encrypt encrypts the given plaintext with the given additional authenticated data.
 // It returns the concatenation of the primary's identifier and the ciphertext.
 func (a *wrappedHybridEncrypt) Encrypt(pt, ad []byte) ([]byte, error) {
 	primary := a.ps.Primary
-	var p = (primary.Primitive).(tink.HybridEncrypt)
+	p, ok := (primary.Primitive).(tink.HybridEncrypt)
+	if !ok {
+		return nil, fmt.Errorf("hybrid_factory: not a HybridEncrypt primitive")
+	}
+
 	ct, err := p.Encrypt(pt, ad)
 	if err != nil {
 		return nil, err
 	}
+
 	ret := make([]byte, 0, len(primary.Prefix)+len(ct))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, ct...)
+
 	return ret, nil
 }

--- a/go/hybrid/hybrid_factory_test.go
+++ b/go/hybrid/hybrid_factory_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/subtle/random"
 	"github.com/google/tink/go/testkeyset"
 	"github.com/google/tink/go/testutil"
@@ -97,5 +99,43 @@ func TestHybridFactoryTest(t *testing.T) {
 		if !bytes.Equal(pt, gotpt) {
 			t.Error("expected pt:", pt, " not equal to decrypted pt:", gotpt)
 		}
+	}
+}
+
+func TestFactoryWithInvalidPrimitiveSetType(t *testing.T) {
+	wrongKH, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = NewHybridEncrypt(wrongKH)
+	if err == nil {
+		t.Fatal("calling NewHybridEncrypt() with wrong *keyset.Handle should fail")
+	}
+
+	_, err = NewHybridDecrypt(wrongKH)
+	if err == nil {
+		t.Fatal("calling NewHybridDecrypt() with wrong *keyset.Handle should fail")
+	}
+}
+
+func TestFactoryWithValidPrimitiveSetType(t *testing.T) {
+	goodKH, err := keyset.NewHandle(ECIESHKDFAES128GCMKeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	goodPublicKH, err := goodKH.Public()
+	if err != nil {
+		t.Fatalf("failed to get public *keyset.Handle: %s", err)
+	}
+	_, err = NewHybridEncrypt(goodPublicKH)
+	if err != nil {
+		t.Fatalf("calling NewHybridEncrypt() with good *keyset.Handle failed: %s", err)
+	}
+
+	_, err = NewHybridDecrypt(goodKH)
+	if err != nil {
+		t.Fatalf("calling NewHybridDecrypt() with good *keyset.Handle failed %s", err)
 	}
 }

--- a/go/mac/BUILD.bazel
+++ b/go/mac/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//core/registry:go_default_library",
         "//keyset:go_default_library",
         "//mac/subtle:go_default_library",
+        "//signature:go_default_library",
         "//proto:common_go_proto",
         "//proto:hmac_go_proto",
         "//proto:tink_go_proto",

--- a/go/mac/mac_factory_test.go
+++ b/go/mac/mac_factory_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	"github.com/google/tink/go/core/cryptofmt"
+	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/mac"
+	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/testkeyset"
 	"github.com/google/tink/go/testutil"
 	"github.com/google/tink/go/tink"
@@ -147,4 +149,28 @@ func verifyMacPrimitive(computePrimitive tink.MAC, verifyPrimitive tink.MAC,
 		}
 	}
 	return nil
+}
+
+func TestFactoryWithInvalidPrimitiveSetType(t *testing.T) {
+	wrongKH, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = mac.New(wrongKH)
+	if err == nil {
+		t.Fatal("calling New() with wrong *keyset.Handle should fail")
+	}
+}
+
+func TestFactoryWithValidPrimitiveSetType(t *testing.T) {
+	goodKH, err := keyset.NewHandle(mac.HMACSHA256Tag256KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = mac.New(goodKH)
+	if err != nil {
+		t.Fatalf("calling New() with good *keyset.Handle failed: %s", err)
+	}
 }

--- a/go/signature/BUILD.bazel
+++ b/go/signature/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     deps = [
         "//core/cryptofmt:go_default_library",
         "//core/registry:go_default_library",
+        "//mac:go_default_library",
         "//proto:common_go_proto",
         "//proto:ecdsa_go_proto",
         "//proto:ed25519_go_proto",

--- a/go/signature/signer_factory.go
+++ b/go/signature/signer_factory.go
@@ -36,7 +36,8 @@ func NewSignerWithKeyManager(h *keyset.Handle, km registry.KeyManager) (tink.Sig
 	if err != nil {
 		return nil, fmt.Errorf("public_key_sign_factory: cannot obtain primitive set: %s", err)
 	}
-	return newWrappedSigner(ps), nil
+
+	return newWrappedSigner(ps)
 }
 
 // wrappedSigner is an Signer implementation that uses the underlying primitive set for signing.
@@ -47,17 +48,34 @@ type wrappedSigner struct {
 // Asserts that wrappedSigner implements the Signer interface.
 var _ tink.Signer = (*wrappedSigner)(nil)
 
-func newWrappedSigner(ps *primitiveset.PrimitiveSet) *wrappedSigner {
+func newWrappedSigner(ps *primitiveset.PrimitiveSet) (*wrappedSigner, error) {
+	if _, ok := (ps.Primary.Primitive).(tink.Signer); !ok {
+		return nil, fmt.Errorf("public_key_sign_factory: not a Signer primitive")
+	}
+
+	for _, primitives := range ps.Entries {
+		for _, p := range primitives {
+			if _, ok := (p.Primitive).(tink.Signer); !ok {
+				return nil, fmt.Errorf("public_key_sign_factory: not an Signer primitive")
+			}
+		}
+	}
+
 	ret := new(wrappedSigner)
 	ret.ps = ps
-	return ret
+
+	return ret, nil
 }
 
 // Sign signs the given data and returns the signature concatenated with the identifier of the
 // primary primitive.
 func (s *wrappedSigner) Sign(data []byte) ([]byte, error) {
 	primary := s.ps.Primary
-	var signer = (primary.Primitive).(tink.Signer)
+	signer, ok := (primary.Primitive).(tink.Signer)
+	if !ok {
+		return nil, fmt.Errorf("public_key_sign_factory: not a Signer primitive")
+	}
+
 	var signedData []byte
 	if primary.PrefixType == tinkpb.OutputPrefixType_LEGACY {
 		signedData = append(signedData, data...)
@@ -65,10 +83,12 @@ func (s *wrappedSigner) Sign(data []byte) ([]byte, error) {
 	} else {
 		signedData = data
 	}
+
 	signature, err := signer.Sign(signedData)
 	if err != nil {
 		return nil, err
 	}
+
 	ret := make([]byte, 0, len(primary.Prefix)+len(signature))
 	ret = append(ret, primary.Prefix...)
 	ret = append(ret, signature...)

--- a/go/signature/verifier_factory.go
+++ b/go/signature/verifier_factory.go
@@ -37,8 +37,7 @@ func NewVerifierWithKeyManager(h *keyset.Handle, km registry.KeyManager) (tink.V
 	if err != nil {
 		return nil, fmt.Errorf("verifier_factory: cannot obtain primitive set: %s", err)
 	}
-	var ret = newWrappedVerifier(ps)
-	return ret, nil
+	return newWrappedVerifier(ps)
 }
 
 // verifierSet is a Verifier implementation that uses the
@@ -50,10 +49,23 @@ type wrappedVerifier struct {
 // Asserts that verifierSet implements the Verifier interface.
 var _ tink.Verifier = (*wrappedVerifier)(nil)
 
-func newWrappedVerifier(ps *primitiveset.PrimitiveSet) *wrappedVerifier {
+func newWrappedVerifier(ps *primitiveset.PrimitiveSet) (*wrappedVerifier, error) {
+	if _, ok := (ps.Primary.Primitive).(tink.Verifier); !ok {
+		return nil, fmt.Errorf("verifier_factory: not a Verifier primitive")
+	}
+
+	for _, primitives := range ps.Entries {
+		for _, p := range primitives {
+			if _, ok := (p.Primitive).(tink.Verifier); !ok {
+				return nil, fmt.Errorf("verifier_factory: not an Verifier primitive")
+			}
+		}
+	}
+
 	ret := new(wrappedVerifier)
 	ret.ps = ps
-	return ret
+
+	return ret, nil
 }
 
 var errInvalidSignature = errors.New("verifier_factory: invalid signature")
@@ -64,6 +76,7 @@ func (v *wrappedVerifier) Verify(signature, data []byte) error {
 	if len(signature) < prefixSize {
 		return errInvalidSignature
 	}
+
 	// try non-raw keys
 	prefix := signature[:prefixSize]
 	signatureNoPrefix := signature[prefixSize:]
@@ -76,21 +89,32 @@ func (v *wrappedVerifier) Verify(signature, data []byte) error {
 			} else {
 				signedData = data
 			}
-			var verifier = (entries[i].Primitive).(tink.Verifier)
+
+			verifier, ok := (entries[i].Primitive).(tink.Verifier)
+			if !ok {
+				return fmt.Errorf("verifier_factory: not an Verifier primitive")
+			}
+
 			if err = verifier.Verify(signatureNoPrefix, signedData); err == nil {
 				return nil
 			}
 		}
 	}
+
 	// try raw keys
 	entries, err = v.ps.RawEntries()
 	if err == nil {
 		for i := 0; i < len(entries); i++ {
-			var verifier = (entries[i].Primitive).(tink.Verifier)
+			verifier, ok := (entries[i].Primitive).(tink.Verifier)
+			if !ok {
+				return fmt.Errorf("verifier_factory: not an Verifier primitive")
+			}
+
 			if err = verifier.Verify(signature, data); err == nil {
 				return nil
 			}
 		}
 	}
+
 	return errInvalidSignature
 }

--- a/go/streamingaead/BUILD.bazel
+++ b/go/streamingaead/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//proto:common_go_proto",
         "//proto:tink_go_proto",
         "//streamingaead/subtle:go_default_library",
+        "//mac:go_default_library",
         "//subtle/random:go_default_library",
         "//testkeyset:go_default_library",
         "//testutil:go_default_library",

--- a/go/streamingaead/streamingaead_factory_test.go
+++ b/go/streamingaead/streamingaead_factory_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/mac"
 	"github.com/google/tink/go/streamingaead"
 	"github.com/google/tink/go/subtle/random"
 	"github.com/google/tink/go/testkeyset"
@@ -120,4 +122,29 @@ func encryptDecrypt(encryptCipher, decryptCipher tink.StreamingAEAD, ptSize, aad
 		return fmt.Errorf("decryption failed")
 	}
 	return nil
+}
+
+
+func TestFactoryWithInvalidPrimitiveSetType(t *testing.T) {
+	wrongKH, err := keyset.NewHandle(mac.HMACSHA256Tag128KeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = streamingaead.New(wrongKH)
+	if err == nil {
+		t.Fatal("New() should fail with wrong *keyset.Handle")
+	}
+}
+
+func TestFactoryWithValidPrimitiveSetType(t *testing.T) {
+	goodKH, err := keyset.NewHandle(streamingaead.AES128GCMHKDF4KBKeyTemplate())
+	if err != nil {
+		t.Fatalf("failed to build *keyset.Handle: %s", err)
+	}
+
+	_, err = streamingaead.New(goodKH)
+	if err != nil {
+		t.Fatalf("New() failed with good *keyset.Handle: %s", err)
+	}
 }


### PR DESCRIPTION
For each of the available primitives in Go - ensure type checking of the primitive to avoid panics in the API. 

closes #336

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>