### PR TITLE
docs: replace dead link to pre-gen'd templates.

### DIFF
--- a/docs/JAVA-HOWTO.md
+++ b/docs/JAVA-HOWTO.md
@@ -574,7 +574,7 @@ message.
 ```
 
 Some common specifications are available as pre-generated templates in
-[examples/keytemplates](https://github.com/google/tink/tree/master/examples/keytemplates),
+[testdata/templates](https://github.com/google/tink/tree/master/testdata/templates),
 and can be accessed via the `...KeyTemplates.java` classes of the respective
 primitives.
 


### PR DESCRIPTION
Previously `docs/JAVA-HOWTO.md` had a Markdown link for `examples/keytemplates` that pointed to a folder that was removed in 68195f5 and now produces a 404 error.

This PR updates the link to point to `testdata/templates`, which appears to have similar content as the `examples/keytemplates` dir held previously. 

*Note to reviewers: I'm brand new to Tink and made an educated guess about the up-to-date link target. It's possible the correct fix is to remove the link or point it elsewhere*.