### PR TITLE
Revise Java How-To to avoid usage of deprecated API

### DIFF
--- a/docs/JAVA-HOWTO.md
+++ b/docs/JAVA-HOWTO.md
@@ -188,7 +188,7 @@ common key management tasks.
 
 Still, if there is a need to generate a KeysetHandle with fresh key material
 directly in Java code, you can use
-[`KeysetHandle`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeysetHandle.java).
+[`KeysetHandle`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/KeysetHandle.java).
 For example, you can generate a keyset containing a randomly generated
 AES128-GCM with the help of the factory methods from [`AesGcmKeyManager`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/aead/AesGcmKeyManager.java) key as follows.
 
@@ -262,7 +262,7 @@ KMS key as follows:
 ## Loading existing keysets
 
 To load encrypted keysets, use
-[`KeysetHandle`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeysetHandle.java):
+[`KeysetHandle`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/KeysetHandle.java):
 
 ```java
     import com.google.crypto.tink.JsonKeysetReader;
@@ -279,7 +279,7 @@ To load encrypted keysets, use
 ```
 
 To load cleartext keysets, use
-[`CleartextKeysetHandle`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/CleartextKeysetHandle.java):
+[`CleartextKeysetHandle`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/CleartextKeysetHandle.java):
 
 ```java
     import com.google.crypto.tink.CleartextKeysetHandle;
@@ -551,7 +551,7 @@ using the credentials in `credentials.json` as follows:
 ## Key rotation
 
 Support for key rotation in Tink is provided via the
-[`KeysetManager`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeysetManager.java)
+[`KeysetManager`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/KeysetManager.java)
 class.
 
 You have to provide a `KeysetHandle`-object that contains the keyset that should
@@ -609,11 +609,11 @@ To create a custom implementation of a primitive proceed as follows:
     cryptographic scheme; the name of the key protocol buffer (a.k.a. type URL)
     determines the _key type_ for the custom implementation.
 3.  Implement a
-    [`KeyManager`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeyManager.java)
+    [`KeyManager`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/KeyManager.java)
     interface for the _primitive_ from step #1 and the _key type_ from step #2.
 
 To use a custom implementation of a primitive in an application, register with
-the [`Registry`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/Registry.java)
+the [`Registry`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/Registry.java)
 the custom `KeyManager` implementation (from step #3 above) for the custom key
 type (from step #2 above):
 
@@ -654,7 +654,7 @@ rather register the needed `KeyManager`-instances manually.
 
 For a concrete example, let's assume that we'd like a custom implementation of
 the
-[`Aead`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/Aead.java)
+[`Aead`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/Aead.java)
 primitive (step #1). We define then three protocol buffer messages (step #2):
 
  * `MyCustomAeadParams`: holds parameters needed for the use of the key material.
@@ -689,7 +689,7 @@ The corresponding _key type_ in Java is defined as
 ```
 
 and the corresponding _key manager_ implements (step #3) the interface
-[`KeyManager<Aead>`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeyManager.java)
+[`KeyManager<Aead>`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/KeyManager.java)
 
 ```java
     class MyCustomAeadKeyManager implements KeyManager<Aead> {

--- a/docs/JAVA-HOWTO.md
+++ b/docs/JAVA-HOWTO.md
@@ -190,22 +190,25 @@ Still, if there is a need to generate a KeysetHandle with fresh key material
 directly in Java code, you can use
 [`KeysetHandle`](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/KeysetHandle.java).
 For example, you can generate a keyset containing a randomly generated
-AES128-GCM key as follows.
+AES128-GCM with the help of the factory methods from [`AesGcmKeyManager`](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/aead/AesGcmKeyManager.java) key as follows.
 
 ```java
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.aead.AeadKeyTemplates;
-
-    KeyTemplate keyTemplate = AeadKeyTemplates.AES128_GCM;
-    KeysetHandle keysetHandle = KeysetHandle.generateNew(keyTemplate);
+    import com.google.crypto.tink.KeyTemplate;
+    import com.google.crypto.tink.aead.AesGcmKeyManager;
+    
+    KeyTemplate keysetTemplate = AesGcmKeyManager.aes128GcmTemplate(); 
+    KeysetHandle keysetHandle = KeysetHandle.generateNew(keysetTemplate);
 ```
 
-Recommended key templates for MAC, digital signature and hybrid encryption can
+HmacKeyManager.hmacSha256HalfDigestTemplate()
+
+Recommended factory methods to create key templates for MAC, digital signature and hybrid encryption can
 be found in
-[MacKeyTemplates](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/mac/MacKeyTemplates.java),
-[SignatureKeyTemplates](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/signature/SignatureKeyTemplates.java)
+[HmacKeyManager](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/mac/HmacKeyManager.java),
+[RsaSsaPssSignKeyManager](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/signature/RsaSsaPssSignKeyManager.java)
 and
-[HybridKeyTemplates](https://github.com/google/tink/blob/master/java/src/main/java/com/google/crypto/tink/hybrid/HybridKeyTemplates.java),
+[EciesAeadHkdfPrivateKeyManager](https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/hybrid/EciesAeadHkdfPrivateKeyManager.java),
 respectively.
 
 ## Storing keysets
@@ -216,13 +219,13 @@ e.g., writing to a file:
 ```java
     import com.google.crypto.tink.CleartextKeysetHandle;
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.aead.AeadKeyTemplates;
+    import com.google.crypto.tink.aead.AesGcmKeyManager;
     import com.google.crypto.tink.JsonKeysetWriter;
     import java.io.File;
 
     // Generate the key material...
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        AeadKeyTemplates.AES128_GCM);
+        AesGcmKeyManager.aes128GcmTemplate());
 
     // and write it to a file.
     String keysetFilename = "my_keyset.json";
@@ -240,13 +243,13 @@ KMS key as follows:
 ```java
     import com.google.crypto.tink.JsonKeysetWriter;
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.aead.AeadKeyTemplates;
+    import com.google.crypto.tink.aead.AesGcmKeyManager;
     import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
     import java.io.File;
 
     // Generate the key material...
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        AeadKeyTemplates.AES128_GCM);
+        AesGcmKeyManager.aes128GcmTemplate());
 
     // and write it to a file...
     String keysetFilename = "my_keyset.json";
@@ -313,11 +316,11 @@ encrypt or decrypt data:
 ```java
     import com.google.crypto.tink.Aead;
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.aead.AeadKeyTemplates;
+    import com.google.crypto.tink.aead.AesGcmKeyManager;
 
     // 1. Generate the key material.
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        AeadKeyTemplates.AES128_GCM);
+        AesGcmKeyManager.aes128GcmTemplate());
 
     // 2. Get the primitive.
     Aead aead = keysetHandle.getPrimitive(Aead.class);
@@ -339,11 +342,11 @@ primitive to encrypt or decrypt data:
 ```java
     import com.google.crypto.tink.DeterministicAead;
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.daead.DeterministicAeadKeyTemplates;
+    import com.google.crypto.tink.daead.AesSivKeyManager;
 
     // 1. Generate the key material.
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        DeterministicAeadKeyTemplates.AES256_SIV);
+        AesSivKeyManager.aes256SivTemplate());
 
     // 2. Get the primitive.
     DeterministicAead daead =
@@ -365,15 +368,15 @@ to encrypt or decrypt data streams:
 ```java
     import com.google.crypto.tink.StreamingAead;
     import com.google.crypto.tink.KeysetHandle;
-    import com.google.crypto.tink.streamingaead.StreamingAeadKeyTemplates;
-    import java.nio.ByteBuffer
+    import com.google.crypto.tink.streamingaead.AesGcmHkdfStreamingKeyManager;
+    import java.nio.ByteBuffer;
     import java.nio.channels.FileChannel;
     import java.nio.channels.SeekableByteChannel;
     import java.nio.channels.WritableByteChannel;
 
     // 1. Generate the key material.
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        StreamingAeadKeyTemplates.AES128_CTR_HMAC_SHA256_4KB);
+        AesGcmHkdfStreamingKeyManager.aes128GcmHkdf4KBTemplate());
 
     // 2. Get the primitive.
     StreamingAead streamingAead = keysetHandle.getPrimitive(StreamingAead.class);
@@ -421,11 +424,11 @@ Authentication Code)](PRIMITIVES.md#message-authentication-code):
 ```java
     import com.google.crypto.tink.KeysetHandle;
     import com.google.crypto.tink.Mac;
-    import com.google.crypto.tink.mac.MacKeyTemplates;
+    import com.google.crypto.tink.mac.HmacKeyManager;
 
     // 1. Generate the key material.
     KeysetHandle keysetHandle = KeysetHandle.generateNew(
-        MacKeyTemplates.HMAC_SHA256_128BITTAG);
+        HmacKeyManager.hmacSha256HalfDigestTemplate());
 
     // 2. Get the primitive.
     Mac mac = keysetHandle.getPrimitive(Mac.class);
@@ -446,13 +449,13 @@ signature](PRIMITIVES.md#digital-signatures):
     import com.google.crypto.tink.KeysetHandle;
     import com.google.crypto.tink.PublicKeySign;
     import com.google.crypto.tink.PublicKeyVerify;
-    import com.google.crypto.tink.signature.SignatureKeyTemplates;
+    import com.google.crypto.tink.signature.EcdsaSignKeyManager;
 
     // SIGNING
 
     // 1. Generate the private key material.
     KeysetHandle privateKeysetHandle = KeysetHandle.generateNew(
-        SignatureKeyTemplates.ECDSA_P256);
+        EcdsaSignKeyManager.ecdsaP256Template());
 
     // 2. Get the primitive.
     PublicKeySign signer = privateKeysetHandle.getPrimitive(PublicKeySign.class);
@@ -482,12 +485,12 @@ use the following:
 ```java
     import com.google.crypto.tink.HybridDecrypt;
     import com.google.crypto.tink.HybridEncrypt;
-    import com.google.crypto.tink.hybrid.HybridKeyTemplates;
+    import com.google.crypto.tink.hybrid.EciesAeadHkdfPrivateKeyManager;
     import com.google.crypto.tink.KeysetHandle;
 
     // 1. Generate the private key material.
     KeysetHandle privateKeysetHandle = KeysetHandle.generateNew(
-        HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM);
+        EciesAeadHkdfPrivateKeyManager.eciesP256HkdfHmacSha256Aes128GcmTemplate());
 
     // Obtain the public key material.
     KeysetHandle publicKeysetHandle =


### PR DESCRIPTION
This revises the API usage in the Java How-To examples by following the API suggestions from the deprecation notes.

Note that I could not revise the `envelope encryption` example, since the API doesn't seem to provide a non-deprecated way
to create an envelop Aead key via `createKmsEnvelopeAeadKeyTemplate`, since the method requires
a `com.google.crypto.tink.proto.KeyTemplate` instead of a `com.google.crypto.tink.KeyTemplate`.
Otherwise one could have used `AesGcmKeyManager.aes128GcmTemplate()`.

The `key rotation` also still uses the deprecated `.rotate(keyTemplate)` method, which should probably be replaced with
something like 
```
KeysetHandle rotatedKeysetHandle = KeysetManager
                .withKeysetHandle(keysetHandle)
                .add(...) // adds key
                .setPrimary(...) // promotes it as primary key (here or at a later stage)
```

Fixes #429