### PR TITLE
Check error from AWS KMS decrypt call before using result.

### DIFF
--- a/go/integration/awskms/aws_kms_aead.go
+++ b/go/integration/awskms/aws_kms_aead.go
@@ -83,11 +83,11 @@ func (a *AWSAEAD) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
 		}
 	}
 	resp, err := a.kms.Decrypt(req)
-	if strings.Compare(*resp.KeyId, a.keyURI) != 0 {
-		return nil, errors.New("decryption failed: wrong key id")
-	}
 	if err != nil {
 		return nil, err
+	}
+	if strings.Compare(aws.StringValue(resp.KeyId), a.keyURI) != 0 {
+		return nil, errors.New("decryption failed: wrong key id")
 	}
 	return resp.Plaintext, nil
 }


### PR DESCRIPTION
This fixes panics when the decrypt call fails.