### PR TITLE
Added static KeyTemplate function for #445

### DIFF
--- a/java_src/src/main/java/com/google/crypto/tink/aead/KmsEnvelopeAeadKeyManager.java
+++ b/java_src/src/main/java/com/google/crypto/tink/aead/KmsEnvelopeAeadKeyManager.java
@@ -98,11 +98,11 @@ public class KmsEnvelopeAeadKeyManager extends KeyTypeManager<KmsEnvelopeAeadKey
   }
   
   public static final com.google.crypto.tink.KeyTemplate kmsEnvelopeAeadKeyTemplate(final String keyUri){
-    final var aesKeyFormat = AesGcmKeyFormat.newBuilder().setKeySize(32).build();
-    final var keyFormat = KmsEnvelopeAeadKeyFormat.newBuilder()
+    final AesGcmKeyFormat  aesKeyFormat = AesGcmKeyFormat.newBuilder().setKeySize(32).build();
+    final byte[] keyFormat = KmsEnvelopeAeadKeyFormat.newBuilder()
             .setDekTemplate(com.google.crypto.tink.KeyTemplate.create(new AesGcmKeyManager().getKeyType(),aesKeyFormat.toByteArray(), com.google.crypto.tink.KeyTemplate.OutputPrefixType.TINK))
             .setKekUri(keyUri)
             .build().toByteArray();
-    return com.google.crypto.tink.KeyTemplate.create(keyManager.getKeyType(), keyFormat, com.google.crypto.tink.KeyTemplate.OutputPrefixType.TINK)
+    return com.google.crypto.tink.KeyTemplate.create(new KmsEnvelopeAeadKeyManager().getKeyType(), keyFormat, com.google.crypto.tink.KeyTemplate.OutputPrefixType.TINK);
   }
 }

--- a/java_src/src/main/java/com/google/crypto/tink/aead/KmsEnvelopeAeadKeyManager.java
+++ b/java_src/src/main/java/com/google/crypto/tink/aead/KmsEnvelopeAeadKeyManager.java
@@ -16,14 +16,10 @@
 
 package com.google.crypto.tink.aead;
 
-import com.google.crypto.tink.Aead;
-import com.google.crypto.tink.KeyTypeManager;
-import com.google.crypto.tink.KmsClient;
-import com.google.crypto.tink.KmsClients;
-import com.google.crypto.tink.Registry;
+import com.google.crypto.tink.*;
+import com.google.crypto.tink.proto.*;
 import com.google.crypto.tink.proto.KeyData.KeyMaterialType;
-import com.google.crypto.tink.proto.KmsEnvelopeAeadKey;
-import com.google.crypto.tink.proto.KmsEnvelopeAeadKeyFormat;
+import com.google.crypto.tink.proto.KeyTemplate;
 import com.google.crypto.tink.subtle.Validators;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistryLite;
@@ -99,5 +95,14 @@ public class KmsEnvelopeAeadKeyManager extends KeyTypeManager<KmsEnvelopeAeadKey
 
   public static void register(boolean newKeyAllowed) throws GeneralSecurityException {
     Registry.registerKeyManager(new KmsEnvelopeAeadKeyManager(), newKeyAllowed);
+  }
+  
+  public static final com.google.crypto.tink.KeyTemplate kmsEnvelopeAeadKeyTemplate(final String keyUri){
+    final var aesKeyFormat = AesGcmKeyFormat.newBuilder().setKeySize(32).build();
+    final var keyFormat = KmsEnvelopeAeadKeyFormat.newBuilder()
+            .setDekTemplate(com.google.crypto.tink.KeyTemplate.create(new AesGcmKeyManager().getKeyType(),aesKeyFormat.toByteArray(), com.google.crypto.tink.KeyTemplate.OutputPrefixType.TINK))
+            .setKekUri(keyUri)
+            .build().toByteArray();
+    return com.google.crypto.tink.KeyTemplate.create(keyManager.getKeyType(), keyFormat, com.google.crypto.tink.KeyTemplate.OutputPrefixType.TINK)
   }
 }


### PR DESCRIPTION
This PR addresses the issue mentioned in #445. This adds a method that only uses non deprecated methods to create a `KmsEnvelopeAead` KeyTemplate.