### PR TITLE
Upgrade protobuf-java to 3.19.6

### DIFF
--- a/java_src/tink_java_deps.bzl
+++ b/java_src/tink_java_deps.bzl
@@ -65,9 +65,9 @@ def tink_java_deps():
         # Release from 2021-06-08.
         http_archive(
             name = "com_google_protobuf",
-            strip_prefix = "protobuf-3.19.3",
-            urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.3.zip"],
-            sha256 = "6b6bf5cd8d0cca442745c4c3c9f527c83ad6ef35a405f64db5215889ac779b42",
+            strip_prefix = "protobuf-3.19.6",
+            urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.6.zip"],
+            sha256 = "387e2c559bb2c7c1bc3798c4e6cff015381a79b2758696afcbf8e88730b47389",
         )
 
     # -------------------------------------------------------------------------

--- a/maven/tink.pom.xml
+++ b/maven/tink.pom.xml
@@ -85,7 +85,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <protobuf.version>3.19.3</protobuf.version>
+    <protobuf.version>3.19.6</protobuf.version>
     <androidx_annotation.version>1.5.0</androidx_annotation.version>
     <gson.version>2.8.9</gson.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>


### PR DESCRIPTION
This PR upgrades `protobuf-java` to `3.19.6` so tink do not rely on a dependency vulnerable to [CVE-2022-3171](https://nvd.nist.gov/vuln/detail/CVE-2022-3171).