### PR TITLE
Fixed TINKEY permission problem in build docs

### DIFF
--- a/docs/TINKEY.md
+++ b/docs/TINKEY.md
@@ -19,7 +19,8 @@ git clone https://github.com/google/tink.git
 
 ```shell
 cd tink/tools
-bazel build tinkey
+mkdir -p ~/.ccache
+bazel build tinkey --sandbox_writable_path ~/.ccache
 ```
 
 The binary is located at `bazel-bin/tinkey/tinkey`.


### PR DESCRIPTION
If either the `~/.ccache` folder is not existent or not writeable in the build sandbox the build will fail.
Fixes #345