### PR TITLE
Add Handle.KeyInfo() function in Go.

### DIFF
--- a/go/keyset/handle.go
+++ b/go/keyset/handle.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/google/tink/go/core/primitiveset"
 	"github.com/google/tink/go/core/registry"
-	"github.com/google/tink/go/tink"
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/tink"
 )
 
 var errInvalidKeyset = fmt.Errorf("keyset.Handle: invalid keyset")
@@ -121,6 +121,16 @@ func (h *Handle) String() string {
 		return ""
 	}
 	return proto.CompactTextString(info)
+}
+
+// KeysetInfo returns KeysetInfo representation of the managed keyset.
+// The result does not contain any sensitive key material.
+func (h *Handle) KeysetInfo() *tinkpb.KeysetInfo {
+	info, err := getKeysetInfo(h.ks)
+	if err != nil {
+		return nil
+	}
+	return info
 }
 
 // Write encrypts and writes the enclosing keyset.

--- a/go/keyset/handle_test.go
+++ b/go/keyset/handle_test.go
@@ -155,3 +155,24 @@ func TestWithNoSecretsFunctionsFailWithAsymmetricPrivateKeyMaterial(t *testing.T
 		t.Error("keyset.ReadWithNoSecrets should fail when importing secret key material")
 	}
 }
+
+func TestKeysetInfo(t *testing.T) {
+	kt := mac.HMACSHA256Tag128KeyTemplate()
+	kh, err := keyset.NewHandle(kt)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	info := kh.KeysetInfo()
+	if info == nil {
+		t.Error("KeysetInfo must not be nil")
+	}
+	if info.PrimaryKeyId != info.KeyInfo[0].KeyId {
+		t.Errorf("Expected primary key id: %d, but got: %d", info.KeyInfo[0].KeyId, info.PrimaryKeyId)
+	}
+
+	emptykh := &keyset.Handle{}
+	emptykhInfo := emptykh.KeysetInfo()
+	if emptykhInfo != nil {
+		t.Error("KeyInfo must be nil")
+	}
+}


### PR DESCRIPTION
return KeysetInfo struct to convenient to view keys or format output.