### PR TITLE
Make the utility class SigUtil public

### DIFF
--- a/java/src/main/java/com/google/crypto/tink/signature/SigUtil.java
+++ b/java/src/main/java/com/google/crypto/tink/signature/SigUtil.java
@@ -26,7 +26,7 @@ import com.google.crypto.tink.subtle.EllipticCurves;
 import com.google.crypto.tink.subtle.Enums;
 import java.security.GeneralSecurityException;
 
-final class SigUtil {
+public final class SigUtil {
   static final String INVALID_PARAMS = "Invalid ECDSA parameters";
 
   /**


### PR DESCRIPTION
Make the SigUtil class public so that it can be used by clients.