### PR TITLE
Configure CMake dependencies for AWS KMS

### DIFF
--- a/cc/CMakeLists.txt
+++ b/cc/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(aead)
 add_subdirectory(config)
 add_subdirectory(daead)
 add_subdirectory(hybrid)
+add_subdirectory(integration/awskms)
 add_subdirectory(mac)
 add_subdirectory(prf)
 add_subdirectory(signature)
@@ -103,6 +104,9 @@ set(TINK_PUBLIC_API_DEPS
   tink::aead::aead_config
   tink::aead::aead_factory
   tink::aead::aead_key_templates
+  tink::awskms::aws_crypto
+  tink::awskms::aws_kms_aead
+  tink::awskms::aws_kms_client
   tink::config::tink_config
   tink::daead::deterministic_aead_config
   tink::daead::deterministic_aead_factory

--- a/cc/integration/awskms/CMakeLists.txt
+++ b/cc/integration/awskms/CMakeLists.txt
@@ -1,0 +1,46 @@
+tink_module(awskms)
+
+tink_cc_library(
+  NAME aws_crypto
+  SRCS
+    aws_crypto.cc
+    aws_crypto.h
+  DEPS
+    absl::base
+    crypto
+    aws-sdk::core
+    aws-sdk::kms
+)
+
+tink_cc_library(
+  NAME aws_kms_aead
+  SRCS
+    aws_kms_aead.cc
+    aws_kms_aead.h
+  DEPS
+    absl::strings
+    tink::core::aead
+    tink::util::errors
+    tink::util::status
+    tink::util::statusor
+    aws-sdk::core
+    aws-sdk::kms
+)
+
+tink_cc_library(
+  NAME aws_kms_client
+  SRCS
+    aws_kms_client.cc
+    aws_kms_client.h
+  DEPS
+    absl::strings
+    absl::synchronization
+    tink::awskms::aws_crypto
+    tink::awskms::aws_kms_aead
+    tink::core::kms_client
+    tink::util::errors
+    tink::util::status
+    tink::util::statusor
+    aws-sdk::core
+    aws-sdk::kms
+)

--- a/cmake/TinkWorkspace.cmake
+++ b/cmake/TinkWorkspace.cmake
@@ -92,3 +92,13 @@ http_archive(
   SHA256 9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564
   CMAKE_SUBDIR cmake
 )
+
+# Import externally built aws-sdk::core and aws-sdk::kms
+# aws-sdk-cpp-1.8.24 should be located in the same folder as tink.
+set(AWS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../aws-sdk-cpp-1.8.24")
+add_library(aws-sdk::core STATIC IMPORTED)
+add_library(aws-sdk::kms  STATIC IMPORTED)
+set_target_properties(aws-sdk::core PROPERTIES IMPORTED_LOCATION ${AWS_SRC_DIR}/build/aws-cpp-sdk-core/libaws-cpp-sdk-core.a)
+set_target_properties(aws-sdk::kms  PROPERTIES IMPORTED_LOCATION ${AWS_SRC_DIR}/build/aws-cpp-sdk-kms/libaws-cpp-sdk-kms.a)
+set(AWS_INCLUDE_DIRS ${AWS_SRC_DIR}/aws-cpp-sdk-kms/include ${AWS_SRC_DIR}/aws-cpp-sdk-core/include)
+list(APPEND TINK_INCLUDE_DIRS "${AWS_INCLUDE_DIRS}")


### PR DESCRIPTION
Currently Tink's  functionality for encrypting/decrypting keysets with master keys residing in remote AWS KMS is supported only for Bazel builds. This PR configures CMake dependencies for AWS KMS. 

We use `aws-sdk-cpp-1.8.24` (https://github.com/aws/aws-sdk-cpp/archive/1.8.24.tar.gz) and assume that it is located in the same directory as tink. The following commands are used to build static `aws-cpp-sdk-core` and `aws-cpp-sdk-kms` beforehand:
```
wget https://github.com/aws/aws-sdk-cpp/archive/1.8.24.tar.gz
tar -xvzf 1.8.24.tar.gz
cd aws-sdk-cpp-1.8.24
mkdir build && cd build
cmake .. \
    -DBUILD_ONLY=kms \
    -DSTATIC_LINKING=1 \
    -DBUILD_SHARED_LIBS=OFF \
    -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
    -DENABLE_TESTING:BOOL=OFF \
    -DBUILD_DEPS=ON
make
```