### PR TITLE
Fix an example in GOLANG-HOWTO.md

### DIFF
--- a/docs/GOLANG-HOWTO.md
+++ b/docs/GOLANG-HOWTO.md
@@ -286,7 +286,7 @@ func main() {
           return nil, err
         }
 
-        ksPriv, err := proto.Marshal(exported.Keyset)
+        ksPriv, err := proto.Marshal(exportedPriv.Keyset)
         if err != nil {
           return nil, err
         }
@@ -306,7 +306,7 @@ func main() {
           return nil, err
         }
 
-        ksPub, err := proto.Marshal(exported.Keyset)
+        ksPub, err := proto.Marshal(exportedPub.Keyset)
         if err != nil {
           return nil, err
         }


### PR DESCRIPTION
In the example of preparation to use hybrid decryption, it appears that the variables declared as `&keyset.MemReaderWriter{}` are not correctly referenced in the following marshaling function.