### PR TITLE
Fix Broken Link to Python examples in readme

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -18,5 +18,5 @@ Google Assistant, Firebase, the Android Search App, etc.
 For an overview of using Tink in Python, see https://developers.google.com/tink.
 
 In addition, there are illustrative [examples of using Tink
-Python](https://github.com/google/tink/tree/master/examples/python/) which can
+Python](https://github.com/google/tink/tree/master/python/examples) which can
 used as a jumping off point.


### PR DESCRIPTION
-Fix Broken URL https://github.com/google/tink/tree/master/examples/python/ in readme to (https://github.com/google/tink/tree/master/python/examples