### PR TITLE
Change HybridEncryptWrapper class visibility to public

### DIFF
--- a/java_src/src/main/java/com/google/crypto/tink/hybrid/HybridEncryptWrapper.java
+++ b/java_src/src/main/java/com/google/crypto/tink/hybrid/HybridEncryptWrapper.java
@@ -29,7 +29,7 @@ import java.security.GeneralSecurityException;
  * it uses the primary key in the keyset, and prepends to the ciphertext a certain prefix associated
  * with the primary key.
  */
-class HybridEncryptWrapper implements PrimitiveWrapper<HybridEncrypt, HybridEncrypt> {
+public class HybridEncryptWrapper implements PrimitiveWrapper<HybridEncrypt, HybridEncrypt> {
   private static class WrappedHybridEncrypt implements HybridEncrypt {
     final PrimitiveSet<HybridEncrypt> primitives;
 

--- a/java_src/src/main/java/com/google/crypto/tink/hybrid/HybridEncryptWrapper.java
+++ b/java_src/src/main/java/com/google/crypto/tink/hybrid/HybridEncryptWrapper.java
@@ -46,6 +46,8 @@ public class HybridEncryptWrapper implements PrimitiveWrapper<HybridEncrypt, Hyb
     }
   }
 
+  HybridEncryptWrapper() {}
+
   @Override
   public HybridEncrypt wrap(final PrimitiveSet<HybridEncrypt> primitives) {
     return new WrappedHybridEncrypt(primitives);


### PR DESCRIPTION
Looking at the implementation in other languages (go, python, c++) this class/object is exposed.

Without the `HybridEncryptWrapper` class being `public`, users who decide to implement a custom `HybridEncrypt` and `HybridDecrypt` primitives will have to manually register their primitives instead of using the more convenient `HybridEncryptWrapper.register()` and `HybridDecryptWrapper.register()` calls respectively.

Clarification: `HybridDecryptWrapper` is already a public class, it's just `HybridEncryptWrapper` class that needs to be exposed as well.