### PR TITLE
go: Fix size comparison for 32-bit systems

### DIFF
--- a/go/internal/aead/aes_gcm_insecure_iv.go
+++ b/go/internal/aead/aes_gcm_insecure_iv.go
@@ -73,11 +73,12 @@ func (i *AESGCMInsecureIV) Encrypt(iv, plaintext, associatedData []byte) ([]byte
 		return nil, fmt.Errorf("unexpected IV size: got %d, want %d", got, want)
 	}
 	// Seal() checks plaintext length, but this duplicated check avoids panic.
-	maxPlaintextSize := maxIntPlaintextSize
+	var maxPlaintextSize uint64
+	maxPlaintextSize = maxIntPlaintextSize
 	if maxIntPlaintextSize > aesGCMMaxPlaintextSize {
 		maxPlaintextSize = aesGCMMaxPlaintextSize
 	}
-	if len(plaintext) > maxPlaintextSize {
+	if uint64(len(plaintext)) > maxPlaintextSize {
 		return nil, fmt.Errorf("plaintext too long: got %d", len(plaintext))
 	}
 


### PR DESCRIPTION
The `maxAESGCMPlaintextSize` constant is too large to fit into `int` on
32-bit systems.

With 7371ced, the maximum plaintext size was reduced to take into account
the GCM IV and tag size. However, the cast to `uint64` was dropped,
which led to compilation errors:

```
$ GOOS=linux GOARCH=386 go build ./...
# github.com/google/tink/go/aead/subtle
aead/subtle/aes_gcm.go:115:7: constant 68719476704 overflows int
aead/subtle/aes_gcm.go:116:3: constant 68719476704 overflows int
```