### PR TITLE
fix go proto module path

### DIFF
--- a/cc/proto/aes_gcm.proto
+++ b/cc/proto/aes_gcm.proto
@@ -20,7 +20,7 @@ package google.crypto.tink;
 
 option java_package = "com.google.crypto.tink.proto";
 option java_multiple_files = true;
-option go_package = "github.com/google/tink/proto/aes_gcm_go_proto";
+option go_package = "github.com/google/tink/go/proto/aes_gcm_go_proto";
 option objc_class_prefix = "TINKPB";
 
 message AesGcmKeyFormat {

--- a/java_src/proto/aes_gcm.proto
+++ b/java_src/proto/aes_gcm.proto
@@ -20,7 +20,7 @@ package google.crypto.tink;
 
 option java_package = "com.google.crypto.tink.proto";
 option java_multiple_files = true;
-option go_package = "github.com/google/tink/proto/aes_gcm_go_proto";
+option go_package = "github.com/google/tink/go/proto/aes_gcm_go_proto";
 option objc_class_prefix = "TINKPB";
 
 message AesGcmKeyFormat {

--- a/javascript/proto/aes_gcm.proto
+++ b/javascript/proto/aes_gcm.proto
@@ -20,7 +20,7 @@ package google.crypto.tink;
 
 option java_package = "com.google.crypto.tink.proto";
 option java_multiple_files = true;
-option go_package = "github.com/google/tink/proto/aes_gcm_go_proto";
+option go_package = "github.com/google/tink/go/proto/aes_gcm_go_proto";
 option objc_class_prefix = "TINKPB";
 
 message AesGcmKeyFormat {

--- a/proto/aes_gcm.proto
+++ b/proto/aes_gcm.proto
@@ -20,7 +20,7 @@ package google.crypto.tink;
 
 option java_package = "com.google.crypto.tink.proto";
 option java_multiple_files = true;
-option go_package = "github.com/google/tink/proto/aes_gcm_go_proto";
+option go_package = "github.com/google/tink/go/proto/aes_gcm_go_proto";
 option objc_class_prefix = "TINKPB";
 
 message AesGcmKeyFormat {

--- a/python/tink/proto/aes_gcm.proto
+++ b/python/tink/proto/aes_gcm.proto
@@ -20,7 +20,7 @@ package google.crypto.tink;
 
 option java_package = "com.google.crypto.tink.proto";
 option java_multiple_files = true;
-option go_package = "github.com/google/tink/proto/aes_gcm_go_proto";
+option go_package = "github.com/google/tink/go/proto/aes_gcm_go_proto";
 option objc_class_prefix = "TINKPB";
 
 message AesGcmKeyFormat {


### PR DESCRIPTION
Go modules have a go.mod at the referenced path. For google/tink that's in the go subdirectory. This is why `go get` will not work with the package:

```
$ go get github.com/google/tink/proto/aes_gcm_go_proto
go: module github.com/google/tink@upgrade found (v1.7.0), but does not contain package github.com/google/tink/proto/aes_gcm_go_proto
```

Updating the path allows the install to work correctly (and compiling proto code referencing this proto to install the module successfully).