### PR TITLE
Fix com_google_googletest bazel dependency

### DIFF
--- a/cc/tink_cc_deps.bzl
+++ b/cc/tink_cc_deps.bzl
@@ -33,7 +33,7 @@ def tink_cc_deps():
         http_archive(
             name = "com_google_googletest",
             strip_prefix = "googletest-1.10.x",
-            url = "https://github.com/google/googletest/archive/v1.10.x.zip",
+            url = "https://github.com/google/googletest/archive/refs/tags/v1.10.x.zip",
             sha256 = "54a139559cc46a68cf79e55d5c22dc9d48e647a66827342520ce0441402430fe",
         )
 


### PR DESCRIPTION
The https://github.com/google/googletest/archive/v1.10.x.zip URL returns error `the given path has multiple possibilities: #<Git::Ref:0x00007f0a9b69c308>, #<Git::Ref:0x00007f0a9b6a6420>` because there is both a branch and a tag with that name.

I've updated it to use the tag reference, but if it was suppose to be the branch name I can change it to that.