### PR TITLE
Fix broken Markdown in "Primitive implementations supported by language" table

### DIFF
--- a/docs/PRIMITIVES.md
+++ b/docs/PRIMITIVES.md
@@ -41,30 +41,31 @@ TypeScript is still under development.
 
 ### Primitive implementations supported by language
 
-**Primitive**      | **Implementation**                    | **Java** | **C++ (BoringSSL)** | **C++ (OpenSSL)** | **Objective-C** | **Go** | **Python** | **TypeScript**
------------------- | ------------------------------------- | :------: | :-----------------: | :---------------: | :-------------: | :----: | :--------: | :------------:
-AEAD               | AES-GCM                               | yes      | yes                 | yes               | yes             | yes    | yes        | yes
-                   | AES-GCM-SIV                           | yes      | yes                 | **no**            | **no**          | **no** | **no**     | **no**
-                   | AES-CTR-HMAC                          | yes      | yes                 | yes               | yes             | yes    | yes        | yes
-                   | AES-EAX                               | yes      | yes                 | yes               | yes             | **no** | yes        | **no**
-                   | KMS Envelope                          | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-                   | CHACHA20-POLY1305                     | yes      | **no**              | **no**            | **no**          | yes    | **no**     | **no**
-                   | XCHACHA20-POLY1305                    | yes      | yes                 | **no**            | yes             | yes    | yes        | **no**
-Streaming AEAD     | AES-GCM-HKDF-STREAMING                | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-                   | AES-CTR-HMAC-STREAMING                | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-Deterministic AEAD | AES-SIV                               | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-MAC                | HMAC-SHA2                             | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-                   | AES-CMAC                              | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-PRF                | HKDF-SHA2                             | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-                   | HMAC-SHA2                             | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-                   | AES-CMAC                              | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
-Digital Signatures | ECDSA over NIST curves                | yes      | yes                 | yes \*            | yes             | yes    | yes        | yes
-                   | Ed25519                               | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-                   | RSA-SSA-PKCS1                         | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-                   | RSA-SSA-PSS                           | yes      | yes                 | yes               | yes             | yes    | yes        | **no**
-Hybrid Encryption  | HPKE                                  | yes      | yes                 | **no**            | **no**          | yes    | yes        | **no**
-                   | ECIES with AEAD and HKDF              | yes      | yes                 | yes               | yes             | yes    | yes        | yes
-                   | ECIES with DeterministicAEAD and HKDF | yes      | yes                 | yes               | **no**          | yes    | yes        | **no**
+
+ | **Primitive**      | **Implementation**                | **Java** | **C++ (BoringSSL)** | **C++ (OpenSSL)** | **Objective-C** | **Go**     | **Python** |
+ | ------------------ | --------------------------------- | :------: | :-----------------: | :---------------: | :-------------: | :--------: | :--------: |
+ | AEAD               | AES-GCM                           | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | AES-GCM-SIV                       | yes      | yes                 | **no**            | **no**          | **no**     | **no**     |
+ |                    | AES-CTR-HMAC                      | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | AES-EAX                           | yes      | yes                 | yes               | yes             | **no**     | yes        |
+ |                    | KMS Envelope                      | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ |                    | CHACHA20-POLY1305                 | yes      | **no**              | **no**            | **no**          | yes        | **no**     |
+ |                    | XCHACHA20-POLY1305                | yes      | yes                 | **no**            | yes             | yes        | yes        |
+ | Streaming AEAD     | AES-GCM-HKDF-STREAMING            | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ |                    | AES-CTR-HMAC-STREAMING            | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ | Deterministic AEAD | AES-SIV                           | yes      | yes                 | yes               | yes             | yes        | yes        |
+ | MAC                | HMAC-SHA2                         | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | AES-CMAC                          | yes      | yes                 | yes               | yes             | yes        | yes        |
+ | PRF                | HKDF-SHA2                         | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ |                    | HMAC-SHA2                         | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ |                    | AES-CMAC                          | yes      | yes                 | yes               | **no**          | yes        | yes        |
+ | Digital Signatures | ECDSA over NIST curves            | yes      | yes                 | yes \*            | yes             | yes        | yes        |
+ |                    | Ed25519                           | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | RSA-SSA-PKCS1                     | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | RSA-SSA-PSS                       | yes      | yes                 | yes               | yes             | yes        | yes        |
+ | Hybrid Encryption  | HPKE                              | yes      | yes                 | **no**            | **no**          | yes        | yes        |
+ |                    | ECIES with AEAD and HKDF          | yes      | yes                 | yes               | yes             | yes        | yes        |
+ |                    | ECIES with Deterministic AEAD and HKDF | yes      | yes                 | yes               | **no**          | yes        | yes        |
 
 \* EC key creation from seed (`DeriveKey`) is unsupported.
 


### PR DESCRIPTION
Fix _Primitive implementations supported by language_ table broken in b85ac5fea68c09e11ea15c51f68519d85db9a448