### PR TITLE
Added missing closing parentheses in docs.

### DIFF
--- a/docs/JAVA-HOWTO.md
+++ b/docs/JAVA-HOWTO.md
@@ -307,7 +307,7 @@ primitive (for example `Aead.class` for AEAD).
 ### Symmetric Key Encryption
 
 You can obtain and use an [AEAD (Authenticated Encryption with Associated
-Data](PRIMITIVES.md#authenticated-encryption-with-associated-data) primitive to
+Data)](PRIMITIVES.md#authenticated-encryption-with-associated-data) primitive to
 encrypt or decrypt data:
 
 ```java
@@ -333,7 +333,7 @@ encrypt or decrypt data:
 
 You can obtain and use a [DeterministicAEAD (Deterministic Authenticated
 Encryption with Associated
-Data](PRIMITIVES.md#deterministic-authenticated-encryption-with-associated-data)
+Data)](PRIMITIVES.md#deterministic-authenticated-encryption-with-associated-data)
 primitive to encrypt or decrypt data:
 
 ```java

--- a/docs/PYTHON-HOWTO.md
+++ b/docs/PYTHON-HOWTO.md
@@ -178,7 +178,7 @@ ciphertext = aead_primitive.encrypt(plaintext, associated_data)
 ### Deterministic symmetric key encryption
 
 You can obtain and use a
-[DeterministicAEAD (Deterministic Authenticated Encryption with Associated Data](PRIMITIVES.md#deterministic-authenticated-encryption-with-associated-data)
+[DeterministicAEAD (Deterministic Authenticated Encryption with Associated Data)](PRIMITIVES.md#deterministic-authenticated-encryption-with-associated-data)
 primitive to encrypt or decrypt data:
 
 ```python


### PR DESCRIPTION
Added the missing closing parentheses in `JAVA-HOWTO.md` and `PYTHON-HOWTO.md`.

Fixes #379.