### PR TITLE
remove unneeded directive for homebrew

### DIFF
--- a/tinkey.rb
+++ b/tinkey.rb
@@ -9,8 +9,6 @@ class Tinkey < Formula
   url "https://storage.googleapis.com/tinkey/tinkey-1.6.0.tar.gz"
   sha256 "51d9694a704d00fbac04862a6427ad5f17bf59f91d5e963517d8799141e737c0"
 
-  bottle :unneeded
-
   def install
     bin.install "tinkey"
     bin.install "tinkey_deploy.jar"


### PR DESCRIPTION
this directive no longer matters to Homebrew (as of: https://github.com/Homebrew/brew/pull/11239).

Currently when installing you'll get some noisy messages on install:
```
$ brew install tinkey
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the google/tink tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/google/homebrew-tink/tinkey.rb:12

==> Downloading https://storage.googleapis.com/tinkey/tinkey-1.6.0.tar.gz
Already downloaded: /Users/christian.miller/Library/Caches/Homebrew/downloads/c6046b8c4594ec725506522dff34a5f38c825ca7faad65d08f9dca8e32b52b65--tinkey-1.6.0.tar.gz
==> Installing tinkey from google/tink
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the google/tink tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/google/homebrew-tink/tinkey.rb:12

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the google/tink tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/google/homebrew-tink/tinkey.rb:12

🍺  /usr/local/Cellar/tinkey/1.6.0: 4 files, 16.9MB, built in 5 seconds
```
this should fix that 😄 