### PR TITLE
Add AES-GCM-SIV key templates to Go implementation

### DIFF
--- a/go/aead/aead_key_templates.go
+++ b/go/aead/aead_key_templates.go
@@ -24,6 +24,7 @@ import (
 	ctrpb "github.com/google/tink/go/proto/aes_ctr_go_proto"
 	ctrhmacpb "github.com/google/tink/go/proto/aes_ctr_hmac_aead_go_proto"
 	gcmpb "github.com/google/tink/go/proto/aes_gcm_go_proto"
+	gcmsivpb "github.com/google/tink/go/proto/aes_gcm_siv_go_proto"
 	commonpb "github.com/google/tink/go/proto/common_go_proto"
 	hmacpb "github.com/google/tink/go/proto/hmac_go_proto"
 	kmsenvpb "github.com/google/tink/go/proto/kms_envelope_go_proto"
@@ -52,6 +53,27 @@ func AES256GCMKeyTemplate() *tinkpb.KeyTemplate {
 //   - Output prefix type: RAW
 func AES256GCMNoPrefixKeyTemplate() *tinkpb.KeyTemplate {
 	return createAESGCMKeyTemplate(32, tinkpb.OutputPrefixType_RAW)
+}
+
+// AES128GCMSIVKeyTemplate is a KeyTemplate that generates an AES-GCM-SIV key with the following parameters:
+//   - Key size: 16 bytes
+//   - Output prefix type: TINK
+func AES128GCMSIVKeyTemplate() *tinkpb.KeyTemplate {
+	return createAESGCMSIVKeyTemplate(16, tinkpb.OutputPrefixType_TINK)
+}
+
+// AES256GCMSIVKeyTemplate is a KeyTemplate that generates an AES-GCM-SIV key with the following parameters:
+//   - Key size: 32 bytes
+//   - Output prefix type: TINK
+func AES256GCMSIVKeyTemplate() *tinkpb.KeyTemplate {
+	return createAESGCMSIVKeyTemplate(32, tinkpb.OutputPrefixType_TINK)
+}
+
+// AES256GCMSIVNoPrefixKeyTemplate is a KeyTemplate that generates an AES-GCM key with the following parameters:
+//   - Key size: 32 bytes
+//   - Output prefix type: RAW
+func AES256GCMSIVNoPrefixKeyTemplate() *tinkpb.KeyTemplate {
+	return createAESGCMSIVKeyTemplate(32, tinkpb.OutputPrefixType_RAW)
 }
 
 // AES128CTRHMACSHA256KeyTemplate is a KeyTemplate that generates an AES-CTR-HMAC-AEAD key with the following parameters:
@@ -153,6 +175,23 @@ func createAESGCMKeyTemplate(keySize uint32, outputPrefixType tinkpb.OutputPrefi
 	}
 	return &tinkpb.KeyTemplate{
 		TypeUrl:          aesGCMTypeURL,
+		Value:            serializedFormat,
+		OutputPrefixType: outputPrefixType,
+	}
+}
+
+// createAESGCMSIVKeyTemplate creates a new AES-GCM-SIV key template with the given key
+// size in bytes.
+func createAESGCMSIVKeyTemplate(keySize uint32, outputPrefixType tinkpb.OutputPrefixType) *tinkpb.KeyTemplate {
+	format := &gcmsivpb.AesGcmSivKeyFormat{
+		KeySize: keySize,
+	}
+	serializedFormat, err := proto.Marshal(format)
+	if err != nil {
+		tinkerror.Fail(fmt.Sprintf("failed to marshal key format: %s", err))
+	}
+	return &tinkpb.KeyTemplate{
+		TypeUrl:          aesGCMSIVTypeURL,
 		Value:            serializedFormat,
 		OutputPrefixType: outputPrefixType,
 	}

--- a/go/aead/aead_key_templates_test.go
+++ b/go/aead/aead_key_templates_test.go
@@ -44,6 +44,15 @@ func TestKeyTemplates(t *testing.T) {
 			name:     "AES256_GCM_NO_PREFIX",
 			template: aead.AES256GCMNoPrefixKeyTemplate(),
 		}, {
+			name:     "AES128_GCM_SIV",
+			template: aead.AES128GCMSIVKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_SIV",
+			template: aead.AES256GCMSIVKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_SIV_NO_PREFIX",
+			template: aead.AES256GCMSIVNoPrefixKeyTemplate(),
+		}, {
 			name:     "AES128_CTR_HMAC_SHA256",
 			template: aead.AES128CTRHMACSHA256KeyTemplate(),
 		}, {


### PR DESCRIPTION
This PR adds support for AES-GCM-SIV templates in the Tink library for Go.

I noticed that [functionality exists](https://github.com/google/tink/blob/master/go/aead/aes_gcm_siv_key_manager.go) within the Go library to manage keys used for an AES-GCM-SIV AEAD scheme, but there were no templates to make it easy for developers to create new instances of these keys.

In terms of what key sizes / outputs to support, for now I mirrored what AES-GCM supports today. That is:

* 128 bits with the Tink output
* 256 bits with the Tink output or the raw output

I'm flexible here and can adjust if you'd prefer something else!

I've updated unit tests accordingly and, if needed, this is safe to revert.