### PR TITLE
Fix objc nullability issues

### DIFF
--- a/objc/TINKAeadConfig.h
+++ b/objc/TINKAeadConfig.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKAeadConfig : TINKRegistryConfig
 
 /* Use -initWithError: to get an instance of TINKAeadConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /* Returns config of Aead implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())

--- a/objc/TINKAeadKeyTemplate.h
+++ b/objc/TINKAeadKeyTemplate.h
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKAeadKeyTemplate : TINKKeyTemplate
 
-- (nullable instancetype)init
+- (instancetype)init
     __attribute__((unavailable("Use -initWithKeyTemplate:error: instead.")));
 
 /**

--- a/objc/TINKAllConfig.h
+++ b/objc/TINKAllConfig.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKAllConfig : TINKRegistryConfig
 
 /** Use -initWithError: to get an instance of TINKAllConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /** Returns config of all implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())

--- a/objc/TINKBinaryKeysetReader.h
+++ b/objc/TINKBinaryKeysetReader.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TINKBinaryKeysetReader : TINKKeysetReader
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /** Initializes a TINKBinaryKeysetReader using a serialized keyset. */
 - (nullable instancetype)initWithSerializedKeyset:(NSData *)keyset

--- a/objc/TINKDeterministicAeadConfig.h
+++ b/objc/TINKDeterministicAeadConfig.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKDeterministicAeadConfig : TINKRegistryConfig
 
 /* Use -initWithError: to get an instance of TINKDeterministicAeadConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /* Returns config of Deterministic Aead implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error

--- a/objc/TINKDeterministicAeadKeyTemplate.h
+++ b/objc/TINKDeterministicAeadKeyTemplate.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKDeterministicAeadKeyTemplate : TINKKeyTemplate
 
-- (nullable instancetype)init
+- (instancetype)init
     __attribute__((unavailable("Use -initWithKeyTemplate:error: instead.")));
 
 /**

--- a/objc/TINKHybridConfig.h
+++ b/objc/TINKHybridConfig.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKHybridConfig : TINKRegistryConfig
 
 /* Use initWithError: to get an instance of TINKHybridConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /* Returns config of Hybrid implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())

--- a/objc/TINKHybridKeyTemplate.h
+++ b/objc/TINKHybridKeyTemplate.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKHybridKeyTemplate : TINKKeyTemplate
 
-- (nullable instancetype)init
+- (instancetype)init
     __attribute__((unavailable("Use -initWithKeyTemplate:error: instead.")));
 
 /**

--- a/objc/TINKJSONKeysetReader.h
+++ b/objc/TINKJSONKeysetReader.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TINKJSONKeysetReader : TINKKeysetReader
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * Initializes a TINKJSONKeysetReader using a serialized keyset in proto JSON wire format.

--- a/objc/TINKKeyTemplate.h
+++ b/objc/TINKKeyTemplate.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This class is not meant to be instantiated directly; instead use one of the subclasses
  * (TINKAeadKeyTemplate, TINKHybridKeyTemplate etc.) to get an instance.
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithKeyTemplate:(id)keyTemplate error:(NSError **)error NS_UNAVAILABLE;
 

--- a/objc/TINKKeysetHandle.h
+++ b/objc/TINKKeysetHandle.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Use -initWithKeysetReader:andKey:error: or -initWithTemplate:error: to get an instance of
  * TINKKeysetHandle.
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * Creates a TINKKeysetHandle from an encrypted keyset obtained via @c reader using @c aeadKey to

--- a/objc/TINKMacConfig.h
+++ b/objc/TINKMacConfig.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKMacConfig : TINKRegistryConfig
 
 /* Use -initWithError: to get an instance of TINKMacConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /* Returns config of Mac implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())

--- a/objc/TINKMacKeyTemplate.h
+++ b/objc/TINKMacKeyTemplate.h
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKMacKeyTemplate : TINKKeyTemplate
 
-- (nullable instancetype)init
+- (instancetype)init
     __attribute__((unavailable("Use -initWithKeyTemplate:error: instead.")));
 
 /**

--- a/objc/TINKRegistryConfig.h
+++ b/objc/TINKRegistryConfig.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This class is not meant to be instantiated directly; instead use one of the subclasses
  * (TINKAeadConfig, TINKAllConfig etc.) to get an instance.
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())
     NS_DESIGNATED_INITIALIZER;

--- a/objc/TINKSignatureConfig.h
+++ b/objc/TINKSignatureConfig.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TINKSignatureConfig : TINKRegistryConfig
 
 /* Use -initWithError: to get an instance of TINKSignatureConfig. */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /* Returns config of Signature implementations supported in the latest version of Tink. */
 - (nullable instancetype)initWithError:(NSError **)error NS_SWIFT_NAME(init())

--- a/objc/TINKSignatureKeyTemplate.h
+++ b/objc/TINKSignatureKeyTemplate.h
@@ -153,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKSignatureKeyTemplate : TINKKeyTemplate
 
-- (nullable instancetype)init
+- (instancetype)init
     __attribute__((unavailable("Use -initWithKeyTemplate:error: instead.")));
 
 /**

--- a/objc/aead/TINKAeadInternal.h
+++ b/objc/aead/TINKAeadInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKAeadInternal : NSObject <TINKAead>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCAead:(std::unique_ptr<crypto::tink::Aead>)ccAead
     NS_DESIGNATED_INITIALIZER;

--- a/objc/daead/TINKDeterministicAeadInternal.h
+++ b/objc/daead/TINKDeterministicAeadInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKDeterministicAeadInternal : NSObject <TINKDeterministicAead>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCDeterministicAead:
     (std::unique_ptr<crypto::tink::DeterministicAead>)ccDeterministicAead NS_DESIGNATED_INITIALIZER;

--- a/objc/hybrid/TINKHybridDecryptInternal.h
+++ b/objc/hybrid/TINKHybridDecryptInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKHybridDecryptInternal : NSObject <TINKHybridDecrypt>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCHybridDecrypt:
     (std::unique_ptr<crypto::tink::HybridDecrypt>)ccHybridDecrypt NS_DESIGNATED_INITIALIZER;

--- a/objc/hybrid/TINKHybridEncryptInternal.h
+++ b/objc/hybrid/TINKHybridEncryptInternal.h
@@ -28,7 +28,7 @@
  */
 @interface TINKHybridEncryptInternal : NSObject <TINKHybridEncrypt>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCHybridEncrypt:
     (std::unique_ptr<crypto::tink::HybridEncrypt>)ccHybridEncrypt NS_DESIGNATED_INITIALIZER;

--- a/objc/mac/TINKMacInternal.h
+++ b/objc/mac/TINKMacInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKMacInternal : NSObject <TINKMac>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCMac:(std::unique_ptr<crypto::tink::Mac>)ccMac
     NS_DESIGNATED_INITIALIZER;

--- a/objc/signature/TINKPublicKeySignInternal.h
+++ b/objc/signature/TINKPublicKeySignInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKPublicKeySignInternal : NSObject <TINKPublicKeySign>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCPublicKeySign:
     (std::unique_ptr<crypto::tink::PublicKeySign>)ccPublicKeySign NS_DESIGNATED_INITIALIZER;

--- a/objc/signature/TINKPublicKeyVerifyInternal.h
+++ b/objc/signature/TINKPublicKeyVerifyInternal.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TINKPublicKeyVerifyInternal : NSObject <TINKPublicKeyVerify>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable instancetype)initWithCCPublicKeyVerify:
     (std::unique_ptr<crypto::tink::PublicKeyVerify>)ccPublicKeyVerify NS_DESIGNATED_INITIALIZER;


### PR DESCRIPTION
NSObject's -init method isn't nullable anymore, so declaring the
overridden initializers as being nullable results in a nullability check
failure.