### PR TITLE
Call OutOptions.validate from CreatePublicKeysetCommand.

### DIFF
--- a/tools/tinkey/src/main/java/com/google/crypto/tink/tinkey/CreatePublicKeysetCommand.java
+++ b/tools/tinkey/src/main/java/com/google/crypto/tink/tinkey/CreatePublicKeysetCommand.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 public class CreatePublicKeysetCommand extends OutOptions implements Command {
   @Override
   public void run() throws Exception {
+    validate();
     create(outputStream, outFormat, inputStream, inFormat, masterKeyUri, credentialPath);
     outputStream.close();
     inputStream.close();


### PR DESCRIPTION
This ensures output options are validated and format is applied (and
output redirected to standard out when no --out parameter is present).

Fixes GitHub #546.