### PR TITLE
Use absolute link in Python README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ Google Assistant, Firebase, the Android Search App, etc.
 ## Documentation
 
 For an overview of using Tink in Python, see the
-[Python HOW-TO](../docs/PYTHON-HOWTO.md).
+[Python HOW-TO](https://github.com/google/tink/blob/master/docs/PYTHON-HOWTO.md).
 
 In addition, there are illustrative [examples of using Tink
 Python](https://github.com/google/tink/tree/master/examples/python/) which can


### PR DESCRIPTION
Explicitly specify an absolute link for [the Python HOW-TO](https://github.com/google/tink/blob/master/docs/PYTHON-HOWTO.md) in the README for Python.
This will fix the link in the project description on [PyPI](https://pypi.org/project/tink/) for the next release, which currently links to https://pypi.org/project/docs/PYTHON-HOWTO.md/ using the relative link and shows a 404 error page.