### PR TITLE
Allow to create Ed25519Sign.KeyPair with a given private key.

### DIFF
--- a/java_src/src/main/java/com/google/crypto/tink/subtle/Ed25519Sign.java
+++ b/java_src/src/main/java/com/google/crypto/tink/subtle/Ed25519Sign.java
@@ -88,5 +88,11 @@ public final class Ed25519Sign implements PublicKeySign {
       byte[] publicKey = Ed25519.scalarMultWithBaseToBytes(Ed25519.getHashedScalar(privateKey));
       return new KeyPair(publicKey, privateKey);
     }
+
+    /** Creates <publicKey, privateKey> KeyPair with a given private key. */
+    public static KeyPair createKeyPair(byte[] privateKey) throws GeneralSecurityException {
+      byte[] publicKey = Ed25519.scalarMultWithBaseToBytes(Ed25519.getHashedScalar(privateKey));
+      return new KeyPair(publicKey, privateKey);
+    }
   }
 }


### PR DESCRIPTION
This change will allow to create `Ed25519Sign.KeyPair` with a given private key.
The usecase is to create a key pair from [bip39 mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki):
```kotlin
val mnemonic = MnemonicCode("user input")
val privateKey = mnemonic.toEntropy()
val keyPair = Ed25519Sign.KeyPair.createKeyPair(privateKey)

val publicKey = keyPair.publicKey
val signer = Ed25519Sign(keyPair.privateKey)
```