### PR TITLE
Remove stacktrace in INFO logs for AndroidKeysetManager

### DIFF
--- a/java_src/src/main/java/com/google/crypto/tink/integration/android/AndroidKeysetManager.java
+++ b/java_src/src/main/java/com/google/crypto/tink/integration/android/AndroidKeysetManager.java
@@ -287,7 +287,7 @@ public final class AndroidKeysetManager {
         return read();
       } catch (FileNotFoundException ex) {
         // Not found, handle below.
-        Log.i(TAG, "keyset not found, will generate a new one", ex);
+        Log.i(TAG, String.format("keyset not found, will generate a new one. %s", ex.getMessage()));
       }
 
       // Not found.


### PR DESCRIPTION
Every time a new keyset is created, the whole stack trace is logged via the `Log.i` in `AndroidKeysetManager`. For instrumentation tests which are run over and over, this log is triggered every time and happens several times. This creates more noise in logs.

The log message itself has useful information with the name of the pref value that it does not find so this PR is suggesting to replace with just the `ex.getMessage()` in the log message while removing the stack trace.

Before
```
08-05 21:50:37.402: I/AndroidKeysetManager(6547): keyset not found, will generate a new one
08-05 21:50:37.402: I/AndroidKeysetManager(6547): java.io.FileNotFoundException: can't read keyset; the pref value __app_encrypted_prefs_value_keyset__ does not exist
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at coil.collection.LinkedMultimap.readPref(LinkedMultimap.kt:4)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.google.crypto.tink.KeysetHandle.read(KeysetHandle.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.read(AndroidKeysetManager.java:2)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.readOrGenerateNewKeyset(AndroidKeysetManager.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.build(AndroidKeysetManager.java:3)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.security.crypto.EncryptedSharedPreferences.create(EncryptedSharedPreferences.java:14)
...
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at io.reactivex.rxjava3.internal.observers.ConsumerSingleObserver.onSuccess(ConsumerSingleObserver.java:2)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at io.reactivex.rxjava3.internal.operators.single.SingleObserveOn$ObserveOnSingleObserver.run(SingleObserveOn.java:3)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at io.reactivex.rxjava3.android.schedulers.HandlerScheduler$ScheduledRunnable.run(HandlerScheduler.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.os.Handler.handleCallback(Handler.java:739)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.os.Handler.dispatchMessage(Handler.java:95)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.base.Interrogator.loopAndInterrogate(Interrogator.java:14)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.base.UiControllerImpl.loopUntil(UiControllerImpl.java:8)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.base.UiControllerImpl.loopUntil(UiControllerImpl.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.base.UiControllerImpl.loopMainThreadForAtLeast(UiControllerImpl.java:8)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at slack.app.viewaction.WaitForActivityAction.perform(WaitForActivityAction.kt:43)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.ViewInteraction$SingleExecutionViewAction.perform(ViewInteraction.java:2)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.ViewInteraction.doPerform(ViewInteraction.java:22)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.ViewInteraction.access$100(ViewInteraction.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.ViewInteraction$1.call(ViewInteraction.java:2)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at androidx.test.espresso.ViewInteraction$1.call(ViewInteraction.java:1)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.os.Handler.handleCallback(Handler.java:739)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.os.Handler.dispatchMessage(Handler.java:95)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.os.Looper.loop(Looper.java:148)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at android.app.ActivityThread.main(ActivityThread.java:5417)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at java.lang.reflect.Method.invoke(Native Method)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
08-05 21:50:37.402: I/AndroidKeysetManager(6547): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

After 
```
08-05 21:50:37.402: I/AndroidKeysetManager(6547): keyset not found, will generate a new one. java.io.FileNotFoundException: can't read keyset; the pref value __app_encrypted_prefs_value_keyset__ does not exist
```