### PR TITLE
Fix outdated link to "hello world" examples in the README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the Bazel team and makes it easy to ensure usage of a version of Bazel that's
 compatible with the project.
 
 As a starting point, the [`hello world
-examples`](https://github.com/google/tink/tree/master/examples/helloworld)
+examples`](https://github.com/google/tink/tree/master/examples)
 demonstrate performing simple tasks using Tink in a variety of languages.
 
 ## Overview


### PR DESCRIPTION
As of https://github.com/google/tink/commit/b08453e6d824cf621ab0ecb67cad728aefd4aae9 the "examples/helloworld" directory no longer exists, hence the link no longer works.

Linking to the general examples dir seems reasonable, since the helloworld examples are readily visible there. 

If another fix to this is preferred, please feel free to comment or close this PR and commit that instead. :) 