### PR TITLE
Modify getTrustedSigningKeysJson visibiliity

### DIFF
--- a/apps/paymentmethodtoken/src/main/java/com/google/crypto/tink/apps/paymentmethodtoken/GooglePaymentsPublicKeysManager.java
+++ b/apps/paymentmethodtoken/src/main/java/com/google/crypto/tink/apps/paymentmethodtoken/GooglePaymentsPublicKeysManager.java
@@ -93,7 +93,7 @@ public class GooglePaymentsPublicKeysManager {
    *
    * <p>Meant to be called by {@link PaymentMethodTokenRecipient}.
    */
-  String getTrustedSigningKeysJson() throws IOException {
+  public String getTrustedSigningKeysJson() throws IOException {
     return this.downloader.download();
   }
 


### PR DESCRIPTION
Due to the nature of secure repositories, whom handle credit card information and do not want to expose external calls to API's among other security considerations, this change exposes the visibility level of getTrustedSigningKeysJson, so that the root signing keys may be fetched at any time, and passed to where needed.

The service in question handles encrypted credit card data, lives in a separate VPC than other services, and does not want to expose external API calls to the Google signing keys API.

Per transaction, the use case better supports fetching only the keys downstream and passing them into Tink using the [senderVerifyingKeys](https://github.com/google/tink/blob/06aa21432e1985fea4ab26c26f6038895b22cce0/apps/paymentmethodtoken/src/main/java/com/google/crypto/tink/apps/paymentmethodtoken/PaymentMethodTokenRecipient.java#L240) method.

If there are better alternatives used at Google, please advise!
Does Google recommend using the KeysDownloader class directly instead as an alternative?