### PR TITLE
WebPushHybridDecrypt doesn't support padding #256

### DIFF
--- a/apps/webpush/src/main/java/com/google/crypto/tink/apps/webpush/WebPushHybridDecrypt.java
+++ b/apps/webpush/src/main/java/com/google/crypto/tink/apps/webpush/WebPushHybridDecrypt.java
@@ -258,9 +258,21 @@ public final class WebPushHybridDecrypt implements HybridDecrypt {
     GCMParameterSpec params = new GCMParameterSpec(8 * WebPushConstants.TAG_SIZE, nonce);
     cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), params);
     byte[] plaintext = cipher.doFinal(ciphertext);
+    plaintext = removePadding(plaintext);
     if (plaintext[plaintext.length - 1] != WebPushConstants.PADDING_DELIMITER_BYTE) {
       throw new GeneralSecurityException("decryption failed");
     }
     return Arrays.copyOfRange(plaintext, 0, plaintext.length - 1);
+  }
+
+  private byte[] removePadding(byte[] plaintext) {
+    int index = plaintext.length - 1;
+    while (index > 0) {
+      if (plaintext[index] != 0) {
+        break;
+      }
+      index--;
+    }
+    return Arrays.copyOf(plaintext, index + 1);
   }
 }


### PR DESCRIPTION
As #256 describes WebPushHybridDecrypt.java currently doesn't support padding at the end of the plaintext string. The following fix removes potential padding bits, while keeping all current checks untouched. This is done after the actual decryption took place, to avoid breaking stuff.

_Disclaimer_
I'm no security expert and also wasn't able to build the code, as I wasn't able to get the Bazel setup working. I tested everything as good as possible and it should work. If additional testing is required I would ask the reviewer or someone with an up and running setup to add those.