### PR TITLE
Update bazel-toolchains mirror URL warning

### DIFF
--- a/tink_base_deps.bzl
+++ b/tink_base_deps.bzl
@@ -73,7 +73,7 @@ def tink_base_deps():
             sha256 = "db48eed61552e25d36fe051a65d2a329cc0fb08442627e8f13960c5ab087a44e",
             strip_prefix = "bazel-toolchains-3.2.0",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.2.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.2.0/bazel-toolchains-3.2.0.tar.gz",
                 "https://github.com/bazelbuild/bazel-toolchains/archive/3.2.0.tar.gz",
             ],
         )


### PR DESCRIPTION
### What
Change the bazel-toolchains mirror URL to use the release archive format instead of the commit archive format.

### Why
According to @smukherj1 from the bazel project in bazelbuild/bazel-toolchains#891 the GitHub commit archive URL is no longer mirrored by `mirror.bazel.build`. Instead the GitHub release archive URL is mirrored. This incorrect URL is causing bazel to output the following warning during build:

```
$ git clone https://github.com/google/tink
$ git checkout 23ce810c979b1105fe6a657a5667a7275764b411
$ cd tink/tools/tinkey
$ bazel build tinkey
WARNING: Download from https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.2.0.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
...
```