### PR TITLE
Javascript - Improve code style consistency among typescript tests:

### DIFF
--- a/javascript/aead/aead_config_test.ts
+++ b/javascript/aead/aead_config_test.ts
@@ -4,94 +4,105 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {KeysetHandle} from '../internal/keyset_handle';
-import {PbKeyData, PbKeyset, PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
+import { KeysetHandle } from "../internal/keyset_handle";
+import {
+	PbKeyData,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
 
-import {AeadConfig} from './aead_config';
-import {AeadKeyTemplates} from './aead_key_templates';
-import {AesCtrHmacAeadKeyManager} from './aes_ctr_hmac_aead_key_manager';
-import {AesGcmKeyManager} from './aes_gcm_key_manager';
-import {Aead} from './internal/aead';
+import { AeadConfig } from "./aead_config";
+import { AeadKeyTemplates } from "./aead_key_templates";
+import { AesCtrHmacAeadKeyManager } from "./aes_ctr_hmac_aead_key_manager";
+import { AesGcmKeyManager } from "./aes_gcm_key_manager";
+import { Aead } from "./internal/aead";
 
-describe('aead config test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("aead config test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('constants', function() {
-    expect(AeadConfig.PRIMITIVE_NAME).toBe(PRIMITIVE_NAME);
+	it("constants", () => {
+		expect(AeadConfig.PRIMITIVE_NAME).toBe(PRIMITIVE_NAME);
 
-    expect(AeadConfig.AES_CTR_HMAC_AEAD_TYPE_URL)
-        .toBe(AES_CTR_HMAC_AEAD_KEY_TYPE);
-    expect(AeadConfig.AES_GCM_TYPE_URL).toBe(AES_GCM_KEY_TYPE);
-  });
+		expect(AeadConfig.AES_CTR_HMAC_AEAD_TYPE_URL).toBe(
+			AES_CTR_HMAC_AEAD_KEY_TYPE
+		);
+		expect(AeadConfig.AES_GCM_TYPE_URL).toBe(AES_GCM_KEY_TYPE);
+	});
 
-  it('register, corresponding key managers were registered', function() {
-    AeadConfig.register();
+	it("register, corresponding key managers were registered", () => {
+		AeadConfig.register();
 
-    // Test that the corresponding key managers were registered.
-    const aesCtrHmacKeyManager =
-        Registry.getKeyManager(AES_CTR_HMAC_AEAD_KEY_TYPE);
-    expect(aesCtrHmacKeyManager instanceof AesCtrHmacAeadKeyManager).toBe(true);
+		// Test that the corresponding key managers were registered.
+		const aesCtrHmacKeyManager = Registry.getKeyManager(
+			AES_CTR_HMAC_AEAD_KEY_TYPE
+		);
+		expect(aesCtrHmacKeyManager instanceof AesCtrHmacAeadKeyManager).toBe(
+			true
+		);
 
-    const aesGcmKeyManager = Registry.getKeyManager(AES_GCM_KEY_TYPE);
-    expect(aesGcmKeyManager instanceof AesGcmKeyManager).toBe(true);
+		const aesGcmKeyManager = Registry.getKeyManager(AES_GCM_KEY_TYPE);
+		expect(aesGcmKeyManager instanceof AesGcmKeyManager).toBe(true);
 
-    // TODO add tests for other key types here, whenever they are available in
-    // Tink.
-  });
+		// TODO add tests for other key types here, whenever they are available in
+		// Tink.
+	});
 
-  it('register, predefined templates should work', async function() {
-    AeadConfig.register();
-    let templates = [
-      AeadKeyTemplates.aes128Gcm(), AeadKeyTemplates.aes256Gcm(),
-      AeadKeyTemplates.aes128CtrHmacSha256(),
-      AeadKeyTemplates.aes256CtrHmacSha256()
-    ];
-    for (const template of templates) {
-      const keyData = await Registry.newKeyData(template);
-      const keysetHandle = createKeysetHandleFromKeyData(keyData);
+	it("register, predefined templates should work", async () => {
+		AeadConfig.register();
+		let templates = [
+			AeadKeyTemplates.aes128Gcm(),
+			AeadKeyTemplates.aes256Gcm(),
+			AeadKeyTemplates.aes128CtrHmacSha256(),
+			AeadKeyTemplates.aes256CtrHmacSha256(),
+		];
+		for (const template of templates) {
+			const keyData = await Registry.newKeyData(template);
+			const keysetHandle = createKeysetHandleFromKeyData(keyData);
 
-      const aead = await keysetHandle.getPrimitive<Aead>(Aead);
-      const plaintext = Random.randBytes(10);
-      const aad = Random.randBytes(8);
-      const ciphertext = await aead.encrypt(plaintext, aad);
-      const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
+			const aead = await keysetHandle.getPrimitive<Aead>(Aead);
+			const plaintext = Random.randBytes(10);
+			const aad = Random.randBytes(8);
+			const ciphertext = await aead.encrypt(plaintext, aad);
+			const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
 
-      expect(decryptedCiphertext).toEqual(plaintext);
-    }
-  });
+			expect(decryptedCiphertext).toEqual(plaintext);
+		}
+	});
 });
 
 // Constants used in tests.
-const PRIMITIVE_NAME = 'Aead';
+const PRIMITIVE_NAME = "Aead";
 const AES_CTR_HMAC_AEAD_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey';
-const AES_GCM_KEY_TYPE = 'type.googleapis.com/google.crypto.tink.AesGcmKey';
+	"type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey";
+const AES_GCM_KEY_TYPE = "type.googleapis.com/google.crypto.tink.AesGcmKey";
 
 /**
  * Creates a keyset containing only the key given by keyData and returns it
  * wrapped in a KeysetHandle.
  */
 function createKeysetHandleFromKeyData(keyData: PbKeyData): KeysetHandle {
-  const keyId = 1;
-  const key = new PbKeysetKey()
-                  .setKeyData(keyData)
-                  .setStatus(PbKeyStatusType.ENABLED)
-                  .setKeyId(keyId)
-                  .setOutputPrefixType(PbOutputPrefixType.TINK);
+	const keyId = 1;
+	const key = new PbKeysetKey()
+		.setKeyData(keyData)
+		.setStatus(PbKeyStatusType.ENABLED)
+		.setKeyId(keyId)
+		.setOutputPrefixType(PbOutputPrefixType.TINK);
 
-  const keyset = new PbKeyset();
-  keyset.addKey(key);
-  keyset.setPrimaryKeyId(keyId);
-  return new KeysetHandle(keyset);
+	const keyset = new PbKeyset();
+	keyset.addKey(key);
+	keyset.setPrimaryKeyId(keyId);
+	return new KeysetHandle(keyset);
 }

--- a/javascript/aead/aead_key_templates_test.ts
+++ b/javascript/aead/aead_key_templates_test.ts
@@ -4,33 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbKeyTemplate} from '../internal/proto';
+import { PbKeyTemplate } from "../internal/proto";
 
-import {AeadKeyTemplates} from './aead_key_templates';
+import { AeadKeyTemplates } from "./aead_key_templates";
 
-describe('aead key templates test', function() {
-  it('aes128 ctr hmac sha256', function() {
-    const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-    expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
-  });
+describe("aead key templates test", () => {
+	it("aes128 ctr hmac sha256", () => {
+		const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+		expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
+	});
 
-  it('aes256 ctr hmac sha256', function() {
-    const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
-    expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
-  });
+	it("aes256 ctr hmac sha256", () => {
+		const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
+		expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
+	});
 
-  it('aes128 gcm', function() {
-    const keyTemplate = AeadKeyTemplates.aes128Gcm();
-    expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
-  });
+	it("aes128 gcm", () => {
+		const keyTemplate = AeadKeyTemplates.aes128Gcm();
+		expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
+	});
 
-  it('aes256 gcm', function() {
-    const keyTemplate = AeadKeyTemplates.aes256Gcm();
-    expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
-  });
+	it("aes256 gcm", () => {
+		const keyTemplate = AeadKeyTemplates.aes256Gcm();
+		expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
+	});
 
-  it('aes256 gcm no prefix', function() {
-    const keyTemplate = AeadKeyTemplates.aes256GcmNoPrefix();
-    expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
-  });
+	it("aes256 gcm no prefix", () => {
+		const keyTemplate = AeadKeyTemplates.aes256GcmNoPrefix();
+		expect(keyTemplate instanceof PbKeyTemplate).toBe(true);
+	});
 });

--- a/javascript/aead/aead_wrapper_test.ts
+++ b/javascript/aead/aead_wrapper_test.ts
@@ -4,169 +4,190 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {SecurityException} from '../exception/security_exception';
-import {CryptoFormat} from '../internal/crypto_format';
-import * as PrimitiveSet from '../internal/primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Bytes from '../subtle/bytes';
-import {assertExists} from '../testing/internal/test_utils';
+import { SecurityException } from "../exception/security_exception";
+import { CryptoFormat } from "../internal/crypto_format";
+import * as PrimitiveSet from "../internal/primitive_set";
+import {
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Bytes from "../subtle/bytes";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {AeadWrapper} from './aead_wrapper';
-import {Aead} from './internal/aead';
+import { AeadWrapper } from "./aead_wrapper";
+import { Aead } from "./internal/aead";
 
-describe('aead wrapper test', function() {
-  it('new aead primitive set without primary', async function() {
-    const primitiveSet = createPrimitiveSet(/* opt_withPrimary = */ false);
-    try {
-      new AeadWrapper().wrap(primitiveSet);
-    // This is an intentionally unsafe partial mock
-    // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.primitiveSetWithoutPrimary());
-      return;
-    }
-    fail('Should throw an exception.');
-  });
+describe("aead wrapper test", () => {
+	it("new aead primitive set without primary", async () => {
+		const primitiveSet = createPrimitiveSet(/* opt_withPrimary = */ false);
+		try {
+			new AeadWrapper().wrap(primitiveSet);
+			// This is an intentionally unsafe partial mock
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.primitiveSetWithoutPrimary()
+			);
+			return;
+		}
+		fail("Should throw an exception.");
+	});
 
-  it('new aead primitive should work', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
-    expect(aead != null && aead != undefined).toBe(true);
-  });
+	it("new aead primitive should work", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
+		expect(aead != null && aead != undefined).toBe(true);
+	});
 
-  it('encrypt', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
+	it("encrypt", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    const plaintext = new Uint8Array([0, 1, 2, 3]);
+		const plaintext = new Uint8Array([0, 1, 2, 3]);
 
-    const ciphertext = await aead.encrypt(plaintext);
-    expect(ciphertext != null).toBe(true);
+		const ciphertext = await aead.encrypt(plaintext);
+		expect(ciphertext != null).toBe(true);
 
-    // Ciphertext should begin with primary key output prefix.
-    expect(ciphertext.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE))
-        .toEqual(assertExists(primitiveSet.getPrimary()).getIdentifier());
-  });
+		// Ciphertext should begin with primary key output prefix.
+		expect(
+			ciphertext.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE)
+		).toEqual(assertExists(primitiveSet.getPrimary()).getIdentifier());
+	});
 
-  it('decrypt bad ciphertext', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
+	it("decrypt bad ciphertext", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    const ciphertext = new Uint8Array([9, 8, 7, 6, 5, 4, 3]);
+		const ciphertext = new Uint8Array([9, 8, 7, 6, 5, 4, 3]);
 
-    try {
-      await aead.decrypt(ciphertext);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-      return;
-    }
-    fail('Should throw an exception');
-  });
+		try {
+			await aead.decrypt(ciphertext);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+			return;
+		}
+		fail("Should throw an exception");
+	});
 
-  it('decrypt with ciphertext encrypted by primary key', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
+	it("decrypt with ciphertext encrypted by primary key", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    const plaintext = new Uint8Array([12, 51, 45, 200, 120, 111]);
+		const plaintext = new Uint8Array([12, 51, 45, 200, 120, 111]);
 
-    const ciphertext = await aead.encrypt(plaintext);
-    const decryptResult = await aead.decrypt(ciphertext);
+		const ciphertext = await aead.encrypt(plaintext);
+		const decryptResult = await aead.decrypt(ciphertext);
 
-    expect(decryptResult).toEqual(plaintext);
-  });
+		expect(decryptResult).toEqual(plaintext);
+	});
 
-  it('decrypt ciphertext encrypted by non primary key', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
+	it("decrypt ciphertext encrypted by non primary key", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    // Encrypt the plaintext with primary.
-    const plaintext = new Uint8Array([0xAA, 0xBB, 0xAB, 0xBA, 0xFF]);
-    const ciphertext = await aead.encrypt(plaintext);
+		// Encrypt the plaintext with primary.
+		const plaintext = new Uint8Array([0xaa, 0xbb, 0xab, 0xba, 0xff]);
+		const ciphertext = await aead.encrypt(plaintext);
 
-    // Add a new primary to primitive set and make new AeadSetWrapper with the
-    // updated primitive set.
-    const keyId = 0xFFFFFFFF;
-    const key =
-        createKey(keyId, PbOutputPrefixType.LEGACY, /* enabled = */ true);
-    const entry =
-        primitiveSet.addPrimitive(new DummyAead(new Uint8Array([0xFF])), key);
-    primitiveSet.setPrimary(entry);
-    const aead2 = new AeadWrapper().wrap(primitiveSet);
+		// Add a new primary to primitive set and make new AeadSetWrapper with the
+		// updated primitive set.
+		const keyId = 0xffffffff;
+		const key = createKey(
+			keyId,
+			PbOutputPrefixType.LEGACY,
+			/* enabled = */ true
+		);
+		const entry = primitiveSet.addPrimitive(
+			new DummyAead(new Uint8Array([0xff])),
+			key
+		);
+		primitiveSet.setPrimary(entry);
+		const aead2 = new AeadWrapper().wrap(primitiveSet);
 
-    // Check that the ciphertext can be decrypted by the setWrapper with new
-    // primary and that the decryption corresponds to the plaintext.
-    const decryptResult = await aead2.decrypt(ciphertext);
+		// Check that the ciphertext can be decrypted by the setWrapper with new
+		// primary and that the decryption corresponds to the plaintext.
+		const decryptResult = await aead2.decrypt(ciphertext);
 
-    expect(decryptResult).toEqual(plaintext);
-  });
+		expect(decryptResult).toEqual(plaintext);
+	});
 
-  it('decrypt ciphertext raw primitive', async function() {
-    const primitiveSet = createPrimitiveSet();
-    // Create a RAW primitive and add it to primitiveSet.
-    const keyId = 0xFFFFFFFF;
-    const rawKey =
-        createKey(keyId, PbOutputPrefixType.RAW, /* enabled = */ true);
-    const rawKeyAead = new DummyAead(new Uint8Array([0xFF]));
-    primitiveSet.addPrimitive(rawKeyAead, rawKey);
+	it("decrypt ciphertext raw primitive", async () => {
+		const primitiveSet = createPrimitiveSet();
+		// Create a RAW primitive and add it to primitiveSet.
+		const keyId = 0xffffffff;
+		const rawKey = createKey(
+			keyId,
+			PbOutputPrefixType.RAW,
+			/* enabled = */ true
+		);
+		const rawKeyAead = new DummyAead(new Uint8Array([0xff]));
+		primitiveSet.addPrimitive(rawKeyAead, rawKey);
 
-    // Encrypt the plaintext by aead corresponding to the rawKey.
-    const plaintext = new Uint8Array([0x11, 0x15, 0xAA, 0x54]);
-    const ciphertext = await rawKeyAead.encrypt(plaintext);
+		// Encrypt the plaintext by aead corresponding to the rawKey.
+		const plaintext = new Uint8Array([0x11, 0x15, 0xaa, 0x54]);
+		const ciphertext = await rawKeyAead.encrypt(plaintext);
 
-    // Create aead which should be able to decrypt the ciphertext.
-    const aead = new AeadWrapper().wrap(primitiveSet);
+		// Create aead which should be able to decrypt the ciphertext.
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    // Try to decrypt the ciphertext by aead and check that the result
-    // corresponds to the plaintext.
-    const decryptResult = await aead.decrypt(ciphertext);
-    expect(decryptResult).toEqual(plaintext);
-  });
+		// Try to decrypt the ciphertext by aead and check that the result
+		// corresponds to the plaintext.
+		const decryptResult = await aead.decrypt(ciphertext);
+		expect(decryptResult).toEqual(plaintext);
+	});
 
-  it('decrypt ciphertext disabled primitive', async function() {
-    const primitiveSet = createPrimitiveSet();
+	it("decrypt ciphertext disabled primitive", async () => {
+		const primitiveSet = createPrimitiveSet();
 
-    // Create a primitive with disabled key and add it to primitiveSet.
-    const keyId = 0xFFFFFFFF;
-    const key = createKey(keyId, PbOutputPrefixType.RAW, /* enabled = */ false);
-    const disabledKeyAead = new DummyAead(new Uint8Array([0xFF]));
-    primitiveSet.addPrimitive(disabledKeyAead, key);
+		// Create a primitive with disabled key and add it to primitiveSet.
+		const keyId = 0xffffffff;
+		const key = createKey(
+			keyId,
+			PbOutputPrefixType.RAW,
+			/* enabled = */ false
+		);
+		const disabledKeyAead = new DummyAead(new Uint8Array([0xff]));
+		primitiveSet.addPrimitive(disabledKeyAead, key);
 
-    // Encrypt the plaintext by a primitive with disabled key.
-    const plaintext = new Uint8Array([0, 1, 2, 3]);
-    const ciphertext = await disabledKeyAead.encrypt(plaintext);
+		// Encrypt the plaintext by a primitive with disabled key.
+		const plaintext = new Uint8Array([0, 1, 2, 3]);
+		const ciphertext = await disabledKeyAead.encrypt(plaintext);
 
-    // Create aead containing the primitive with disabled key.
-    const aead = new AeadWrapper().wrap(primitiveSet);
+		// Create aead containing the primitive with disabled key.
+		const aead = new AeadWrapper().wrap(primitiveSet);
 
-    // Check that the ciphertext cannot be decrypted as disabled keys cannot be
-    // used to neither encryption nor decryption.
-    try {
-      await aead.decrypt(ciphertext);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		// Check that the ciphertext cannot be decrypted as disabled keys cannot be
+		// used to neither encryption nor decryption.
+		try {
+			await aead.decrypt(ciphertext);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('encrypt decrypt,  associated data should be passed', async function() {
-    const primitiveSet = createPrimitiveSet();
-    const aead = new AeadWrapper().wrap(primitiveSet);
-    const plaintext = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
-    const aad = new Uint8Array([8, 9, 10, 11, 12]);
+	it("encrypt decrypt,  associated data should be passed", async () => {
+		const primitiveSet = createPrimitiveSet();
+		const aead = new AeadWrapper().wrap(primitiveSet);
+		const plaintext = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
+		const aad = new Uint8Array([8, 9, 10, 11, 12]);
 
-    // Encrypt the plaintext with aad. The ciphertext should end with aad if
-    // it was passed correctly.
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    const ciphertextAad =
-        ciphertext.slice(ciphertext.length - aad.length, ciphertext.length);
-    expect(ciphertextAad).toEqual(aad);
+		// Encrypt the plaintext with aad. The ciphertext should end with aad if
+		// it was passed correctly.
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		const ciphertextAad = ciphertext.slice(
+			ciphertext.length - aad.length,
+			ciphertext.length
+		);
+		expect(ciphertextAad).toEqual(aad);
 
-    // Decrypt the ciphertext with aad. It is possible only if aad was passed
-    // correctly.
-    const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		// Decrypt the ciphertext with aad. It is possible only if aad was passed
+		// correctly.
+		const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 });
 
 /**
@@ -174,111 +195,125 @@ describe('aead wrapper test', function() {
  * @final
  */
 class ExceptionText {
-  static nullPrimitiveSet(): string {
-    return 'SecurityException: Primitive set has to be non-null.';
-  }
+	static nullPrimitiveSet(): string {
+		return "SecurityException: Primitive set has to be non-null.";
+	}
 
-  static primitiveSetWithoutPrimary(): string {
-    return 'SecurityException: Primary has to be non-null.';
-  }
+	static primitiveSetWithoutPrimary(): string {
+		return "SecurityException: Primary has to be non-null.";
+	}
 
-  static cannotBeDecrypted(): string {
-    return 'SecurityException: Decryption failed for the given ciphertext.';
-  }
+	static cannotBeDecrypted(): string {
+		return "SecurityException: Decryption failed for the given ciphertext.";
+	}
 }
 
 /** Function for creating keys for testing purposes. */
 function createKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  return key;
+	return key;
 }
 
 /**
- * Creates a primitive set with 'numberOfPrimitives' primitives. The keys
+ * Creates a primitive set with "numberOfPrimitives" primitives. The keys
  * corresponding to the primitives have ids from the set
  * [1, ..., numberOfPrimitives] and the primitive corresponding to key with id
- * 'numberOfPrimitives' is set to be primary whenever opt_withPrimary is set to
+ * "numberOfPrimitives" is set to be primary whenever opt_withPrimary is set to
  * true (where true is the default value).
  */
-function createPrimitiveSet(opt_withPrimary: boolean = true):
-    PrimitiveSet.PrimitiveSet<Aead> {
-  const numberOfPrimitives = 5;
+function createPrimitiveSet(
+	opt_withPrimary: boolean = true
+): PrimitiveSet.PrimitiveSet<Aead> {
+	const numberOfPrimitives = 5;
 
-  const primitiveSet = new PrimitiveSet.PrimitiveSet<DummyAead>(DummyAead);
-  for (let i = 1; i < numberOfPrimitives; i++) {
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    const key = createKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
-    primitiveSet.addPrimitive(new DummyAead(new Uint8Array([i])), key);
-  }
+	const primitiveSet = new PrimitiveSet.PrimitiveSet<DummyAead>(DummyAead);
+	for (let i = 1; i < numberOfPrimitives; i++) {
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		const key = createKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
+		primitiveSet.addPrimitive(new DummyAead(new Uint8Array([i])), key);
+	}
 
-  const key = createKey(
-      numberOfPrimitives, PbOutputPrefixType.TINK, /* enabled = */ true);
-  const aead = new DummyAead(new Uint8Array([numberOfPrimitives]));
-  const entry = primitiveSet.addPrimitive(aead, key);
-  if (opt_withPrimary) {
-    primitiveSet.setPrimary(entry);
-  }
+	const key = createKey(
+		numberOfPrimitives,
+		PbOutputPrefixType.TINK,
+		/* enabled = */ true
+	);
+	const aead = new DummyAead(new Uint8Array([numberOfPrimitives]));
+	const entry = primitiveSet.addPrimitive(aead, key);
+	if (opt_withPrimary) {
+		primitiveSet.setPrimary(entry);
+	}
 
-  return primitiveSet;
+	return primitiveSet;
 }
 
 /** @final */
 class DummyAead extends Aead {
-  constructor(private readonly primitiveIdentifier: Uint8Array) {
-    super();
-  }
+	constructor(private readonly primitiveIdentifier: Uint8Array) {
+		super();
+	}
 
-  /** @override*/
-  async encrypt(plaintext: Uint8Array, opt_associatedData?: Uint8Array) {
-    const result = Bytes.concat(plaintext, this.primitiveIdentifier);
-    if (opt_associatedData) {
-      return Bytes.concat(result, opt_associatedData);
-    }
-    return result;
-  }
+	/** @override*/
+	async encrypt(plaintext: Uint8Array, opt_associatedData?: Uint8Array) {
+		const result = Bytes.concat(plaintext, this.primitiveIdentifier);
+		if (opt_associatedData) {
+			return Bytes.concat(result, opt_associatedData);
+		}
+		return result;
+	}
 
-  /** @override*/
-  async decrypt(ciphertext: Uint8Array, opt_associatedData?: Uint8Array) {
-    if (opt_associatedData) {
-      const aad = ciphertext.subarray(
-          ciphertext.length - opt_associatedData.length, ciphertext.length);
+	/** @override*/
+	async decrypt(ciphertext: Uint8Array, opt_associatedData?: Uint8Array) {
+		if (opt_associatedData) {
+			const aad = ciphertext.subarray(
+				ciphertext.length - opt_associatedData.length,
+				ciphertext.length
+			);
 
-      if ([...aad].toString() != [...opt_associatedData].toString()) {
-        throw new SecurityException(ExceptionText.cannotBeDecrypted());
-      }
-      ciphertext = ciphertext.subarray(0, ciphertext.length - aad.length);
-    }
+			if ([...aad].toString() != [...opt_associatedData].toString()) {
+				throw new SecurityException(ExceptionText.cannotBeDecrypted());
+			}
+			ciphertext = ciphertext.subarray(0, ciphertext.length - aad.length);
+		}
 
-    const primitiveIdentifier = ciphertext.subarray(
-        ciphertext.length - this.primitiveIdentifier.length, ciphertext.length);
-    if ([...primitiveIdentifier].toString() !=
-        [...this.primitiveIdentifier].toString()) {
-      throw new SecurityException(ExceptionText.cannotBeDecrypted());
-    }
+		const primitiveIdentifier = ciphertext.subarray(
+			ciphertext.length - this.primitiveIdentifier.length,
+			ciphertext.length
+		);
+		if (
+			[...primitiveIdentifier].toString() !=
+			[...this.primitiveIdentifier].toString()
+		) {
+			throw new SecurityException(ExceptionText.cannotBeDecrypted());
+		}
 
-    return ciphertext.subarray(
-        0, ciphertext.length - this.primitiveIdentifier.length);
-  }
+		return ciphertext.subarray(
+			0,
+			ciphertext.length - this.primitiveIdentifier.length
+		);
+	}
 }

--- a/javascript/aead/aes_ctr_hmac_aead_key_manager_test.ts
+++ b/javascript/aead/aes_ctr_hmac_aead_key_manager_test.ts
@@ -4,15 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbAesCtrHmacAeadKey, PbAesCtrHmacAeadKeyFormat, PbAesCtrKey, PbAesCtrKeyFormat, PbAesCtrParams, PbHashType, PbHmacKey, PbHmacKeyFormat, PbHmacParams, PbKeyData} from '../internal/proto';
-import {bytesLength} from '../internal/proto_shims';
-import * as Random from '../subtle/random';
-import {assertExists} from '../testing/internal/test_utils';
+import {
+	PbAesCtrHmacAeadKey,
+	PbAesCtrHmacAeadKeyFormat,
+	PbAesCtrKey,
+	PbAesCtrKeyFormat,
+	PbAesCtrParams,
+	PbHashType,
+	PbHmacKey,
+	PbHmacKeyFormat,
+	PbHmacParams,
+	PbKeyData,
+} from "../internal/proto";
+import { bytesLength } from "../internal/proto_shims";
+import * as Random from "../subtle/random";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {AesCtrHmacAeadKeyManager} from './aes_ctr_hmac_aead_key_manager';
-import {Aead} from './internal/aead';
+import { AesCtrHmacAeadKeyManager } from "./aes_ctr_hmac_aead_key_manager";
+import { Aead } from "./internal/aead";
 
-const KEY_TYPE = 'type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey';
+const KEY_TYPE = "type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey";
 const VERSION = 0;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -20,546 +31,589 @@ const VERSION = 0;
 
 /** creates new AesCtrHmacAeadKeyFormat with allowed parameters */
 function createTestKeyFormat(): PbAesCtrHmacAeadKeyFormat {
-  const KEY_SIZE = 16;
-  const IV_SIZE = 12;
-  const TAG_SIZE = 16;
+	const KEY_SIZE = 16;
+	const IV_SIZE = 12;
+	const TAG_SIZE = 16;
 
+	const keyFormat = new PbAesCtrHmacAeadKeyFormat();
+	const aesCtrKeyFormat = new PbAesCtrKeyFormat();
+	aesCtrKeyFormat.setKeySize(KEY_SIZE);
+	const aesCtrParams = new PbAesCtrParams();
+	aesCtrParams.setIvSize(IV_SIZE);
+	aesCtrKeyFormat.setParams(aesCtrParams);
+	keyFormat.setAesCtrKeyFormat(aesCtrKeyFormat);
 
-  const keyFormat = new PbAesCtrHmacAeadKeyFormat();
-  const aesCtrKeyFormat = new PbAesCtrKeyFormat();
-  aesCtrKeyFormat.setKeySize(KEY_SIZE);
-  const aesCtrParams = new PbAesCtrParams();
-  aesCtrParams.setIvSize(IV_SIZE);
-  aesCtrKeyFormat.setParams(aesCtrParams);
-  keyFormat.setAesCtrKeyFormat(aesCtrKeyFormat);
+	// set HMAC key
+	const hmacKeyFormat = new PbHmacKeyFormat();
+	hmacKeyFormat.setKeySize(KEY_SIZE);
+	const hmacParams = new PbHmacParams();
+	hmacParams.setHash(PbHashType.SHA1);
+	hmacParams.setTagSize(TAG_SIZE);
+	hmacKeyFormat.setParams(hmacParams);
+	keyFormat.setHmacKeyFormat(hmacKeyFormat);
 
-  // set HMAC key
-  const hmacKeyFormat = new PbHmacKeyFormat();
-  hmacKeyFormat.setKeySize(KEY_SIZE);
-  const hmacParams = new PbHmacParams();
-  hmacParams.setHash(PbHashType.SHA1);
-  hmacParams.setTagSize(TAG_SIZE);
-  hmacKeyFormat.setParams(hmacParams);
-  keyFormat.setHmacKeyFormat(hmacKeyFormat);
-
-  return keyFormat;
+	return keyFormat;
 }
 
 /** creates new AesCtrHmacAeadKey with allowed parameters */
 function createTestKey(): PbAesCtrHmacAeadKey {
-  const KEY_SIZE = 16;
-  const IV_SIZE = 12;
-  const TAG_SIZE = 16;
+	const KEY_SIZE = 16;
+	const IV_SIZE = 12;
+	const TAG_SIZE = 16;
 
+	const key = new PbAesCtrHmacAeadKey();
+	key.setVersion(0);
+	const aesCtrKey = new PbAesCtrKey();
+	aesCtrKey.setVersion(0);
+	const aesCtrParams = new PbAesCtrParams();
+	aesCtrParams.setIvSize(IV_SIZE);
+	aesCtrKey.setParams(aesCtrParams);
+	aesCtrKey.setKeyValue(Random.randBytes(KEY_SIZE));
+	key.setAesCtrKey(aesCtrKey);
 
-  const key = new PbAesCtrHmacAeadKey();
-  key.setVersion(0);
-  const aesCtrKey = new PbAesCtrKey();
-  aesCtrKey.setVersion(0);
-  const aesCtrParams = new PbAesCtrParams();
-  aesCtrParams.setIvSize(IV_SIZE);
-  aesCtrKey.setParams(aesCtrParams);
-  aesCtrKey.setKeyValue(Random.randBytes(KEY_SIZE));
-  key.setAesCtrKey(aesCtrKey);
+	// set HMAC key
+	const hmacKey = new PbHmacKey();
+	hmacKey.setVersion(0);
+	const hmacParams = new PbHmacParams();
+	hmacParams.setHash(PbHashType.SHA1);
+	hmacParams.setTagSize(TAG_SIZE);
+	hmacKey.setParams(hmacParams);
+	hmacKey.setKeyValue(Random.randBytes(KEY_SIZE));
+	key.setHmacKey(hmacKey);
 
-  // set HMAC key
-  const hmacKey = new PbHmacKey();
-  hmacKey.setVersion(0);
-  const hmacParams = new PbHmacParams();
-  hmacParams.setHash(PbHashType.SHA1);
-  hmacParams.setTagSize(TAG_SIZE);
-  hmacKey.setParams(hmacParams);
-  hmacKey.setKeyValue(Random.randBytes(KEY_SIZE));
-  key.setHmacKey(hmacKey);
-
-  return key;
+	return key;
 }
 
 /** creates new PbKeyData with allowed parameters */
 function createTestKeyData(): PbKeyData {
-  const keyData = new PbKeyData()
-                      .setTypeUrl(KEY_TYPE)
-                      .setValue(createTestKey().serializeBinary())
-                      .setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
-  return keyData;
+	const keyData = new PbKeyData()
+		.setTypeUrl(KEY_TYPE)
+		.setValue(createTestKey().serializeBinary())
+		.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
+	return keyData;
 }
 
-describe('aes ctr hmac aead key manager test', function() {
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for newKey method
-
-  // newKey method -- key formats
-  it('new key bad key format', async function() {
-    const keyFormat = new PbAesCtrKeyFormat();
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: Expected AesCtrHmacAeadKeyFormat-proto');
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-
-  it('new key bad serialized key', async function() {
-    // this is not a serialized key format
-    const serializedKeyFormat = new Uint8Array(4);
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    try {
-      manager.getKeyFactory().newKey(serializedKeyFormat);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Could not parse the given Uint8Array as a serialized' +
-              ' proto of ' + KEY_TYPE);
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-
-  // newKey method -- bad parametrs of AES CTR KEY format
-  it('new key not supported aes ctr key size', async function() {
-    const keySize: number = 11;
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-    keyFormat.getAesCtrKeyFormat()?.setKeySize(keySize);
-
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: unsupported AES key size: ' +
-              keySize);
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-  it('new key iv size out of range', async function() {
-    const ivSizeOutOfRange: number[] = [10, 18];
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-
-    const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
-    for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
-      keyFormat.getAesCtrKeyFormat()?.getParams()?.setIvSize(
-          ivSizeOutOfRange[i]);
-      try {
-        manager.getKeyFactory().newKey(keyFormat);
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(
-                'SecurityException: Invalid AES CTR HMAC key format: IV size is ' +
-                'out of range: ' + ivSizeOutOfRange[i]);
-        continue;
-      }
-      fail('An exception should be thrown.');
-    }
-  });
-
-  // newKey method -- bad parametrs of HMAC KEY format
-  it('new key small hmac key size', async function() {
-    const keySize: number = 11;
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-    keyFormat.getHmacKeyFormat()?.setKeySize(keySize);
-
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Invalid AES CTR HMAC key format: HMAC key is' +
-              ' too small: ' + keySize);
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-
-  it('new key hash type unsupported', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-    keyFormat.getHmacKeyFormat()?.getParams()?.setHash(PbHashType.UNKNOWN_HASH);
-
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-    } catch (e: any) {
-      expect(e.toString()).toBe('SecurityException: Unknown hash type.');
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-
-  it('new key small tag size', async function() {
-    const SMALL_TAG_SIZE = 8;
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-    keyFormat.getHmacKeyFormat()?.getParams()?.setTagSize(SMALL_TAG_SIZE);
-
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Invalid HMAC params: tag size ' +
-              SMALL_TAG_SIZE + ' is too small.');
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-
-  it('new key big tag size for hash type', async function() {
-    const tagSizes = [
-      {'hashType': PbHashType.SHA1, 'tagSize': 22},
-      {'hashType': PbHashType.SHA256, 'tagSize': 34},
-      {'hashType': PbHashType.SHA512, 'tagSize': 66},
-    ];
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-
-    const tagSizesLength = tagSizes.length;
-    for (let i = 0; i < tagSizesLength; i++) {
-      keyFormat.getHmacKeyFormat()?.getParams()?.setHash(
-          tagSizes[i]['hashType']);
-      keyFormat.getHmacKeyFormat()?.getParams()?.setTagSize(
-          tagSizes[i]['tagSize']);
-      try {
-        manager.getKeyFactory().newKey(keyFormat);
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(
-                'SecurityException: Invalid HMAC params: tag size ' +
-                tagSizes[i]['tagSize'] + ' is out of range.');
-        continue;
-      }
-      fail('An exception should be thrown.');
-    }
-  });
-
-  it('new key via format proto', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-
-    const key = manager.getKeyFactory().newKey(keyFormat);
-
-    // testing AES CTR key
-    expect(bytesLength(key.getAesCtrKey()?.getKeyValue()))
-        .toBe(keyFormat.getAesCtrKeyFormat()?.getKeySize());
-    expect(key.getAesCtrKey()?.getVersion()).toBe(0);
-    expect(key.getAesCtrKey()?.getParams()?.getIvSize())
-        .toBe(keyFormat.getAesCtrKeyFormat()?.getParams()?.getIvSize());
-
-    // testing HMAC key
-    expect(bytesLength(key.getHmacKey()?.getKeyValue()))
-        .toBe(keyFormat.getHmacKeyFormat()?.getKeySize());
-    expect(key.getHmacKey()?.getVersion()).toBe(0);
-    expect(key.getHmacKey()?.getParams()?.getHash())
-        .toBe(keyFormat.getHmacKeyFormat()?.getParams()?.getHash());
-    expect(key.getHmacKey()?.getParams()?.getTagSize())
-        .toBe(keyFormat.getHmacKeyFormat()?.getParams()?.getTagSize());
-  });
-
-  it('new key via serialized format proto', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyFormat = createTestKeyFormat();
-    const serializedKeyFormat = keyFormat.serializeBinary();
-
-    const key = manager.getKeyFactory().newKey(serializedKeyFormat);
-
-    // testing AES CTR key
-    expect(bytesLength(key.getAesCtrKey()?.getKeyValue()))
-        .toBe(keyFormat.getAesCtrKeyFormat()?.getKeySize());
-    expect(key.getAesCtrKey()?.getVersion()).toBe(0);
-    expect(key.getAesCtrKey()?.getParams()?.getIvSize())
-        .toBe(keyFormat.getAesCtrKeyFormat()?.getParams()?.getIvSize());
-
-
-    // testing HMAC key
-    expect(bytesLength(key.getHmacKey()?.getKeyValue()))
-        .toBe(keyFormat.getHmacKeyFormat()?.getKeySize());
-    expect(key.getHmacKey()?.getVersion()).toBe(0);
-    expect(key.getHmacKey()?.getParams()?.getHash())
-        .toBe(keyFormat.getHmacKeyFormat()?.getParams()?.getHash());
-    expect(key.getHmacKey()?.getParams()?.getTagSize())
-        .toBe(keyFormat.getHmacKeyFormat()?.getParams()?.getTagSize());
-  });
-
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for NewKeyData method
-
-  it('new key data bad serialized key', async function() {
-    const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-
-    const serializedKeyFormatsLength = serializedKeyFormats.length;
-    for (let i = 0; i < serializedKeyFormatsLength; i++) {
-      try {
-        aeadKeyManager.getKeyFactory().newKeyData(serializedKeyFormats[i]);
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(
-                'SecurityException: Could not parse the given Uint8Array as a ' +
-                'serialized proto of ' + KEY_TYPE);
-        continue;
-      }
-      fail(
-          'An exception should be thrown for the string: ' +
-          serializedKeyFormats[i]);
-    }
-  });
-
-  it('new key data from valid key', async function() {
-    const keyFormat = createTestKeyFormat();
-    const serializedKeyFormat = keyFormat.serializeBinary();
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const keyData = manager.getKeyFactory().newKeyData(serializedKeyFormat);
-
-    expect(keyData.getTypeUrl()).toBe(KEY_TYPE);
-    expect(keyData.getKeyMaterialType())
-        .toBe(PbKeyData.KeyMaterialType.SYMMETRIC);
-
-    const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
-
-    expect(bytesLength(key.getAesCtrKey()?.getKeyValue()))
-        .toBe(keyFormat.getAesCtrKeyFormat()?.getKeySize());
-    expect(bytesLength(key.getHmacKey()?.getKeyValue()))
-        .toBe(keyFormat.getHmacKeyFormat()?.getKeySize());
-  });
-
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getPrimitive method
-
-  it('get primitive unsupported key data type', async function() {
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const keyData = createTestKeyData().setTypeUrl('bad type url');
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, keyData);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Key type ' + keyData.getTypeUrl() +
-              ' is not supported. This key manager supports ' + KEY_TYPE + '.');
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive unsupported key type', async function() {
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key = new PbAesCtrKey();
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Given key type is not supported. ' +
-              'This key manager supports ' + KEY_TYPE + '.');
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive bad version', async function() {
-    const version = 1;
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    key.getAesCtrKey()?.setVersion(version);
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Version is out of bound, must be between 0 ' +
-              'and ' + VERSION + '.');
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive short aes ctr key', async function() {
-    const keySize = 5;
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    key.getAesCtrKey()?.setKeyValue(new Uint8Array(keySize));
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: unsupported AES key size: ' +
-              keySize);
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive aes ctr key small iv size', async function() {
-    const ivSizeOutOfRange: number[] = [9, 19];
-    const manager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
-    for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
-      key.getAesCtrKey()?.getParams()?.setIvSize(ivSizeOutOfRange[i]);
-      try {
-        await manager.getPrimitive(Aead, key);
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(
-                'SecurityException: Invalid AES CTR HMAC key format: IV size is ' +
-                'out of range: ' + ivSizeOutOfRange[i]);
-        continue;
-      }
-      fail('An exception should be thrown.');
-    }
-  });
-
-  it('get primitive short hmac key', async function() {
-    const keySize = 5;
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    key.getHmacKey()?.setKeyValue(new Uint8Array(keySize));
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Invalid AES CTR HMAC key format: HMAC key is' +
-              ' too small: ' + keySize);
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive hmac key unsupported hash type', async function() {
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    key.getHmacKey()?.getParams()?.setHash(PbHashType.UNKNOWN_HASH);
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString()).toBe('SecurityException: Unknown hash type.');
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive hmac key small tag size', async function() {
-    const SMALL_TAG_SIZE = 9;
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    key.getHmacKey()?.getParams()?.setTagSize(SMALL_TAG_SIZE);
-
-    try {
-      await aeadKeyManager.getPrimitive(Aead, key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: Invalid HMAC params: tag size ' +
-              SMALL_TAG_SIZE + ' is too small.');
-      return;
-    }
-    fail('An exception should be thrown');
-  });
-
-  it('get primitive hmac big tag size', async function() {
-    const tagSizes = [
-      {'hashType': PbHashType.SHA1, 'tagSize': 22},
-      {'hashType': PbHashType.SHA256, 'tagSize': 34},
-      {'hashType': PbHashType.SHA512, 'tagSize': 66},
-    ];
-    const manager = new AesCtrHmacAeadKeyManager();
-
-    const key: PbAesCtrHmacAeadKey = createTestKey();
-
-    const tagSizesLength = tagSizes.length;
-    for (let i = 0; i < tagSizesLength; i++) {
-      const params = assertExists(key.getHmacKey()?.getParams());
-      params.setHash(tagSizes[i]['hashType']);
-      params.setTagSize(tagSizes[i]['tagSize']);
-      try {
-        await manager.getPrimitive(Aead, key);
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(
-                'SecurityException: Invalid HMAC params: tag size ' +
-                tagSizes[i]['tagSize'] + ' is out of range.');
-        continue;
-      }
-      fail('An exception should be thrown.');
-    }
-  });
-
-  // tests for getting primitive from valid key/keyData
-  it('get primitive from key', async function() {
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const key = createTestKey();
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-
-    const primitive: Aead = await aeadKeyManager.getPrimitive(Aead, key);
-    const ciphertext = await primitive.encrypt(plaintext, aad);
-    const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
-
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
-
-  it('get primitive from key data', async function() {
-    const aeadKeyManager = new AesCtrHmacAeadKeyManager();
-    const keyData = createTestKeyData();
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-
-    const primitive: Aead = await aeadKeyManager.getPrimitive(Aead, keyData);
-    const ciphertext = await primitive.encrypt(plaintext, aad);
-    const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
-
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
-
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getVersion, getKeyType and doesSupport methods
-
-  it('get version should be zero', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    expect(manager.getVersion()).toBe(0);
-  });
-
-  it('get key type should be aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    expect(manager.getKeyType()).toBe(KEY_TYPE);
-  });
-
-  it('does support should support aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    expect(manager.doesSupport(KEY_TYPE)).toBe(true);
-  });
-
-  it('get primitive type should be aead', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    expect(manager.getPrimitiveType()).toBe(Aead);
-  });
+describe("aes ctr hmac aead key manager test", () => {
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for newKey method
+
+	// newKey method -- key formats
+	it("new key bad key format", async () => {
+		const keyFormat = new PbAesCtrKeyFormat();
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Expected AesCtrHmacAeadKeyFormat-proto"
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+
+	it("new key bad serialized key", async () => {
+		// this is not a serialized key format
+		const serializedKeyFormat = new Uint8Array(4);
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		try {
+			manager.getKeyFactory().newKey(serializedKeyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Could not parse the given Uint8Array as a serialized" +
+					" proto of " +
+					KEY_TYPE
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+
+	// newKey method -- bad parametrs of AES CTR KEY format
+	it("new key not supported aes ctr key size", async () => {
+		const keySize: number = 11;
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+		keyFormat.getAesCtrKeyFormat()?.setKeySize(keySize);
+
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: unsupported AES key size: " +
+					keySize
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+	it("new key iv size out of range", async () => {
+		const ivSizeOutOfRange: number[] = [10, 18];
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+
+		const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
+		for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
+			keyFormat
+				.getAesCtrKeyFormat()
+				?.getParams()
+				?.setIvSize(ivSizeOutOfRange[i]);
+			try {
+				manager.getKeyFactory().newKey(keyFormat);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"SecurityException: Invalid AES CTR HMAC key format: IV size is " +
+						"out of range: " +
+						ivSizeOutOfRange[i]
+				);
+				continue;
+			}
+			fail("An exception should be thrown.");
+		}
+	});
+
+	// newKey method -- bad parametrs of HMAC KEY format
+	it("new key small hmac key size", async () => {
+		const keySize: number = 11;
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+		keyFormat.getHmacKeyFormat()?.setKeySize(keySize);
+
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Invalid AES CTR HMAC key format: HMAC key is" +
+					" too small: " +
+					keySize
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+
+	it("new key hash type unsupported", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+		keyFormat
+			.getHmacKeyFormat()
+			?.getParams()
+			?.setHash(PbHashType.UNKNOWN_HASH);
+
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe("SecurityException: Unknown hash type.");
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+
+	it("new key small tag size", async () => {
+		const SMALL_TAG_SIZE = 8;
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+		keyFormat.getHmacKeyFormat()?.getParams()?.setTagSize(SMALL_TAG_SIZE);
+
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Invalid HMAC params: tag size " +
+					SMALL_TAG_SIZE +
+					" is too small."
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+
+	it("new key big tag size for hash type", async () => {
+		const tagSizes = [
+			{ hashType: PbHashType.SHA1, tagSize: 22 },
+			{ hashType: PbHashType.SHA256, tagSize: 34 },
+			{ hashType: PbHashType.SHA512, tagSize: 66 },
+		];
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+
+		const tagSizesLength = tagSizes.length;
+		for (let i = 0; i < tagSizesLength; i++) {
+			keyFormat
+				.getHmacKeyFormat()
+				?.getParams()
+				?.setHash(tagSizes[i]["hashType"]);
+			keyFormat
+				.getHmacKeyFormat()
+				?.getParams()
+				?.setTagSize(tagSizes[i]["tagSize"]);
+			try {
+				manager.getKeyFactory().newKey(keyFormat);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"SecurityException: Invalid HMAC params: tag size " +
+						tagSizes[i]["tagSize"] +
+						" is out of range."
+				);
+				continue;
+			}
+			fail("An exception should be thrown.");
+		}
+	});
+
+	it("new key via format proto", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+
+		const key = manager.getKeyFactory().newKey(keyFormat);
+
+		// testing AES CTR key
+		expect(bytesLength(key.getAesCtrKey()?.getKeyValue())).toBe(
+			keyFormat.getAesCtrKeyFormat()?.getKeySize()
+		);
+		expect(key.getAesCtrKey()?.getVersion()).toBe(0);
+		expect(key.getAesCtrKey()?.getParams()?.getIvSize()).toBe(
+			keyFormat.getAesCtrKeyFormat()?.getParams()?.getIvSize()
+		);
+
+		// testing HMAC key
+		expect(bytesLength(key.getHmacKey()?.getKeyValue())).toBe(
+			keyFormat.getHmacKeyFormat()?.getKeySize()
+		);
+		expect(key.getHmacKey()?.getVersion()).toBe(0);
+		expect(key.getHmacKey()?.getParams()?.getHash()).toBe(
+			keyFormat.getHmacKeyFormat()?.getParams()?.getHash()
+		);
+		expect(key.getHmacKey()?.getParams()?.getTagSize()).toBe(
+			keyFormat.getHmacKeyFormat()?.getParams()?.getTagSize()
+		);
+	});
+
+	it("new key via serialized format proto", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyFormat = createTestKeyFormat();
+		const serializedKeyFormat = keyFormat.serializeBinary();
+
+		const key = manager.getKeyFactory().newKey(serializedKeyFormat);
+
+		// testing AES CTR key
+		expect(bytesLength(key.getAesCtrKey()?.getKeyValue())).toBe(
+			keyFormat.getAesCtrKeyFormat()?.getKeySize()
+		);
+		expect(key.getAesCtrKey()?.getVersion()).toBe(0);
+		expect(key.getAesCtrKey()?.getParams()?.getIvSize()).toBe(
+			keyFormat.getAesCtrKeyFormat()?.getParams()?.getIvSize()
+		);
+
+		// testing HMAC key
+		expect(bytesLength(key.getHmacKey()?.getKeyValue())).toBe(
+			keyFormat.getHmacKeyFormat()?.getKeySize()
+		);
+		expect(key.getHmacKey()?.getVersion()).toBe(0);
+		expect(key.getHmacKey()?.getParams()?.getHash()).toBe(
+			keyFormat.getHmacKeyFormat()?.getParams()?.getHash()
+		);
+		expect(key.getHmacKey()?.getParams()?.getTagSize()).toBe(
+			keyFormat.getHmacKeyFormat()?.getParams()?.getTagSize()
+		);
+	});
+
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for NewKeyData method
+
+	it("new key data bad serialized key", async () => {
+		const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+
+		const serializedKeyFormatsLength = serializedKeyFormats.length;
+		for (let i = 0; i < serializedKeyFormatsLength; i++) {
+			try {
+				aeadKeyManager
+					.getKeyFactory()
+					.newKeyData(serializedKeyFormats[i]);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"SecurityException: Could not parse the given Uint8Array as a " +
+						"serialized proto of " +
+						KEY_TYPE
+				);
+				continue;
+			}
+			fail(
+				"An exception should be thrown for the string: " +
+					serializedKeyFormats[i]
+			);
+		}
+	});
+
+	it("new key data from valid key", async () => {
+		const keyFormat = createTestKeyFormat();
+		const serializedKeyFormat = keyFormat.serializeBinary();
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const keyData = manager.getKeyFactory().newKeyData(serializedKeyFormat);
+
+		expect(keyData.getTypeUrl()).toBe(KEY_TYPE);
+		expect(keyData.getKeyMaterialType()).toBe(
+			PbKeyData.KeyMaterialType.SYMMETRIC
+		);
+
+		const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
+
+		expect(bytesLength(key.getAesCtrKey()?.getKeyValue())).toBe(
+			keyFormat.getAesCtrKeyFormat()?.getKeySize()
+		);
+		expect(bytesLength(key.getHmacKey()?.getKeyValue())).toBe(
+			keyFormat.getHmacKeyFormat()?.getKeySize()
+		);
+	});
+
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getPrimitive method
+
+	it("get primitive unsupported key data type", async () => {
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const keyData = createTestKeyData().setTypeUrl("bad type url");
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, keyData);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Key type " +
+					keyData.getTypeUrl() +
+					" is not supported. This key manager supports " +
+					KEY_TYPE +
+					"."
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive unsupported key type", async () => {
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key = new PbAesCtrKey();
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Given key type is not supported. " +
+					"This key manager supports " +
+					KEY_TYPE +
+					"."
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive bad version", async () => {
+		const version = 1;
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		key.getAesCtrKey()?.setVersion(version);
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Version is out of bound, must be between 0 " +
+					"and " +
+					VERSION +
+					"."
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive short aes ctr key", async () => {
+		const keySize = 5;
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		key.getAesCtrKey()?.setKeyValue(new Uint8Array(keySize));
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: unsupported AES key size: " +
+					keySize
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive aes ctr key small iv size", async () => {
+		const ivSizeOutOfRange: number[] = [9, 19];
+		const manager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		const ivSizeOutOfRangeLength = ivSizeOutOfRange.length;
+		for (let i = 0; i < ivSizeOutOfRangeLength; i++) {
+			key.getAesCtrKey()?.getParams()?.setIvSize(ivSizeOutOfRange[i]);
+			try {
+				await manager.getPrimitive(Aead, key);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"SecurityException: Invalid AES CTR HMAC key format: IV size is " +
+						"out of range: " +
+						ivSizeOutOfRange[i]
+				);
+				continue;
+			}
+			fail("An exception should be thrown.");
+		}
+	});
+
+	it("get primitive short hmac key", async () => {
+		const keySize = 5;
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		key.getHmacKey()?.setKeyValue(new Uint8Array(keySize));
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Invalid AES CTR HMAC key format: HMAC key is" +
+					" too small: " +
+					keySize
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive hmac key unsupported hash type", async () => {
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		key.getHmacKey()?.getParams()?.setHash(PbHashType.UNKNOWN_HASH);
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe("SecurityException: Unknown hash type.");
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive hmac key small tag size", async () => {
+		const SMALL_TAG_SIZE = 9;
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		key.getHmacKey()?.getParams()?.setTagSize(SMALL_TAG_SIZE);
+
+		try {
+			await aeadKeyManager.getPrimitive(Aead, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Invalid HMAC params: tag size " +
+					SMALL_TAG_SIZE +
+					" is too small."
+			);
+			return;
+		}
+		fail("An exception should be thrown");
+	});
+
+	it("get primitive hmac big tag size", async () => {
+		const tagSizes = [
+			{ hashType: PbHashType.SHA1, tagSize: 22 },
+			{ hashType: PbHashType.SHA256, tagSize: 34 },
+			{ hashType: PbHashType.SHA512, tagSize: 66 },
+		];
+		const manager = new AesCtrHmacAeadKeyManager();
+
+		const key: PbAesCtrHmacAeadKey = createTestKey();
+
+		const tagSizesLength = tagSizes.length;
+		for (let i = 0; i < tagSizesLength; i++) {
+			const params = assertExists(key.getHmacKey()?.getParams());
+			params.setHash(tagSizes[i]["hashType"]);
+			params.setTagSize(tagSizes[i]["tagSize"]);
+			try {
+				await manager.getPrimitive(Aead, key);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"SecurityException: Invalid HMAC params: tag size " +
+						tagSizes[i]["tagSize"] +
+						" is out of range."
+				);
+				continue;
+			}
+			fail("An exception should be thrown.");
+		}
+	});
+
+	// tests for getting primitive from valid key/keyData
+	it("get primitive from key", async () => {
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const key = createTestKey();
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+
+		const primitive: Aead = await aeadKeyManager.getPrimitive(Aead, key);
+		const ciphertext = await primitive.encrypt(plaintext, aad);
+		const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
+
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
+
+	it("get primitive from key data", async () => {
+		const aeadKeyManager = new AesCtrHmacAeadKeyManager();
+		const keyData = createTestKeyData();
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+
+		const primitive: Aead = await aeadKeyManager.getPrimitive(
+			Aead,
+			keyData
+		);
+		const ciphertext = await primitive.encrypt(plaintext, aad);
+		const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
+
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
+
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getVersion, getKeyType and doesSupport methods
+
+	it("get version should be zero", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		expect(manager.getVersion()).toBe(0);
+	});
+
+	it("get key type should be aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		expect(manager.getKeyType()).toBe(KEY_TYPE);
+	});
+
+	it("does support should support aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		expect(manager.doesSupport(KEY_TYPE)).toBe(true);
+	});
+
+	it("get primitive type should be aead", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		expect(manager.getPrimitiveType()).toBe(Aead);
+	});
 });

--- a/javascript/aead/aes_ctr_hmac_aead_key_templates_test.ts
+++ b/javascript/aead/aes_ctr_hmac_aead_key_templates_test.ts
@@ -4,84 +4,94 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbAesCtrHmacAeadKeyFormat, PbHashType, PbOutputPrefixType} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
+import {
+	PbAesCtrHmacAeadKeyFormat,
+	PbHashType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
 
-import {AesCtrHmacAeadKeyManager} from './aes_ctr_hmac_aead_key_manager';
-import {AesCtrHmacAeadKeyTemplates} from './aes_ctr_hmac_aead_key_templates';
+import { AesCtrHmacAeadKeyManager } from "./aes_ctr_hmac_aead_key_manager";
+import { AesCtrHmacAeadKeyTemplates } from "./aes_ctr_hmac_aead_key_templates";
 
-describe('aes ctr hmac aead key templates test', function() {
-  it('aes128 ctr hmac sha256', function() {
-    // Expects function to create key with following parameters.
-    const expectedAesKeySize = 16;
-    const expectedIvSize = 16;
-    const expectedHmacKeySize = 32;
-    const expectedTagSize = 16;
-    const expectedHashFunction = PbHashType.SHA256;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
+describe("aes ctr hmac aead key templates test", () => {
+	it("aes128 ctr hmac sha256", () => {
+		// Expects function to create key with following parameters.
+		const expectedAesKeySize = 16;
+		const expectedIvSize = 16;
+		const expectedHmacKeySize = 32;
+		const expectedTagSize = 16;
+		const expectedHashFunction = PbHashType.SHA256;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
 
-    // Expected type URL is the one supported by AesCtrHmacAeadKeyManager.
-    const manager = new AesCtrHmacAeadKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+		// Expected type URL is the one supported by AesCtrHmacAeadKeyManager.
+		const manager = new AesCtrHmacAeadKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = AesCtrHmacAeadKeyTemplates.aes128CtrHmacSha256();
+		const keyTemplate = AesCtrHmacAeadKeyTemplates.aes128CtrHmacSha256();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test values in key format.
-    const keyFormat =
-        PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyTemplate.getValue());
+		// Test values in key format.
+		const keyFormat = PbAesCtrHmacAeadKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
 
-    // Test AesCtrKeyFormat.
-    const aesCtrKeyFormat = keyFormat.getAesCtrKeyFormat();
-    expect(aesCtrKeyFormat!.getKeySize()).toBe(expectedAesKeySize);
-    expect(aesCtrKeyFormat!.getParams()!.getIvSize()).toBe(expectedIvSize);
+		// Test AesCtrKeyFormat.
+		const aesCtrKeyFormat = keyFormat.getAesCtrKeyFormat();
+		expect(aesCtrKeyFormat!.getKeySize()).toBe(expectedAesKeySize);
+		expect(aesCtrKeyFormat!.getParams()!.getIvSize()).toBe(expectedIvSize);
 
-    // Test HmacKeyFormat.
-    const hmacKeyFormat = keyFormat.getHmacKeyFormat();
-    expect(hmacKeyFormat!.getKeySize()).toBe(expectedHmacKeySize);
-    expect(hmacKeyFormat!.getParams()!.getTagSize()).toBe(expectedTagSize);
-    expect(hmacKeyFormat!.getParams()!.getHash()).toBe(expectedHashFunction);
+		// Test HmacKeyFormat.
+		const hmacKeyFormat = keyFormat.getHmacKeyFormat();
+		expect(hmacKeyFormat!.getKeySize()).toBe(expectedHmacKeySize);
+		expect(hmacKeyFormat!.getParams()!.getTagSize()).toBe(expectedTagSize);
+		expect(hmacKeyFormat!.getParams()!.getHash()).toBe(
+			expectedHashFunction
+		);
 
-    // Test that the template works with AesCtrHmacAeadKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with AesCtrHmacAeadKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 
-  it('aes256 ctr hmac sha256', function() {
-    // Expects function to create key with following parameters.
-    const expectedAesKeySize = 32;
-    const expectedIvSize = 16;
-    const expectedHmacKeySize = 32;
-    const expectedTagSize = 32;
-    const expectedHashFunction = PbHashType.SHA256;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
+	it("aes256 ctr hmac sha256", () => {
+		// Expects function to create key with following parameters.
+		const expectedAesKeySize = 32;
+		const expectedIvSize = 16;
+		const expectedHmacKeySize = 32;
+		const expectedTagSize = 32;
+		const expectedHashFunction = PbHashType.SHA256;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
 
-    // Expected type URL is the one supported by AesCtrHmacAeadKeyManager.
-    const manager = new AesCtrHmacAeadKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+		// Expected type URL is the one supported by AesCtrHmacAeadKeyManager.
+		const manager = new AesCtrHmacAeadKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = AesCtrHmacAeadKeyTemplates.aes256CtrHmacSha256();
+		const keyTemplate = AesCtrHmacAeadKeyTemplates.aes256CtrHmacSha256();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test values in key format.
-    const keyFormat =
-        PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyTemplate.getValue());
+		// Test values in key format.
+		const keyFormat = PbAesCtrHmacAeadKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
 
-    // Test AesCtrKeyFormat.
-    const aesCtrKeyFormat = keyFormat.getAesCtrKeyFormat();
-    expect(aesCtrKeyFormat!.getKeySize()).toBe(expectedAesKeySize);
-    expect(aesCtrKeyFormat!.getParams()!.getIvSize()).toBe(expectedIvSize);
+		// Test AesCtrKeyFormat.
+		const aesCtrKeyFormat = keyFormat.getAesCtrKeyFormat();
+		expect(aesCtrKeyFormat!.getKeySize()).toBe(expectedAesKeySize);
+		expect(aesCtrKeyFormat!.getParams()!.getIvSize()).toBe(expectedIvSize);
 
-    // Test HmacKeyFormat.
-    const hmacKeyFormat = keyFormat.getHmacKeyFormat();
-    expect(hmacKeyFormat!.getKeySize()).toBe(expectedHmacKeySize);
-    expect(hmacKeyFormat!.getParams()!.getTagSize()).toBe(expectedTagSize);
-    expect(hmacKeyFormat!.getParams()!.getHash()).toBe(expectedHashFunction);
+		// Test HmacKeyFormat.
+		const hmacKeyFormat = keyFormat.getHmacKeyFormat();
+		expect(hmacKeyFormat!.getKeySize()).toBe(expectedHmacKeySize);
+		expect(hmacKeyFormat!.getParams()!.getTagSize()).toBe(expectedTagSize);
+		expect(hmacKeyFormat!.getParams()!.getHash()).toBe(
+			expectedHashFunction
+		);
 
-    // Test that the template works with AesCtrHmacAeadKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with AesCtrHmacAeadKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 });

--- a/javascript/aead/aes_gcm_key_manager_test.ts
+++ b/javascript/aead/aes_gcm_key_manager_test.ts
@@ -4,300 +4,328 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbAesCtrKey, PbAesCtrKeyFormat, PbAesGcmKey, PbAesGcmKeyFormat, PbKeyData} from '../internal/proto';
-import {bytesLength} from '../internal/proto_shims';
-import * as Random from '../subtle/random';
+import {
+	PbAesCtrKey,
+	PbAesCtrKeyFormat,
+	PbAesGcmKey,
+	PbAesGcmKeyFormat,
+	PbKeyData,
+} from "../internal/proto";
+import { bytesLength } from "../internal/proto_shims";
+import * as Random from "../subtle/random";
 
-import {AesGcmKeyManager} from './aes_gcm_key_manager';
-import {Aead} from './internal/aead';
+import { AesGcmKeyManager } from "./aes_gcm_key_manager";
+import { Aead } from "./internal/aead";
 
-const KEY_TYPE = 'type.googleapis.com/google.crypto.tink.AesGcmKey';
+const KEY_TYPE = "type.googleapis.com/google.crypto.tink.AesGcmKey";
 const VERSION = 0;
 const PRIMITIVE = Aead;
 
-describe('aes gcm key manager test', function() {
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for newKey method
+describe("aes gcm key manager test", () => {
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for newKey method
 
-  // newKey method -- key formats
-  it('new key, invalid key format', function() {
-    const keyFormat = new PbAesCtrKeyFormat();
-    const manager = new AesGcmKeyManager();
+	// newKey method -- key formats
+	it("new key, invalid key format", () => {
+		const keyFormat = new PbAesCtrKeyFormat();
+		const manager = new AesGcmKeyManager();
 
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidKeyFormat());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.invalidKeyFormat());
+		}
+	});
 
-  it('new key, invalid serialized key format', function() {
-    const keyFormat = new Uint8Array(0);
-    const manager = new AesGcmKeyManager();
+	it("new key, invalid serialized key format", () => {
+		const keyFormat = new Uint8Array(0);
+		const manager = new AesGcmKeyManager();
 
-    try {
-      manager.getKeyFactory().newKey(keyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKey(keyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidSerializedKeyFormat()
+			);
+		}
+	});
 
-  it('new key, unsupported key sizes', function() {
-    const manager = new AesGcmKeyManager();
+	it("new key, unsupported key sizes", () => {
+		const manager = new AesGcmKeyManager();
 
-    for (let keySize = 0; keySize < 40; keySize++) {
-      if (keySize === 16 || keySize === 32) {
-        // Keys of size 16 and 32 bytes are supported.
-        continue;
-      }
-      const keyFormat = createTestKeyFormat(keySize);
+		for (let keySize = 0; keySize < 40; keySize++) {
+			if (keySize === 16 || keySize === 32) {
+				// Keys of size 16 and 32 bytes are supported.
+				continue;
+			}
+			const keyFormat = createTestKeyFormat(keySize);
 
-      try {
-        manager.getKeyFactory().newKey(keyFormat);
-        fail('An exception should be thrown.');
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.unsupportedKeySize(keySize));
-      }
-    }
-  });
+			try {
+				manager.getKeyFactory().newKey(keyFormat);
+				fail("An exception should be thrown.");
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					ExceptionText.unsupportedKeySize(keySize)
+				);
+			}
+		}
+	});
 
-  it('new key, via format proto', function() {
-    const manager = new AesGcmKeyManager();
+	it("new key, via format proto", () => {
+		const manager = new AesGcmKeyManager();
 
-    const keyFormat = createTestKeyFormat();
+		const keyFormat = createTestKeyFormat();
 
-    const key = manager.getKeyFactory().newKey(keyFormat);
+		const key = manager.getKeyFactory().newKey(keyFormat);
 
-    expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
-  });
+		expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
+	});
 
-  it('new key, via serialized format proto', function() {
-    const manager = new AesGcmKeyManager();
+	it("new key, via serialized format proto", () => {
+		const manager = new AesGcmKeyManager();
 
-    const keyFormat = createTestKeyFormat();
-    const serializedKeyFormat = keyFormat.serializeBinary();
+		const keyFormat = createTestKeyFormat();
+		const serializedKeyFormat = keyFormat.serializeBinary();
 
-    const key = manager.getKeyFactory().newKey(serializedKeyFormat);
+		const key = manager.getKeyFactory().newKey(serializedKeyFormat);
 
-    expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
-  });
+		expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for NewKeyData method
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for NewKeyData method
 
-  it('new key data, should work', function() {
-    const keyFormat = createTestKeyFormat();
-    const serializedKeyFormat = keyFormat.serializeBinary();
-    const manager = new AesGcmKeyManager();
+	it("new key data, should work", () => {
+		const keyFormat = createTestKeyFormat();
+		const serializedKeyFormat = keyFormat.serializeBinary();
+		const manager = new AesGcmKeyManager();
 
-    const keyData = manager.getKeyFactory().newKeyData(serializedKeyFormat);
+		const keyData = manager.getKeyFactory().newKeyData(serializedKeyFormat);
 
-    expect(keyData.getTypeUrl()).toBe(KEY_TYPE);
-    expect(keyData.getKeyMaterialType())
-        .toBe(PbKeyData.KeyMaterialType.SYMMETRIC);
+		expect(keyData.getTypeUrl()).toBe(KEY_TYPE);
+		expect(keyData.getKeyMaterialType()).toBe(
+			PbKeyData.KeyMaterialType.SYMMETRIC
+		);
 
-    const key = PbAesGcmKey.deserializeBinary(keyData.getValue());
+		const key = PbAesGcmKey.deserializeBinary(keyData.getValue());
 
-    expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
-  });
+		expect(bytesLength(key.getKeyValue())).toBe(keyFormat.getKeySize());
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getPrimitive method
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getPrimitive method
 
-  it('get primitive, unsupported key data type', async function() {
-    const manager = new AesGcmKeyManager();
-    const keyData = createTestKeyData().setTypeUrl('bad_type_url');
+	it("get primitive, unsupported key data type", async () => {
+		const manager = new AesGcmKeyManager();
+		const keyData = createTestKeyData().setTypeUrl("bad_type_url");
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, keyData);
-      fail('An exception should be thrown');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyType(keyData.getTypeUrl()));
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, keyData);
+			fail("An exception should be thrown");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyType(keyData.getTypeUrl())
+			);
+		}
+	});
 
-  it('get primitive, unsupported key type', async function() {
-    const manager = new AesGcmKeyManager();
-    const key = new PbAesCtrKey();
+	it("get primitive, unsupported key type", async () => {
+		const manager = new AesGcmKeyManager();
+		const key = new PbAesCtrKey();
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
+		}
+	});
 
-  it('get primitive, bad version', async function() {
-    const version = 1;
-    const manager = new AesGcmKeyManager();
-    const key = createTestKey().setVersion(version);
+	it("get primitive, bad version", async () => {
+		const version = 1;
+		const manager = new AesGcmKeyManager();
+		const key = createTestKey().setVersion(version);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
+		}
+	});
 
-  it('get primitive, unsupported key sizes', async function() {
-    const manager = new AesGcmKeyManager();
+	it("get primitive, unsupported key sizes", async () => {
+		const manager = new AesGcmKeyManager();
 
-    for (let keySize = 0; keySize < 40; keySize++) {
-      if (keySize === 16 || keySize === 32) {
-        // Keys of sizes 16 and 32 bytes are supported.
-        continue;
-      }
+		for (let keySize = 0; keySize < 40; keySize++) {
+			if (keySize === 16 || keySize === 32) {
+				// Keys of sizes 16 and 32 bytes are supported.
+				continue;
+			}
 
-      const key: PbAesGcmKey = createTestKey(keySize);
-      try {
-        await manager.getPrimitive(PRIMITIVE, key);
-        fail('An exception should be thrown');
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.unsupportedKeySize(keySize));
-      }
-    }
-  });
+			const key: PbAesGcmKey = createTestKey(keySize);
+			try {
+				await manager.getPrimitive(PRIMITIVE, key);
+				fail("An exception should be thrown");
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					ExceptionText.unsupportedKeySize(keySize)
+				);
+			}
+		}
+	});
 
-  it('get primitive, bad serialization', async function() {
-    const manager = new AesGcmKeyManager();
-    const keyData = createTestKeyData().setValue(new Uint8Array([0]));
+	it("get primitive, bad serialization", async () => {
+		const manager = new AesGcmKeyManager();
+		const keyData = createTestKeyData().setValue(new Uint8Array([0]));
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, keyData);
-      fail('An exception should be thrown');
-    } catch (e: any) {
-      let message = e.toString();
-      if (message === ExceptionText.unsupportedKeySize(0)) {
-        message = ExceptionText.invalidSerializedKey();
-      }
-      expect(message).toBe(ExceptionText.invalidSerializedKey());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, keyData);
+			fail("An exception should be thrown");
+		} catch (e: any) {
+			let message = e.toString();
+			if (message === ExceptionText.unsupportedKeySize(0)) {
+				message = ExceptionText.invalidSerializedKey();
+			}
+			expect(message).toBe(ExceptionText.invalidSerializedKey());
+		}
+	});
 
-  // Tests for getting primitive from valid key/keyData.
-  it('get primitive, from key', async function() {
-    const manager = new AesGcmKeyManager();
-    const key = createTestKey();
+	// Tests for getting primitive from valid key/keyData.
+	it("get primitive, from key", async () => {
+		const manager = new AesGcmKeyManager();
+		const key = createTestKey();
 
-    // Get the primitive from key manager.
-    const primitive: Aead = await manager.getPrimitive(PRIMITIVE, key);
+		// Get the primitive from key manager.
+		const primitive: Aead = await manager.getPrimitive(PRIMITIVE, key);
 
-    // Test the returned primitive.
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await primitive.encrypt(plaintext, aad);
-    const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
+		// Test the returned primitive.
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await primitive.encrypt(plaintext, aad);
+		const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
 
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 
-  it('get primitive, from key data', async function() {
-    const manager = new AesGcmKeyManager();
-    const keyData = createTestKeyData();
+	it("get primitive, from key data", async () => {
+		const manager = new AesGcmKeyManager();
+		const keyData = createTestKeyData();
 
-    // Get primitive.
-    const primitive: Aead = await manager.getPrimitive(PRIMITIVE, keyData);
+		// Get primitive.
+		const primitive: Aead = await manager.getPrimitive(PRIMITIVE, keyData);
 
-    // Test the returned primitive.
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await primitive.encrypt(plaintext, aad);
-    const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
+		// Test the returned primitive.
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await primitive.encrypt(plaintext, aad);
+		const decryptedCiphertext = await primitive.decrypt(ciphertext, aad);
 
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getVersion, getKeyType and doesSupport methods
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getVersion, getKeyType and doesSupport methods
 
-  it('get version, should be zero', function() {
-    const manager = new AesGcmKeyManager();
-    expect(manager.getVersion()).toBe(0);
-  });
+	it("get version, should be zero", () => {
+		const manager = new AesGcmKeyManager();
+		expect(manager.getVersion()).toBe(0);
+	});
 
-  it('get key type, should be aes gcm key type', function() {
-    const manager = new AesGcmKeyManager();
-    expect(manager.getKeyType()).toBe(KEY_TYPE);
-  });
+	it("get key type, should be aes gcm key type", () => {
+		const manager = new AesGcmKeyManager();
+		expect(manager.getKeyType()).toBe(KEY_TYPE);
+	});
 
-  it('does support, should support aes gcm key type', function() {
-    const manager = new AesGcmKeyManager();
-    expect(manager.doesSupport(KEY_TYPE)).toBe(true);
-  });
+	it("does support, should support aes gcm key type", () => {
+		const manager = new AesGcmKeyManager();
+		expect(manager.doesSupport(KEY_TYPE)).toBe(true);
+	});
 
-  it('get primitive type, should be aead', function() {
-    const manager = new AesGcmKeyManager();
-    expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
-  });
+	it("get primitive type, should be aead", () => {
+		const manager = new AesGcmKeyManager();
+		expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
+	});
 });
 
 /////////////////////////////////////////////////////////////////////////////
 // Helper functions for tests
 
 class ExceptionText {
-  static unsupportedPrimitive(): string {
-    return 'SecurityException: Requested primitive type which is not supported ' +
-        'by this key manager.';
-  }
+	static unsupportedPrimitive(): string {
+		return (
+			"SecurityException: Requested primitive type which is not supported " +
+			"by this key manager."
+		);
+	}
 
-  static unsupportedKeySize(keySize: number): string {
-    return 'InvalidArgumentsException: unsupported AES key size: ' + keySize;
-  }
+	static unsupportedKeySize(keySize: number): string {
+		return (
+			"InvalidArgumentsException: unsupported AES key size: " + keySize
+		);
+	}
 
-  static versionOutOfBounds(): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        VERSION + '.';
-  }
+	static versionOutOfBounds(): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			VERSION +
+			"."
+		);
+	}
 
-  static unsupportedKeyType(opt_unsupportedKeyType?: string): string {
-    const prefix = 'SecurityException: Key type';
-    const suffix =
-        'is not supported. This key manager supports ' + KEY_TYPE + '.';
+	static unsupportedKeyType(opt_unsupportedKeyType?: string): string {
+		const prefix = "SecurityException: Key type";
+		const suffix =
+			"is not supported. This key manager supports " + KEY_TYPE + ".";
 
-    if (opt_unsupportedKeyType) {
-      return prefix + ' ' + opt_unsupportedKeyType + ' ' + suffix;
-    } else {
-      return prefix + ' ' + suffix;
-    }
-  }
+		if (opt_unsupportedKeyType) {
+			return prefix + " " + opt_unsupportedKeyType + " " + suffix;
+		} else {
+			return prefix + " " + suffix;
+		}
+	}
 
-  static invalidSerializedKey(): string {
-    return 'SecurityException: Could not parse the input as a serialized proto of ' +
-        KEY_TYPE + ' key.';
-  }
+	static invalidSerializedKey(): string {
+		return (
+			"SecurityException: Could not parse the input as a serialized proto of " +
+			KEY_TYPE +
+			" key."
+		);
+	}
 
-  static invalidSerializedKeyFormat() {
-    return 'SecurityException: Could not parse the input as a serialized proto of ' +
-        KEY_TYPE + ' key format.';
-  }
+	static invalidSerializedKeyFormat() {
+		return (
+			"SecurityException: Could not parse the input as a serialized proto of " +
+			KEY_TYPE +
+			" key format."
+		);
+	}
 
-  static invalidKeyFormat(): string {
-    return 'SecurityException: Expected AesGcmKeyFormat-proto';
-  }
+	static invalidKeyFormat(): string {
+		return "SecurityException: Expected AesGcmKeyFormat-proto";
+	}
 }
 
 function createTestKeyFormat(opt_keySize: number = 16): PbAesGcmKeyFormat {
-  const keyFormat = new PbAesGcmKeyFormat().setKeySize(opt_keySize);
-  return keyFormat;
+	const keyFormat = new PbAesGcmKeyFormat().setKeySize(opt_keySize);
+	return keyFormat;
 }
 
 function createTestKey(opt_keySize: number = 16): PbAesGcmKey {
-  const key = new PbAesGcmKey().setVersion(0).setKeyValue(
-      Random.randBytes(opt_keySize));
+	const key = new PbAesGcmKey()
+		.setVersion(0)
+		.setKeyValue(Random.randBytes(opt_keySize));
 
-  return key;
+	return key;
 }
 
 function createTestKeyData(opt_keySize?: number): PbKeyData {
-  const keyData = new PbKeyData()
-                      .setTypeUrl(KEY_TYPE)
-                      .setValue(createTestKey(opt_keySize).serializeBinary())
-                      .setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
+	const keyData = new PbKeyData()
+		.setTypeUrl(KEY_TYPE)
+		.setValue(createTestKey(opt_keySize).serializeBinary())
+		.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
 
-  return keyData;
+	return keyData;
 }

--- a/javascript/aead/aes_gcm_key_templates_test.ts
+++ b/javascript/aead/aes_gcm_key_templates_test.ts
@@ -4,76 +4,79 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbAesGcmKeyFormat, PbOutputPrefixType} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
+import { PbAesGcmKeyFormat, PbOutputPrefixType } from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
 
-import {AesGcmKeyManager} from './aes_gcm_key_manager';
-import {AesGcmKeyTemplates} from './aes_gcm_key_templates';
+import { AesGcmKeyManager } from "./aes_gcm_key_manager";
+import { AesGcmKeyTemplates } from "./aes_gcm_key_templates";
 
-describe('aes gcm key templates test', function() {
-  it('aes128 gcm', function() {
-    // The created key should have the following parameters.
-    const expectedKeySize = 16;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
-    // Expected type URL is the one supported by AesGcmKeyManager.
-    const manager = new AesGcmKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+describe("aes gcm key templates test", () => {
+	it("aes128 gcm", () => {
+		// The created key should have the following parameters.
+		const expectedKeySize = 16;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
+		// Expected type URL is the one supported by AesGcmKeyManager.
+		const manager = new AesGcmKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = AesGcmKeyTemplates.aes128Gcm();
+		const keyTemplate = AesGcmKeyTemplates.aes128Gcm();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test key size value in key format.
-    const keyFormat =
-        PbAesGcmKeyFormat.deserializeBinary(keyTemplate.getValue());
-    expect(keyFormat.getKeySize()).toBe(expectedKeySize);
+		// Test key size value in key format.
+		const keyFormat = PbAesGcmKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		expect(keyFormat.getKeySize()).toBe(expectedKeySize);
 
-    // Test that the template works with AesCtrHmacAeadKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with AesCtrHmacAeadKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 
-  it('aes256 gcm', function() {
-    // The created key should have the following parameters.
-    const expectedKeySize = 32;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
-    // Expected type URL is the one supported by AesGcmKeyManager.
-    const manager = new AesGcmKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+	it("aes256 gcm", () => {
+		// The created key should have the following parameters.
+		const expectedKeySize = 32;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
+		// Expected type URL is the one supported by AesGcmKeyManager.
+		const manager = new AesGcmKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = AesGcmKeyTemplates.aes256Gcm();
+		const keyTemplate = AesGcmKeyTemplates.aes256Gcm();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test key size value in key format.
-    const keyFormat =
-        PbAesGcmKeyFormat.deserializeBinary(keyTemplate.getValue());
-    expect(keyFormat.getKeySize()).toBe(expectedKeySize);
+		// Test key size value in key format.
+		const keyFormat = PbAesGcmKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		expect(keyFormat.getKeySize()).toBe(expectedKeySize);
 
-    // Test that the template works with AesCtrHmacAeadKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with AesCtrHmacAeadKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 
-  it('aes256 gcm no prefix', function() {
-    // The created key should have the following parameters.
-    const expectedKeySize = 32;
-    const expectedOutputPrefix = PbOutputPrefixType.RAW;
-    // Expected type URL is the one supported by AesGcmKeyManager.
-    const manager = new AesGcmKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+	it("aes256 gcm no prefix", () => {
+		// The created key should have the following parameters.
+		const expectedKeySize = 32;
+		const expectedOutputPrefix = PbOutputPrefixType.RAW;
+		// Expected type URL is the one supported by AesGcmKeyManager.
+		const manager = new AesGcmKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = AesGcmKeyTemplates.aes256GcmNoPrefix();
+		const keyTemplate = AesGcmKeyTemplates.aes256GcmNoPrefix();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test key size value in key format.
-    const keyFormat =
-        PbAesGcmKeyFormat.deserializeBinary(keyTemplate.getValue());
-    expect(keyFormat.getKeySize()).toBe(expectedKeySize);
+		// Test key size value in key format.
+		const keyFormat = PbAesGcmKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		expect(keyFormat.getKeySize()).toBe(expectedKeySize);
 
-    // Test that the template works with AesCtrHmacAeadKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with AesCtrHmacAeadKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 });

--- a/javascript/aead/internal/insecure_iv_aes_gcm_test.ts
+++ b/javascript/aead/internal/insecure_iv_aes_gcm_test.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {SecurityException} from '../../exception/security_exception';
+import { SecurityException } from "../../exception/security_exception";
 
-import {fromHex, toHex} from '../../subtle/bytes';
-import {insecureIvAesGcmFromRawKey, IV_SIZE_IN_BYTES} from './insecure_iv_aes_gcm';
+import { fromHex, toHex } from "../../subtle/bytes";
+import {
+	insecureIvAesGcmFromRawKey,
+	IV_SIZE_IN_BYTES,
+} from "./insecure_iv_aes_gcm";
 
 const AAD_LENGTH: number = 20;
 
@@ -19,551 +22,566 @@ const KEY_SIZE_IN_BYTES: number[] = [16, 32];
  */
 
 const NIST_TEST_VECTORS = [
-  {
-    'Key': 'b52c505a37d78eda5dd34f20c22540ea1b58963cf8e5bf8ffa85f9f2492505b4',
-    'IV': '516c33929df5a3284ff463d7',
-    'PT': '',
-    'AAD': '',
-    'CT': '',
-    'Tag': 'bdc1ac884d332457a1d2664f168c76f0',
-  },
-  {
-    'Key': '78dc4e0aaf52d935c3c01eea57428f00ca1fd475f5da86a49c8dd73d68c8e223',
-    'IV': 'd79cf22d504cc793c3fb6c8a',
-    'PT': '',
-    'AAD': 'b96baa8c1c75a671bfb2d08d06be5f36',
-    'CT': '',
-    'Tag': '3e5d486aa2e30b22e040b85723a06e76',
-  },
-  {
-    'Key': '886cff5f3e6b8d0e1ad0a38fcdb26de97e8acbe79f6bed66959a598fa5047d65',
-    'IV': '3a8efa1cd74bbab5448f9945',
-    'PT': '',
-    'AAD': '519fee519d25c7a304d6c6aa1897ee1eb8c59655',
-    'CT': '',
-    'Tag': 'f6d47505ec96c98a42dc3ae719877b87',
-  },
-  {
-    'Key': 'f4069bb739d07d0cafdcbc609ca01597f985c43db63bbaaa0debbb04d384e49c',
-    'IV': 'd25ff30fdc3d464fe173e805',
-    'PT': '',
-    'AAD':
-        '3e1449c4837f0892f9d55127c75c4b25d69be334baf5f19394d2d8bb460cbf2120e14736d0f634aa792feca20e455f11',
-    'CT': '',
-    'Tag': '805ec2931c2181e5bfb74fa0a975f0cf',
-  },
-  {
-    'Key': '03ccb7dbc7b8425465c2c3fc39ed0593929ffd02a45ff583bd89b79c6f646fe9',
-    'IV': 'fd119985533bd5520b301d12',
-    'PT': '',
-    'AAD':
-        '98e68c10bf4b5ae62d434928fc6405147c6301417303ef3a703dcfd2c0c339a4d0a89bd29fe61fecf1066ab06d7a5c31a48ffbfed22f749b17e9bd0dc1c6f8fbd6fd4587184db964d5456132106d782338c3f117ec05229b0899',
-    'CT': '',
-    'Tag': 'cf54e7141349b66f248154427810c87a',
-  },
-  {
-    'Key': '31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22',
-    'IV': '0d18e06c7c725ac9e362e1ce',
-    'PT': '2db5168e932556f8089a0622981d017d',
-    'AAD': '',
-    'CT': 'fa4362189661d163fcd6a56d8bf0405a',
-    'Tag': 'd636ac1bbedd5cc3ee727dc2ab4a9489',
-  },
-  {
-    'Key': '92e11dcdaa866f5ce790fd24501f92509aacf4cb8b1339d50c9c1240935dd08b',
-    'IV': 'ac93a1a6145299bde902f21a',
-    'PT': '2d71bcfa914e4ac045b2aa60955fad24',
-    'AAD': '1e0889016f67601c8ebea4943bc23ad6',
-    'CT': '8995ae2e6df3dbf96fac7b7137bae67f',
-    'Tag': 'eca5aa77d51d4a0a14d9c51e1da474ab',
-  },
-  {
-    'Key': '83688deb4af8007f9b713b47cfa6c73e35ea7a3aa4ecdb414dded03bf7a0fd3a',
-    'IV': '0b459724904e010a46901cf3',
-    'PT': '33d893a2114ce06fc15d55e454cf90c3',
-    'AAD': '794a14ccd178c8ebfd1379dc704c5e208f9d8424',
-    'CT': 'cc66bee423e3fcd4c0865715e9586696',
-    'Tag': '0fb291bd3dba94a1dfd8b286cfb97ac5',
-  },
-  {
-    'Key': 'e4fed339c7b0cd267305d11ab0d5c3273632e8872d35bdc367a1363438239a35',
-    'IV': '0365882cf75432cfd23cbd42',
-    'PT': 'fff39a087de39a03919fbd2f2fa5f513',
-    'AAD':
-        '8a97d2af5d41160ac2ff7dd8ba098e7aa4d618f0f455957d6a6d0801796747ba57c32dfbaaaf15176528fe3a0e4550c9',
-    'CT': '8d9e68f03f7e5f4a0ffaa7650d026d08',
-    'Tag': '3554542c478c0635285a61d1b51f6afa',
-  },
-  {
-    'Key': '80d755e24d129e68a5259ec2cf618e39317074a83c8961d3768ceb2ed8d5c3d7',
-    'IV': '7598c07ba7b16cd12cf50813',
-    'PT': '5e7fd1298c4f15aa0f1c1e47217aa7a9',
-    'AAD':
-        '0e94f4c48fd0c9690c853ad2a5e197c5de262137b69ed0cdfa28d8d12413e4ffff15374e1cccb0423e8ed829a954a335ed705a272ad7f9abd1057c849bb0d54b768e9d79879ec552461cc04adb6ca0040c5dd5bc733d21a93702',
-    'CT': '5762a38cf3f2fdf3645d2f6696a7eead',
-    'Tag': '8a6708e69468915c5367573924fe1ae3',
-  },
-  {
-    'Key': '82c4f12eeec3b2d3d157b0f992d292b237478d2cecc1d5f161389b97f999057a',
-    'IV': '7b40b20f5f397177990ef2d1',
-    'PT': '982a296ee1cd7086afad976945',
-    'AAD': '',
-    'CT': 'ec8e05a0471d6b43a59ca5335f',
-    'Tag': '113ddeafc62373cac2f5951bb9165249',
-  },
-  {
-    'Key': 'dad89d9be9bba138cdcf8752c45b579d7e27c3dbb40f53e771dd8cfd500aa2d5',
-    'IV': 'cfb2aec82cfa6c7d89ee72ff',
-    'PT': 'b526ba1050177d05b0f72f8d67',
-    'AAD': '6e43784a91851a77667a02198e28dc32',
-    'CT': '8b29e66e924ecae84f6d8f7d68',
-    'Tag': '1e365805c8f28b2ed8a5cadfd9079158',
-  },
-  {
-    'Key': '69b458f2644af9020463b40ee503cdf083d693815e2659051ae0d039e606a970',
-    'IV': '8d1da8ab5f91ccd09205944b',
-    'PT': 'f3e0e09224256bf21a83a5de8d',
-    'AAD': '036ad5e5494ef817a8af2f5828784a4bfedd1653',
-    'CT': 'c0a62d77e6031bfdc6b13ae217',
-    'Tag': 'a794a9aaee48cd92e47761bf1baff0af',
-  },
-  {
-    'Key': '5f671466378f470ba5f5160e2209f3d95a48b7e560625d5a08654414de23aee2',
-    'IV': '6b3c08a663d04132243dd96c',
-    'PT': 'c428592d9f8a7f107ec4d0df05',
-    'AAD':
-        '12965559c31d538f937bda6eee9c93b0387318dc5d9496fb1c3a0b9b978dbfebff2a5823974ee9d679834dbe59f7ec51',
-    'CT': '1d8d7fe4357080c817303ce19c',
-    'Tag': 'e88d6b566fdc7b4fd62106bd2eb806ec',
-  },
-  {
-    'Key': 'ff9506b4d46ba54128876fadfcc673a4c927c618ea7d95cfcaa508cbc8f7fc66',
-    'IV': '3742ad2208a0484345eee1be',
-    'PT': '7fd0d6cadc92cad27bb2d7d8c8',
-    'AAD':
-        'f1360a27fdc244be8739d85af6491c762a693aafe668c449515fdeeedb6a90aeee3891bbc8b69adc6a6426cb12fcdebc32c9f58c5259d128b91efa28620a3a9a0168b0ff5e76951cb41647ba4aa1f87fac0d97ac580e42cffc7e',
-    'CT': 'bdb8346b28eb4d7226493611a6',
-    'Tag': '7484d827b767647f44c7f94a39f8175c',
-  },
-  {
-    'Key': '268ed1b5d7c9c7304f9cae5fc437b4cd3aebe2ec65f0d85c3918d3d3b5bba89b',
-    'IV': '9ed9d8180564e0e945f5e5d4',
-    'PT': 'fe29a40d8ebf57262bdb87191d01843f4ca4b2de97d88273154a0b7d9e2fdb80',
-    'AAD': '',
-    'CT': '791a4a026f16f3a5ea06274bf02baab469860abde5e645f3dd473a5acddeecfc',
-    'Tag': '05b2b74db0662550435ef1900e136b15',
-  },
-  {
-    'Key': '37ccdba1d929d6436c16bba5b5ff34deec88ed7df3d15d0f4ddf80c0c731ee1f',
-    'IV': '5c1b21c8998ed6299006d3f9',
-    'PT': 'ad4260e3cdc76bcc10c7b2c06b80b3be948258e5ef20c508a81f51e96a518388',
-    'AAD': '22ed235946235a85a45bc5fad7140bfa',
-    'CT': '3b335f8b08d33ccdcad228a74700f1007542a4d1e7fc1ebe3f447fe71af29816',
-    'Tag': '1fbf49cc46f458bf6e88f6370975e6d4',
-  },
-  {
-    'Key': '5853c020946b35f2c58ec427152b840420c40029636adcbb027471378cfdde0f',
-    'IV': 'eec313dd07cc1b3e6b068a47',
-    'PT': 'ce7458e56aef9061cb0c42ec2315565e6168f5a6249ffd31610b6d17ab64935e',
-    'AAD': '1389b522c24a774181700553f0246bbabdd38d6f',
-    'CT': 'eadc3b8766a77ded1a58cb727eca2a9790496c298654cda78febf0da16b6903b',
-    'Tag': '3d49a5b32fde7eafcce90079217ffb57',
-  },
-  {
-    'Key': 'dc776f0156c15d032623854b625c61868e5db84b7b6f9fbd3672f12f0025e0f6',
-    'IV': '67130951c4a57f6ae7f13241',
-    'PT': '9378a727a5119595ad631b12a5a6bc8a91756ef09c8d6eaa2b718fe86876da20',
-    'AAD':
-        'fd0920faeb7b212932280a009bac969145e5c316cf3922622c3705c3457c4e9f124b2076994323fbcfb523f8ed16d241',
-    'CT': '6d958c20870d401a3c1f7a0ac092c97774d451c09f7aae992a8841ff0ab9d60d',
-    'Tag': 'b876831b4ecd7242963b040aa45c4114',
-  },
-  {
-    'Key': '26bf255bee60ef0f653769e7034db95b8c791752754e575c761059e9ee8dcf78',
-    'IV': 'cecd97ab07ce57c1612744f5',
-    'PT': '96983917a036650763aca2b4e927d95ffc74339519ed40c4336dba91edfbf9ad',
-    'AAD':
-        'afebbe9f260f8c118e52b84d8880a34622675faef334cdb41be9385b7d059b79c0f8a432d25f8b71e781b177fce4d4c57ac5734543e85d7513f96382ff4b2d4b95b2f1fdbaf9e78bbd1db13a7dd26e8a4ac83a3e8ab42d1d545f',
-    'CT': 'e34b1540a769f7913331d66796e00bdc3ee0f258cf244eb7663375cc5ad6c658',
-    'Tag': '3841f02beb7a7fca7e578922d0a2f80c',
-  },
-  {
-    'Key': '1fded32d5999de4a76e0f8082108823aef60417e1896cf4218a2fa90f632ec8a',
-    'IV': '1f3afa4711e9474f32e70462',
-    'PT':
-        '06b2c75853df9aeb17befd33cea81c630b0fc53667ff45199c629c8e15dce41e530aa792f796b8138eeab2e86c7b7bee1d40b0',
-    'AAD': '',
-    'CT':
-        '91fbd061ddc5a7fcc9513fcdfdc9c3a7c5d4d64cedf6a9c24ab8a77c36eefbf1c5dc00bc50121b96456c8cd8b6ff1f8b3e480f',
-    'Tag': '30096d340f3d5c42d82a6f475def23eb',
-  },
-  {
-    'Key': '5fe01c4baf01cbe07796d5aaef6ec1f45193a98a223594ae4f0ef4952e82e330',
-    'IV': 'bd587321566c7f1a5dd8652d',
-    'PT':
-        '881dc6c7a5d4509f3c4bd2daab08f165ddc204489aa8134562a4eac3d0bcad7965847b102733bb63d1e5c598ece0c3e5dadddd',
-    'AAD': '9013617817dda947e135ee6dd3653382',
-    'CT':
-        '16e375b4973b339d3f746c1c5a568bc7526e909ddff1e19c95c94a6ccff210c9a4a40679de5760c396ac0e2ceb1234f9f5fe26',
-    'Tag': 'abd3d26d65a6275f7a4f56b422acab49',
-  },
-  {
-    'Key': '24501ad384e473963d476edcfe08205237acfd49b5b8f33857f8114e863fec7f',
-    'IV': '9ff18563b978ec281b3f2794',
-    'PT':
-        '27f348f9cdc0c5bd5e66b1ccb63ad920ff2219d14e8d631b3872265cf117ee86757accb158bd9abb3868fdc0d0b074b5f01b2c',
-    'AAD': 'adb5ec720ccf9898500028bf34afccbcaca126ef',
-    'CT':
-        'eb7cb754c824e8d96f7c6d9b76c7d26fb874ffbf1d65c6f64a698d839b0b06145dae82057ad55994cf59ad7f67c0fa5e85fab8',
-    'Tag': 'bc95c532fecc594c36d1550286a7a3f0',
-  },
-  {
-    'Key': '463b412911767d57a0b33969e674ffe7845d313b88c6fe312f3d724be68e1fca',
-    'IV': '611ce6f9a6880750de7da6cb',
-    'PT':
-        'e7d1dcf668e2876861940e012fe52a98dacbd78ab63c08842cc9801ea581682ad54af0c34d0d7f6f59e8ee0bf4900e0fd85042',
-    'AAD':
-        '0a682fbc6192e1b47a5e0868787ffdafe5a50cead3575849990cdd2ea9b3597749403efb4a56684f0c6bde352d4aeec5',
-    'CT':
-        '8886e196010cb3849d9c1a182abe1eeab0a5f3ca423c3669a4a8703c0f146e8e956fb122e0d721b869d2b6fcd4216d7d4d3758',
-    'Tag': '2469cecd70fd98fec9264f71df1aee9a',
-  },
-  {
-    'Key': '148579a3cbca86d5520d66c0ec71ca5f7e41ba78e56dc6eebd566fed547fe691',
-    'IV': 'b08a5ea1927499c6ecbfd4e0',
-    'PT':
-        '9d0b15fdf1bd595f91f8b3abc0f7dec927dfd4799935a1795d9ce00c9b879434420fe42c275a7cd7b39d638fb81ca52b49dc41',
-    'AAD':
-        'e4f963f015ffbb99ee3349bbaf7e8e8e6c2a71c230a48f9d59860a29091d2747e01a5ca572347e247d25f56ba7ae8e05cde2be3c97931292c02370208ecd097ef692687fecf2f419d3200162a6480a57dad408a0dfeb492e2c5d',
-    'CT':
-        '2097e372950a5e9383c675e89eea1c314f999159f5611344b298cda45e62843716f215f82ee663919c64002a5c198d7878fd3f',
-    'Tag': 'adbecdb0d5c2224d804d2886ff9a5760',
-  },
-  {
-    'Key': '11754cd72aec309bf52f7687212e8957',
-    'IV': '3c819d9a9bed087615030b65',
-    'PT': '',
-    'AAD': '',
-    'CT': '',
-    'Tag': '250327c674aaf477aef2675748cf6971',
-  },
-  {
-    'Key': '77be63708971c4e240d1cb79e8d77feb',
-    'IV': 'e0e00f19fed7ba0136a797f3',
-    'PT': '',
-    'AAD': '7a43ec1d9c0a5a78a0b16533a6213cab',
-    'CT': '',
-    'Tag': '209fcc8d3675ed938e9c7166709dd946',
-  },
-  {
-    'Key': '2fb45e5b8f993a2bfebc4b15b533e0b4',
-    'IV': '5b05755f984d2b90f94b8027',
-    'PT': '',
-    'AAD': 'e85491b2202caf1d7dce03b97e09331c32473941',
-    'CT': '',
-    'Tag': 'c75b7832b2a2d9bd827412b6ef5769db',
-  },
-  {
-    'Key': '99e3e8793e686e571d8285c564f75e2b',
-    'IV': 'c2dd0ab868da6aa8ad9c0d23',
-    'PT': '',
-    'AAD':
-        'b668e42d4e444ca8b23cfdd95a9fedd5178aa521144890b093733cf5cf22526c5917ee476541809ac6867a8c399309fc',
-    'CT': '',
-    'Tag': '3f4fba100eaf1f34b0baadaae9995d85',
-  },
-  {
-    'Key': '20b5b6b854e187b058a84d57bc1538b6',
-    'IV': '94c1935afc061cbf254b936f',
-    'PT': '',
-    'AAD':
-        'ca418e71dbf810038174eaa3719b3fcb80531c7110ad9192d105eeaafa15b819ac005668752b344ed1b22faf77048baf03dbddb3b47d6b00e95c4f005e0cc9b7627ccafd3f21b3312aa8d91d3fa0893fe5bff7d44ca46f23afe0',
-    'CT': '',
-    'Tag': 'b37286ebaf4a54e0ffc2a1deafc9f6db',
-  },
-  {
-    'Key': '7fddb57453c241d03efbed3ac44e371c',
-    'IV': 'ee283a3fc75575e33efd4887',
-    'PT': 'd5de42b461646c255c87bd2962d3b9a2',
-    'AAD': '',
-    'CT': '2ccda4a5415cb91e135c2a0f78c9b2fd',
-    'Tag': 'b36d1df9b9d5e596f83e8b7f52971cb3',
-  },
-  {
-    'Key': 'c939cc13397c1d37de6ae0e1cb7c423c',
-    'IV': 'b3d8cc017cbb89b39e0f67e2',
-    'PT': 'c3b3c41f113a31b73d9a5cd432103069',
-    'AAD': '24825602bd12a984e0092d3e448eda5f',
-    'CT': '93fe7d9e9bfd10348a5606e5cafa7354',
-    'Tag': '0032a1dc85f1c9786925a2e71d8272dd',
-  },
-  {
-    'Key': 'd4a22488f8dd1d5c6c19a7d6ca17964c',
-    'IV': 'f3d5837f22ac1a0425e0d1d5',
-    'PT': '7b43016a16896497fb457be6d2a54122',
-    'AAD': 'f1c5d424b83f96c6ad8cb28ca0d20e475e023b5a',
-    'CT': 'c2bd67eef5e95cac27e3b06e3031d0a8',
-    'Tag': 'f23eacf9d1cdf8737726c58648826e9c',
-  },
-  {
-    'Key': '89850dd398e1f1e28443a33d40162664',
-    'IV': 'e462c58482fe8264aeeb7231',
-    'PT': '2805cdefb3ef6cc35cd1f169f98da81a',
-    'AAD':
-        'd74e99d1bdaa712864eec422ac507bddbe2b0d4633cd3dff29ce5059b49fe868526c59a2a3a604457bc2afea866e7606',
-    'CT': 'ba80e244b7fc9025cd031d0f63677e06',
-    'Tag': 'd84a8c3eac57d1bb0e890a8f461d1065',
-  },
-  {
-    'Key': 'bd7c5c63b7542b56a00ebe71336a1588',
-    'IV': '87721f23ba9c3c8ea5571abc',
-    'PT': 'de15ddbb1e202161e8a79af6a55ac6f3',
-    'AAD':
-        'a6ec8075a0d3370eb7598918f3b93e48444751624997b899a87fa6a9939f844e008aa8b70e9f4c3b1a19d3286bf543e7127bfecba1ad17a5ec53fccc26faecacc4c75369498eaa7d706aef634d0009279b11e4ba6c993e5e9ed9',
-    'CT': '41eb28c0fee4d762de972361c863bc80',
-    'Tag': '9cb567220d0b252eb97bff46e4b00ff8',
-  },
-  {
-    'Key': 'fe9bb47deb3a61e423c2231841cfd1fb',
-    'IV': '4d328eb776f500a2f7fb47aa',
-    'PT': 'f1cc3818e421876bb6b8bbd6c9',
-    'AAD': '',
-    'CT': 'b88c5c1977b35b517b0aeae967',
-    'Tag': '43fd4727fe5cdb4b5b42818dea7ef8c9',
-  },
-  {
-    'Key': 'dfefde23c6122bf0370ab5890e804b73',
-    'IV': '92d6a8029990670f16de79e2',
-    'PT': '64260a8c287de978e96c7521d0',
-    'AAD': 'a2b16d78251de6c191ce350e5c5ef242',
-    'CT': 'bf78de948a847c173649d4b4d0',
-    'Tag': '9da3829968cdc50794d1c30d41cd4515',
-  },
-  {
-    'Key': 'fe0121f42e599f88ff02a985403e19bb',
-    'IV': '3bb9eb7724cbe1943d43de21',
-    'PT': 'fd331ca8646091c29f21e5f0a1',
-    'AAD': '2662d895035b6519f3510eae0faa3900ad23cfdf',
-    'CT': '59fe29b07b0de8d869efbbd9b4',
-    'Tag': 'd24c3e9c1c73c0af1097e26061c857de',
-  },
-  {
-    'Key': 'cbd3b8dbfcfb11ce345706e6cd73881a',
-    'IV': 'dc62bb68d0ec9a5d759d6741',
-    'PT': '85f83bf598dfd55bc8bfde2a64',
-    'AAD':
-        '0944b661fe6294f3c92abb087ec1b259b032dc4e0c5f28681cbe6e63c2178f474326f35ad3ca80c28e3485e7e5b252c8',
-    'CT': '206f6b3bb032dfecd39f8340b1',
-    'Tag': '425a21b2ea90580c889134032b914bb5',
-  },
-  {
-    'Key': 'e5b1e7a94e9e1fda0873571eec713429',
-    'IV': '5ddde829a81713346af8e5b7',
-    'PT': '850069e5ed768b5dc9ed7ad485',
-    'AAD':
-        'b0ce75da427fba93da6d3455b2b440a877599a6d8d6d2d66ee90b5cf9a33baaa8329a9ffaac290e8e33f2af2548c2a8a181b3d4d9f8fac860cc26b0d26b9cc53bc9f405afa73605ebeb376f2d1d7fcb065bab92f20f295556ade',
-    'CT': 'c211d9079d5562659db01e17d1',
-    'Tag': '884893fb035d3d7237d47c363de62bb3',
-  },
-  {
-    'Key': '9971071059abc009e4f2bd69869db338',
-    'IV': '07a9a95ea3821e9c13c63251',
-    'PT': 'f54bc3501fed4f6f6dfb5ea80106df0bd836e6826225b75c0222f6e859b35983',
-    'AAD': '',
-    'CT': '0556c159f84ef36cb1602b4526b12009c775611bffb64dc0d9ca9297cd2c6a01',
-    'Tag': '7870d9117f54811a346970f1de090c41',
-  },
-  {
-    'Key': '298efa1ccf29cf62ae6824bfc19557fc',
-    'IV': '6f58a93fe1d207fae4ed2f6d',
-    'PT': 'cc38bccd6bc536ad919b1395f5d63801f99f8068d65ca5ac63872daf16b93901',
-    'AAD': '021fafd238463973ffe80256e5b1c6b1',
-    'CT': 'dfce4e9cd291103d7fe4e63351d9e79d3dfd391e3267104658212da96521b7db',
-    'Tag': '542465ef599316f73a7a560509a2d9f2',
-  },
-  {
-    'Key': 'fedc7155192d00b23cdd98750db9ebba',
-    'IV': 'a76b74f55c1a1756a08338b1',
-    'PT': '6831435b8857daf1c513b148820d13b5a72cc490bda79a98a6f520d8763c39d1',
-    'AAD': '2ad206c4176e7e552aa08836886816fafa77e759',
-    'CT': '15823805da89a1923bfc1d6f87784d56bad1128b4dffdbdeefbb2fa562c35e68',
-    'Tag': 'd23dc455ced49887c717e8eabeec2984',
-  },
-  {
-    'Key': '48b7f337cdf9252687ecc760bd8ec184',
-    'IV': '3e894ebb16ce82a53c3e05b2',
-    'PT': 'bb2bac67a4709430c39c2eb9acfabc0d456c80d30aa1734e57997d548a8f0603',
-    'AAD':
-        '7d924cfd37b3d046a96eb5e132042405c8731e06509787bbeb41f258275746495e884d69871f77634c584bb007312234',
-    'CT': 'd263228b8ce051f67e9baf1ce7df97d10cd5f3bc972362055130c7d13c3ab2e7',
-    'Tag': '71446737ca1fa92e6d026d7d2ed1aa9c',
-  },
-  {
-    'Key': '8fbf7ca12fd525dde91e625873fe51c2',
-    'IV': '200bea517b9790a1cfadaf5e',
-    'PT': '39d3e6277c4b4963840d1642e6faae0a5be2da97f61c4e55bb57ce021903d4c4',
-    'AAD':
-        'a414c07fe2e60bec9ccc409e9e899c6fe60580bb2607c861f7f08523e69cda1b9c3a711d1d9c35091771e4c950b9996d0ad04f2e00d1b3105853542a96e09ffffc2ec80f8cf88728f594f0aeb14f98a688234e8bfbf70327b364',
-    'CT': 'fe678ef76f69ac95db553b6dadd5a07a9dc8e151fe6a9fa3a1cd621636b87868',
-    'Tag': '7c860774f88332b9a7ce6bbd0272a727',
-  },
-  {
-    'Key': '594157ec4693202b030f33798b07176d',
-    'IV': '49b12054082660803a1df3df',
-    'PT':
-        '3feef98a976a1bd634f364ac428bb59cd51fb159ec1789946918dbd50ea6c9d594a3a31a5269b0da6936c29d063a5fa2cc8a1c',
-    'AAD': '',
-    'CT':
-        'c1b7a46a335f23d65b8db4008a49796906e225474f4fe7d39e55bf2efd97fd82d4167de082ae30fa01e465a601235d8d68bc69',
-    'Tag': 'ba92d3661ce8b04687e8788d55417dc2',
-  },
-  {
-    'Key': 'b61553bb854895b929751cd0c5f80384',
-    'IV': '8863f999ae64e55d0bbd7457',
-    'PT':
-        '9b1b113217d0c4ea7943cf123c69c6ad2e3c97368c51c9754145d155dde1ee8640c8cafff17a5c9737d26a137eee4bf369096d',
-    'AAD': 'd914b5f2d1b08ce53ea59cb310587245',
-    'CT':
-        'acfab4632b8a25805112f13d85e082bc89dc49bd92164fa8a2dad242c3a1b2f2696f2fdff579025f3f146ea97da3e47dc34b65',
-    'Tag': '5d9b5f4a9868c1c69cbd6fd851f01340',
-  },
-  {
-    'Key': 'fe47fcce5fc32665d2ae399e4eec72ba',
-    'IV': '5adb9609dbaeb58cbd6e7275',
-    'PT':
-        '7c0e88c88899a779228465074797cd4c2e1498d259b54390b85e3eef1c02df60e743f1b840382c4bccaf3bafb4ca8429bea063',
-    'AAD': '88319d6e1d3ffa5f987199166c8a9b56c2aeba5a',
-    'CT':
-        '98f4826f05a265e6dd2be82db241c0fbbbf9ffb1c173aa83964b7cf5393043736365253ddbc5db8778371495da76d269e5db3e',
-    'Tag': '291ef1982e4defedaa2249f898556b47',
-  },
-  {
-    'Key': '3c50622868f450aa0928990c15e1eb36',
-    'IV': '811d5290768d57e7d87bb6c7',
-    'PT':
-        'edd0a8f82833e919740fe2bf9edecf4ac86c72dc89490cef7b6983aaaf99fc856c5cc87d63f98a7c861bf3271fea6da86a15ab',
-    'AAD':
-        'dae2c7e0a3d3fd2bc04eca19b15178a003b5cf84890c28c2a615f20f8adb427f70698c12b2ef87780c1193fbb8cd1674',
-    'CT':
-        'a51425b0608d3b4b46d4ec05ca1ddaf02bdd2089ae0554ecfb2a1c84c63d82dc71ddb9ab1b1f0b49de2ad27c2b5173e7000aa6',
-    'Tag': 'bd9b5efca48008cd973a4f7d2c723844',
-  },
-  {
-    'Key': '2c1f21cf0f6fb3661943155c3e3d8492',
-    'IV': '23cb5ff362e22426984d1907',
-    'PT':
-        '42f758836986954db44bf37c6ef5e4ac0adaf38f27252a1b82d02ea949c8a1a2dbc0d68b5615ba7c1220ff6510e259f06655d8',
-    'AAD':
-        '5d3624879d35e46849953e45a32a624d6a6c536ed9857c613b572b0333e701557a713e3f010ecdf9a6bd6c9e3e44b065208645aff4aabee611b391528514170084ccf587177f4488f33cfb5e979e42b6e1cfc0a60238982a7aec',
-    'CT':
-        '81824f0e0d523db30d3da369fdc0d60894c7a0a20646dd015073ad2732bd989b14a222b6ad57af43e1895df9dca2a5344a62cc',
-    'Tag': '57a3ee28136e94c74838997ae9823f3a',
-  },
+	{
+		Key: "b52c505a37d78eda5dd34f20c22540ea1b58963cf8e5bf8ffa85f9f2492505b4",
+		IV: "516c33929df5a3284ff463d7",
+		PT: "",
+		AAD: "",
+		CT: "",
+		Tag: "bdc1ac884d332457a1d2664f168c76f0",
+	},
+	{
+		Key: "78dc4e0aaf52d935c3c01eea57428f00ca1fd475f5da86a49c8dd73d68c8e223",
+		IV: "d79cf22d504cc793c3fb6c8a",
+		PT: "",
+		AAD: "b96baa8c1c75a671bfb2d08d06be5f36",
+		CT: "",
+		Tag: "3e5d486aa2e30b22e040b85723a06e76",
+	},
+	{
+		Key: "886cff5f3e6b8d0e1ad0a38fcdb26de97e8acbe79f6bed66959a598fa5047d65",
+		IV: "3a8efa1cd74bbab5448f9945",
+		PT: "",
+		AAD: "519fee519d25c7a304d6c6aa1897ee1eb8c59655",
+		CT: "",
+		Tag: "f6d47505ec96c98a42dc3ae719877b87",
+	},
+	{
+		Key: "f4069bb739d07d0cafdcbc609ca01597f985c43db63bbaaa0debbb04d384e49c",
+		IV: "d25ff30fdc3d464fe173e805",
+		PT: "",
+		AAD: "3e1449c4837f0892f9d55127c75c4b25d69be334baf5f19394d2d8bb460cbf2120e14736d0f634aa792feca20e455f11",
+		CT: "",
+		Tag: "805ec2931c2181e5bfb74fa0a975f0cf",
+	},
+	{
+		Key: "03ccb7dbc7b8425465c2c3fc39ed0593929ffd02a45ff583bd89b79c6f646fe9",
+		IV: "fd119985533bd5520b301d12",
+		PT: "",
+		AAD: "98e68c10bf4b5ae62d434928fc6405147c6301417303ef3a703dcfd2c0c339a4d0a89bd29fe61fecf1066ab06d7a5c31a48ffbfed22f749b17e9bd0dc1c6f8fbd6fd4587184db964d5456132106d782338c3f117ec05229b0899",
+		CT: "",
+		Tag: "cf54e7141349b66f248154427810c87a",
+	},
+	{
+		Key: "31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22",
+		IV: "0d18e06c7c725ac9e362e1ce",
+		PT: "2db5168e932556f8089a0622981d017d",
+		AAD: "",
+		CT: "fa4362189661d163fcd6a56d8bf0405a",
+		Tag: "d636ac1bbedd5cc3ee727dc2ab4a9489",
+	},
+	{
+		Key: "92e11dcdaa866f5ce790fd24501f92509aacf4cb8b1339d50c9c1240935dd08b",
+		IV: "ac93a1a6145299bde902f21a",
+		PT: "2d71bcfa914e4ac045b2aa60955fad24",
+		AAD: "1e0889016f67601c8ebea4943bc23ad6",
+		CT: "8995ae2e6df3dbf96fac7b7137bae67f",
+		Tag: "eca5aa77d51d4a0a14d9c51e1da474ab",
+	},
+	{
+		Key: "83688deb4af8007f9b713b47cfa6c73e35ea7a3aa4ecdb414dded03bf7a0fd3a",
+		IV: "0b459724904e010a46901cf3",
+		PT: "33d893a2114ce06fc15d55e454cf90c3",
+		AAD: "794a14ccd178c8ebfd1379dc704c5e208f9d8424",
+		CT: "cc66bee423e3fcd4c0865715e9586696",
+		Tag: "0fb291bd3dba94a1dfd8b286cfb97ac5",
+	},
+	{
+		Key: "e4fed339c7b0cd267305d11ab0d5c3273632e8872d35bdc367a1363438239a35",
+		IV: "0365882cf75432cfd23cbd42",
+		PT: "fff39a087de39a03919fbd2f2fa5f513",
+		AAD: "8a97d2af5d41160ac2ff7dd8ba098e7aa4d618f0f455957d6a6d0801796747ba57c32dfbaaaf15176528fe3a0e4550c9",
+		CT: "8d9e68f03f7e5f4a0ffaa7650d026d08",
+		Tag: "3554542c478c0635285a61d1b51f6afa",
+	},
+	{
+		Key: "80d755e24d129e68a5259ec2cf618e39317074a83c8961d3768ceb2ed8d5c3d7",
+		IV: "7598c07ba7b16cd12cf50813",
+		PT: "5e7fd1298c4f15aa0f1c1e47217aa7a9",
+		AAD: "0e94f4c48fd0c9690c853ad2a5e197c5de262137b69ed0cdfa28d8d12413e4ffff15374e1cccb0423e8ed829a954a335ed705a272ad7f9abd1057c849bb0d54b768e9d79879ec552461cc04adb6ca0040c5dd5bc733d21a93702",
+		CT: "5762a38cf3f2fdf3645d2f6696a7eead",
+		Tag: "8a6708e69468915c5367573924fe1ae3",
+	},
+	{
+		Key: "82c4f12eeec3b2d3d157b0f992d292b237478d2cecc1d5f161389b97f999057a",
+		IV: "7b40b20f5f397177990ef2d1",
+		PT: "982a296ee1cd7086afad976945",
+		AAD: "",
+		CT: "ec8e05a0471d6b43a59ca5335f",
+		Tag: "113ddeafc62373cac2f5951bb9165249",
+	},
+	{
+		Key: "dad89d9be9bba138cdcf8752c45b579d7e27c3dbb40f53e771dd8cfd500aa2d5",
+		IV: "cfb2aec82cfa6c7d89ee72ff",
+		PT: "b526ba1050177d05b0f72f8d67",
+		AAD: "6e43784a91851a77667a02198e28dc32",
+		CT: "8b29e66e924ecae84f6d8f7d68",
+		Tag: "1e365805c8f28b2ed8a5cadfd9079158",
+	},
+	{
+		Key: "69b458f2644af9020463b40ee503cdf083d693815e2659051ae0d039e606a970",
+		IV: "8d1da8ab5f91ccd09205944b",
+		PT: "f3e0e09224256bf21a83a5de8d",
+		AAD: "036ad5e5494ef817a8af2f5828784a4bfedd1653",
+		CT: "c0a62d77e6031bfdc6b13ae217",
+		Tag: "a794a9aaee48cd92e47761bf1baff0af",
+	},
+	{
+		Key: "5f671466378f470ba5f5160e2209f3d95a48b7e560625d5a08654414de23aee2",
+		IV: "6b3c08a663d04132243dd96c",
+		PT: "c428592d9f8a7f107ec4d0df05",
+		AAD: "12965559c31d538f937bda6eee9c93b0387318dc5d9496fb1c3a0b9b978dbfebff2a5823974ee9d679834dbe59f7ec51",
+		CT: "1d8d7fe4357080c817303ce19c",
+		Tag: "e88d6b566fdc7b4fd62106bd2eb806ec",
+	},
+	{
+		Key: "ff9506b4d46ba54128876fadfcc673a4c927c618ea7d95cfcaa508cbc8f7fc66",
+		IV: "3742ad2208a0484345eee1be",
+		PT: "7fd0d6cadc92cad27bb2d7d8c8",
+		AAD: "f1360a27fdc244be8739d85af6491c762a693aafe668c449515fdeeedb6a90aeee3891bbc8b69adc6a6426cb12fcdebc32c9f58c5259d128b91efa28620a3a9a0168b0ff5e76951cb41647ba4aa1f87fac0d97ac580e42cffc7e",
+		CT: "bdb8346b28eb4d7226493611a6",
+		Tag: "7484d827b767647f44c7f94a39f8175c",
+	},
+	{
+		Key: "268ed1b5d7c9c7304f9cae5fc437b4cd3aebe2ec65f0d85c3918d3d3b5bba89b",
+		IV: "9ed9d8180564e0e945f5e5d4",
+		PT: "fe29a40d8ebf57262bdb87191d01843f4ca4b2de97d88273154a0b7d9e2fdb80",
+		AAD: "",
+		CT: "791a4a026f16f3a5ea06274bf02baab469860abde5e645f3dd473a5acddeecfc",
+		Tag: "05b2b74db0662550435ef1900e136b15",
+	},
+	{
+		Key: "37ccdba1d929d6436c16bba5b5ff34deec88ed7df3d15d0f4ddf80c0c731ee1f",
+		IV: "5c1b21c8998ed6299006d3f9",
+		PT: "ad4260e3cdc76bcc10c7b2c06b80b3be948258e5ef20c508a81f51e96a518388",
+		AAD: "22ed235946235a85a45bc5fad7140bfa",
+		CT: "3b335f8b08d33ccdcad228a74700f1007542a4d1e7fc1ebe3f447fe71af29816",
+		Tag: "1fbf49cc46f458bf6e88f6370975e6d4",
+	},
+	{
+		Key: "5853c020946b35f2c58ec427152b840420c40029636adcbb027471378cfdde0f",
+		IV: "eec313dd07cc1b3e6b068a47",
+		PT: "ce7458e56aef9061cb0c42ec2315565e6168f5a6249ffd31610b6d17ab64935e",
+		AAD: "1389b522c24a774181700553f0246bbabdd38d6f",
+		CT: "eadc3b8766a77ded1a58cb727eca2a9790496c298654cda78febf0da16b6903b",
+		Tag: "3d49a5b32fde7eafcce90079217ffb57",
+	},
+	{
+		Key: "dc776f0156c15d032623854b625c61868e5db84b7b6f9fbd3672f12f0025e0f6",
+		IV: "67130951c4a57f6ae7f13241",
+		PT: "9378a727a5119595ad631b12a5a6bc8a91756ef09c8d6eaa2b718fe86876da20",
+		AAD: "fd0920faeb7b212932280a009bac969145e5c316cf3922622c3705c3457c4e9f124b2076994323fbcfb523f8ed16d241",
+		CT: "6d958c20870d401a3c1f7a0ac092c97774d451c09f7aae992a8841ff0ab9d60d",
+		Tag: "b876831b4ecd7242963b040aa45c4114",
+	},
+	{
+		Key: "26bf255bee60ef0f653769e7034db95b8c791752754e575c761059e9ee8dcf78",
+		IV: "cecd97ab07ce57c1612744f5",
+		PT: "96983917a036650763aca2b4e927d95ffc74339519ed40c4336dba91edfbf9ad",
+		AAD: "afebbe9f260f8c118e52b84d8880a34622675faef334cdb41be9385b7d059b79c0f8a432d25f8b71e781b177fce4d4c57ac5734543e85d7513f96382ff4b2d4b95b2f1fdbaf9e78bbd1db13a7dd26e8a4ac83a3e8ab42d1d545f",
+		CT: "e34b1540a769f7913331d66796e00bdc3ee0f258cf244eb7663375cc5ad6c658",
+		Tag: "3841f02beb7a7fca7e578922d0a2f80c",
+	},
+	{
+		Key: "1fded32d5999de4a76e0f8082108823aef60417e1896cf4218a2fa90f632ec8a",
+		IV: "1f3afa4711e9474f32e70462",
+		PT: "06b2c75853df9aeb17befd33cea81c630b0fc53667ff45199c629c8e15dce41e530aa792f796b8138eeab2e86c7b7bee1d40b0",
+		AAD: "",
+		CT: "91fbd061ddc5a7fcc9513fcdfdc9c3a7c5d4d64cedf6a9c24ab8a77c36eefbf1c5dc00bc50121b96456c8cd8b6ff1f8b3e480f",
+		Tag: "30096d340f3d5c42d82a6f475def23eb",
+	},
+	{
+		Key: "5fe01c4baf01cbe07796d5aaef6ec1f45193a98a223594ae4f0ef4952e82e330",
+		IV: "bd587321566c7f1a5dd8652d",
+		PT: "881dc6c7a5d4509f3c4bd2daab08f165ddc204489aa8134562a4eac3d0bcad7965847b102733bb63d1e5c598ece0c3e5dadddd",
+		AAD: "9013617817dda947e135ee6dd3653382",
+		CT: "16e375b4973b339d3f746c1c5a568bc7526e909ddff1e19c95c94a6ccff210c9a4a40679de5760c396ac0e2ceb1234f9f5fe26",
+		Tag: "abd3d26d65a6275f7a4f56b422acab49",
+	},
+	{
+		Key: "24501ad384e473963d476edcfe08205237acfd49b5b8f33857f8114e863fec7f",
+		IV: "9ff18563b978ec281b3f2794",
+		PT: "27f348f9cdc0c5bd5e66b1ccb63ad920ff2219d14e8d631b3872265cf117ee86757accb158bd9abb3868fdc0d0b074b5f01b2c",
+		AAD: "adb5ec720ccf9898500028bf34afccbcaca126ef",
+		CT: "eb7cb754c824e8d96f7c6d9b76c7d26fb874ffbf1d65c6f64a698d839b0b06145dae82057ad55994cf59ad7f67c0fa5e85fab8",
+		Tag: "bc95c532fecc594c36d1550286a7a3f0",
+	},
+	{
+		Key: "463b412911767d57a0b33969e674ffe7845d313b88c6fe312f3d724be68e1fca",
+		IV: "611ce6f9a6880750de7da6cb",
+		PT: "e7d1dcf668e2876861940e012fe52a98dacbd78ab63c08842cc9801ea581682ad54af0c34d0d7f6f59e8ee0bf4900e0fd85042",
+		AAD: "0a682fbc6192e1b47a5e0868787ffdafe5a50cead3575849990cdd2ea9b3597749403efb4a56684f0c6bde352d4aeec5",
+		CT: "8886e196010cb3849d9c1a182abe1eeab0a5f3ca423c3669a4a8703c0f146e8e956fb122e0d721b869d2b6fcd4216d7d4d3758",
+		Tag: "2469cecd70fd98fec9264f71df1aee9a",
+	},
+	{
+		Key: "148579a3cbca86d5520d66c0ec71ca5f7e41ba78e56dc6eebd566fed547fe691",
+		IV: "b08a5ea1927499c6ecbfd4e0",
+		PT: "9d0b15fdf1bd595f91f8b3abc0f7dec927dfd4799935a1795d9ce00c9b879434420fe42c275a7cd7b39d638fb81ca52b49dc41",
+		AAD: "e4f963f015ffbb99ee3349bbaf7e8e8e6c2a71c230a48f9d59860a29091d2747e01a5ca572347e247d25f56ba7ae8e05cde2be3c97931292c02370208ecd097ef692687fecf2f419d3200162a6480a57dad408a0dfeb492e2c5d",
+		CT: "2097e372950a5e9383c675e89eea1c314f999159f5611344b298cda45e62843716f215f82ee663919c64002a5c198d7878fd3f",
+		Tag: "adbecdb0d5c2224d804d2886ff9a5760",
+	},
+	{
+		Key: "11754cd72aec309bf52f7687212e8957",
+		IV: "3c819d9a9bed087615030b65",
+		PT: "",
+		AAD: "",
+		CT: "",
+		Tag: "250327c674aaf477aef2675748cf6971",
+	},
+	{
+		Key: "77be63708971c4e240d1cb79e8d77feb",
+		IV: "e0e00f19fed7ba0136a797f3",
+		PT: "",
+		AAD: "7a43ec1d9c0a5a78a0b16533a6213cab",
+		CT: "",
+		Tag: "209fcc8d3675ed938e9c7166709dd946",
+	},
+	{
+		Key: "2fb45e5b8f993a2bfebc4b15b533e0b4",
+		IV: "5b05755f984d2b90f94b8027",
+		PT: "",
+		AAD: "e85491b2202caf1d7dce03b97e09331c32473941",
+		CT: "",
+		Tag: "c75b7832b2a2d9bd827412b6ef5769db",
+	},
+	{
+		Key: "99e3e8793e686e571d8285c564f75e2b",
+		IV: "c2dd0ab868da6aa8ad9c0d23",
+		PT: "",
+		AAD: "b668e42d4e444ca8b23cfdd95a9fedd5178aa521144890b093733cf5cf22526c5917ee476541809ac6867a8c399309fc",
+		CT: "",
+		Tag: "3f4fba100eaf1f34b0baadaae9995d85",
+	},
+	{
+		Key: "20b5b6b854e187b058a84d57bc1538b6",
+		IV: "94c1935afc061cbf254b936f",
+		PT: "",
+		AAD: "ca418e71dbf810038174eaa3719b3fcb80531c7110ad9192d105eeaafa15b819ac005668752b344ed1b22faf77048baf03dbddb3b47d6b00e95c4f005e0cc9b7627ccafd3f21b3312aa8d91d3fa0893fe5bff7d44ca46f23afe0",
+		CT: "",
+		Tag: "b37286ebaf4a54e0ffc2a1deafc9f6db",
+	},
+	{
+		Key: "7fddb57453c241d03efbed3ac44e371c",
+		IV: "ee283a3fc75575e33efd4887",
+		PT: "d5de42b461646c255c87bd2962d3b9a2",
+		AAD: "",
+		CT: "2ccda4a5415cb91e135c2a0f78c9b2fd",
+		Tag: "b36d1df9b9d5e596f83e8b7f52971cb3",
+	},
+	{
+		Key: "c939cc13397c1d37de6ae0e1cb7c423c",
+		IV: "b3d8cc017cbb89b39e0f67e2",
+		PT: "c3b3c41f113a31b73d9a5cd432103069",
+		AAD: "24825602bd12a984e0092d3e448eda5f",
+		CT: "93fe7d9e9bfd10348a5606e5cafa7354",
+		Tag: "0032a1dc85f1c9786925a2e71d8272dd",
+	},
+	{
+		Key: "d4a22488f8dd1d5c6c19a7d6ca17964c",
+		IV: "f3d5837f22ac1a0425e0d1d5",
+		PT: "7b43016a16896497fb457be6d2a54122",
+		AAD: "f1c5d424b83f96c6ad8cb28ca0d20e475e023b5a",
+		CT: "c2bd67eef5e95cac27e3b06e3031d0a8",
+		Tag: "f23eacf9d1cdf8737726c58648826e9c",
+	},
+	{
+		Key: "89850dd398e1f1e28443a33d40162664",
+		IV: "e462c58482fe8264aeeb7231",
+		PT: "2805cdefb3ef6cc35cd1f169f98da81a",
+		AAD: "d74e99d1bdaa712864eec422ac507bddbe2b0d4633cd3dff29ce5059b49fe868526c59a2a3a604457bc2afea866e7606",
+		CT: "ba80e244b7fc9025cd031d0f63677e06",
+		Tag: "d84a8c3eac57d1bb0e890a8f461d1065",
+	},
+	{
+		Key: "bd7c5c63b7542b56a00ebe71336a1588",
+		IV: "87721f23ba9c3c8ea5571abc",
+		PT: "de15ddbb1e202161e8a79af6a55ac6f3",
+		AAD: "a6ec8075a0d3370eb7598918f3b93e48444751624997b899a87fa6a9939f844e008aa8b70e9f4c3b1a19d3286bf543e7127bfecba1ad17a5ec53fccc26faecacc4c75369498eaa7d706aef634d0009279b11e4ba6c993e5e9ed9",
+		CT: "41eb28c0fee4d762de972361c863bc80",
+		Tag: "9cb567220d0b252eb97bff46e4b00ff8",
+	},
+	{
+		Key: "fe9bb47deb3a61e423c2231841cfd1fb",
+		IV: "4d328eb776f500a2f7fb47aa",
+		PT: "f1cc3818e421876bb6b8bbd6c9",
+		AAD: "",
+		CT: "b88c5c1977b35b517b0aeae967",
+		Tag: "43fd4727fe5cdb4b5b42818dea7ef8c9",
+	},
+	{
+		Key: "dfefde23c6122bf0370ab5890e804b73",
+		IV: "92d6a8029990670f16de79e2",
+		PT: "64260a8c287de978e96c7521d0",
+		AAD: "a2b16d78251de6c191ce350e5c5ef242",
+		CT: "bf78de948a847c173649d4b4d0",
+		Tag: "9da3829968cdc50794d1c30d41cd4515",
+	},
+	{
+		Key: "fe0121f42e599f88ff02a985403e19bb",
+		IV: "3bb9eb7724cbe1943d43de21",
+		PT: "fd331ca8646091c29f21e5f0a1",
+		AAD: "2662d895035b6519f3510eae0faa3900ad23cfdf",
+		CT: "59fe29b07b0de8d869efbbd9b4",
+		Tag: "d24c3e9c1c73c0af1097e26061c857de",
+	},
+	{
+		Key: "cbd3b8dbfcfb11ce345706e6cd73881a",
+		IV: "dc62bb68d0ec9a5d759d6741",
+		PT: "85f83bf598dfd55bc8bfde2a64",
+		AAD: "0944b661fe6294f3c92abb087ec1b259b032dc4e0c5f28681cbe6e63c2178f474326f35ad3ca80c28e3485e7e5b252c8",
+		CT: "206f6b3bb032dfecd39f8340b1",
+		Tag: "425a21b2ea90580c889134032b914bb5",
+	},
+	{
+		Key: "e5b1e7a94e9e1fda0873571eec713429",
+		IV: "5ddde829a81713346af8e5b7",
+		PT: "850069e5ed768b5dc9ed7ad485",
+		AAD: "b0ce75da427fba93da6d3455b2b440a877599a6d8d6d2d66ee90b5cf9a33baaa8329a9ffaac290e8e33f2af2548c2a8a181b3d4d9f8fac860cc26b0d26b9cc53bc9f405afa73605ebeb376f2d1d7fcb065bab92f20f295556ade",
+		CT: "c211d9079d5562659db01e17d1",
+		Tag: "884893fb035d3d7237d47c363de62bb3",
+	},
+	{
+		Key: "9971071059abc009e4f2bd69869db338",
+		IV: "07a9a95ea3821e9c13c63251",
+		PT: "f54bc3501fed4f6f6dfb5ea80106df0bd836e6826225b75c0222f6e859b35983",
+		AAD: "",
+		CT: "0556c159f84ef36cb1602b4526b12009c775611bffb64dc0d9ca9297cd2c6a01",
+		Tag: "7870d9117f54811a346970f1de090c41",
+	},
+	{
+		Key: "298efa1ccf29cf62ae6824bfc19557fc",
+		IV: "6f58a93fe1d207fae4ed2f6d",
+		PT: "cc38bccd6bc536ad919b1395f5d63801f99f8068d65ca5ac63872daf16b93901",
+		AAD: "021fafd238463973ffe80256e5b1c6b1",
+		CT: "dfce4e9cd291103d7fe4e63351d9e79d3dfd391e3267104658212da96521b7db",
+		Tag: "542465ef599316f73a7a560509a2d9f2",
+	},
+	{
+		Key: "fedc7155192d00b23cdd98750db9ebba",
+		IV: "a76b74f55c1a1756a08338b1",
+		PT: "6831435b8857daf1c513b148820d13b5a72cc490bda79a98a6f520d8763c39d1",
+		AAD: "2ad206c4176e7e552aa08836886816fafa77e759",
+		CT: "15823805da89a1923bfc1d6f87784d56bad1128b4dffdbdeefbb2fa562c35e68",
+		Tag: "d23dc455ced49887c717e8eabeec2984",
+	},
+	{
+		Key: "48b7f337cdf9252687ecc760bd8ec184",
+		IV: "3e894ebb16ce82a53c3e05b2",
+		PT: "bb2bac67a4709430c39c2eb9acfabc0d456c80d30aa1734e57997d548a8f0603",
+		AAD: "7d924cfd37b3d046a96eb5e132042405c8731e06509787bbeb41f258275746495e884d69871f77634c584bb007312234",
+		CT: "d263228b8ce051f67e9baf1ce7df97d10cd5f3bc972362055130c7d13c3ab2e7",
+		Tag: "71446737ca1fa92e6d026d7d2ed1aa9c",
+	},
+	{
+		Key: "8fbf7ca12fd525dde91e625873fe51c2",
+		IV: "200bea517b9790a1cfadaf5e",
+		PT: "39d3e6277c4b4963840d1642e6faae0a5be2da97f61c4e55bb57ce021903d4c4",
+		AAD: "a414c07fe2e60bec9ccc409e9e899c6fe60580bb2607c861f7f08523e69cda1b9c3a711d1d9c35091771e4c950b9996d0ad04f2e00d1b3105853542a96e09ffffc2ec80f8cf88728f594f0aeb14f98a688234e8bfbf70327b364",
+		CT: "fe678ef76f69ac95db553b6dadd5a07a9dc8e151fe6a9fa3a1cd621636b87868",
+		Tag: "7c860774f88332b9a7ce6bbd0272a727",
+	},
+	{
+		Key: "594157ec4693202b030f33798b07176d",
+		IV: "49b12054082660803a1df3df",
+		PT: "3feef98a976a1bd634f364ac428bb59cd51fb159ec1789946918dbd50ea6c9d594a3a31a5269b0da6936c29d063a5fa2cc8a1c",
+		AAD: "",
+		CT: "c1b7a46a335f23d65b8db4008a49796906e225474f4fe7d39e55bf2efd97fd82d4167de082ae30fa01e465a601235d8d68bc69",
+		Tag: "ba92d3661ce8b04687e8788d55417dc2",
+	},
+	{
+		Key: "b61553bb854895b929751cd0c5f80384",
+		IV: "8863f999ae64e55d0bbd7457",
+		PT: "9b1b113217d0c4ea7943cf123c69c6ad2e3c97368c51c9754145d155dde1ee8640c8cafff17a5c9737d26a137eee4bf369096d",
+		AAD: "d914b5f2d1b08ce53ea59cb310587245",
+		CT: "acfab4632b8a25805112f13d85e082bc89dc49bd92164fa8a2dad242c3a1b2f2696f2fdff579025f3f146ea97da3e47dc34b65",
+		Tag: "5d9b5f4a9868c1c69cbd6fd851f01340",
+	},
+	{
+		Key: "fe47fcce5fc32665d2ae399e4eec72ba",
+		IV: "5adb9609dbaeb58cbd6e7275",
+		PT: "7c0e88c88899a779228465074797cd4c2e1498d259b54390b85e3eef1c02df60e743f1b840382c4bccaf3bafb4ca8429bea063",
+		AAD: "88319d6e1d3ffa5f987199166c8a9b56c2aeba5a",
+		CT: "98f4826f05a265e6dd2be82db241c0fbbbf9ffb1c173aa83964b7cf5393043736365253ddbc5db8778371495da76d269e5db3e",
+		Tag: "291ef1982e4defedaa2249f898556b47",
+	},
+	{
+		Key: "3c50622868f450aa0928990c15e1eb36",
+		IV: "811d5290768d57e7d87bb6c7",
+		PT: "edd0a8f82833e919740fe2bf9edecf4ac86c72dc89490cef7b6983aaaf99fc856c5cc87d63f98a7c861bf3271fea6da86a15ab",
+		AAD: "dae2c7e0a3d3fd2bc04eca19b15178a003b5cf84890c28c2a615f20f8adb427f70698c12b2ef87780c1193fbb8cd1674",
+		CT: "a51425b0608d3b4b46d4ec05ca1ddaf02bdd2089ae0554ecfb2a1c84c63d82dc71ddb9ab1b1f0b49de2ad27c2b5173e7000aa6",
+		Tag: "bd9b5efca48008cd973a4f7d2c723844",
+	},
+	{
+		Key: "2c1f21cf0f6fb3661943155c3e3d8492",
+		IV: "23cb5ff362e22426984d1907",
+		PT: "42f758836986954db44bf37c6ef5e4ac0adaf38f27252a1b82d02ea949c8a1a2dbc0d68b5615ba7c1220ff6510e259f06655d8",
+		AAD: "5d3624879d35e46849953e45a32a624d6a6c536ed9857c613b572b0333e701557a713e3f010ecdf9a6bd6c9e3e44b065208645aff4aabee611b391528514170084ccf587177f4488f33cfb5e979e42b6e1cfc0a60238982a7aec",
+		CT: "81824f0e0d523db30d3da369fdc0d60894c7a0a20646dd015073ad2732bd989b14a222b6ad57af43e1895df9dca2a5344a62cc",
+		Tag: "57a3ee28136e94c74838997ae9823f3a",
+	},
 ];
 
-describe('insecure IV AES-GCM', () => {
-  for (const prependIv of [true, false]) {
-    describe(`${prependIv ? 'with' : 'without'} a prepended IV`, () => {
-      it('should encrypt and decrypt randomly generated vectors successfully',
-         async () => {
-           const aad: Uint8Array =
-               crypto.getRandomValues(new Uint8Array(AAD_LENGTH));
-           for (const keySize of KEY_SIZE_IN_BYTES) {
-             const key: Uint8Array =
-                 crypto.getRandomValues(new Uint8Array(keySize));
-             const gcm = await insecureIvAesGcmFromRawKey({key, prependIv});
-             for (let messageSize = 0; messageSize < 75; messageSize++) {
-               const message: Uint8Array =
-                   crypto.getRandomValues(new Uint8Array(messageSize));
-               const iv: Uint8Array =
-                   crypto.getRandomValues(new Uint8Array(IV_SIZE_IN_BYTES));
-               const ciphertext: Uint8Array =
-                   await gcm.encrypt(iv, message, aad);
-               const decrypted: Uint8Array =
-                   await gcm.decrypt(iv, ciphertext, aad);
-               expect(message).toEqual(decrypted);
-             }
-           }
-         });
+describe("insecure IV AES-GCM", () => {
+	for (const prependIv of [true, false]) {
+		describe(`${prependIv ? "with" : "without"} a prepended IV`, () => {
+			it("should encrypt and decrypt randomly generated vectors successfully", async () => {
+				const aad: Uint8Array = crypto.getRandomValues(
+					new Uint8Array(AAD_LENGTH)
+				);
+				for (const keySize of KEY_SIZE_IN_BYTES) {
+					const key: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(keySize)
+					);
+					const gcm = await insecureIvAesGcmFromRawKey({
+						key,
+						prependIv,
+					});
+					for (let messageSize = 0; messageSize < 75; messageSize++) {
+						const message: Uint8Array = crypto.getRandomValues(
+							new Uint8Array(messageSize)
+						);
+						const iv: Uint8Array = crypto.getRandomValues(
+							new Uint8Array(IV_SIZE_IN_BYTES)
+						);
+						const ciphertext: Uint8Array = await gcm.encrypt(
+							iv,
+							message,
+							aad
+						);
+						const decrypted: Uint8Array = await gcm.decrypt(
+							iv,
+							ciphertext,
+							aad
+						);
+						expect(message).toEqual(decrypted);
+					}
+				}
+			});
 
-      it('should encrypt and decrypt NIST test vectors successfully',
-         async () => {
-           for (const testInfo of NIST_TEST_VECTORS) {
-             const gcm = await insecureIvAesGcmFromRawKey(
-                 {key: fromHex(testInfo.Key), prependIv});
+			it("should encrypt and decrypt NIST test vectors successfully", async () => {
+				for (const testInfo of NIST_TEST_VECTORS) {
+					const gcm = await insecureIvAesGcmFromRawKey({
+						key: fromHex(testInfo.Key),
+						prependIv,
+					});
 
-             const iv = fromHex(testInfo.IV);
-             const message = fromHex(testInfo.PT);
-             const aad = fromHex(testInfo.AAD);
+					const iv = fromHex(testInfo.IV);
+					const message = fromHex(testInfo.PT);
+					const aad = fromHex(testInfo.AAD);
 
-             const ciphertext: Uint8Array = await gcm.encrypt(iv, message, aad);
-             let expectedCipherText = testInfo.CT + testInfo.Tag;
-             if (prependIv) {
-               expectedCipherText = testInfo.IV + expectedCipherText;
-             }
-             expect(ciphertext).toEqual(fromHex(expectedCipherText));
+					const ciphertext: Uint8Array = await gcm.encrypt(
+						iv,
+						message,
+						aad
+					);
+					let expectedCipherText = testInfo.CT + testInfo.Tag;
+					if (prependIv) {
+						expectedCipherText = testInfo.IV + expectedCipherText;
+					}
+					expect(ciphertext).toEqual(fromHex(expectedCipherText));
 
-             const plaintext =
-                 await gcm.decrypt(iv, fromHex(expectedCipherText), aad);
-             expect(plaintext).toEqual(message);
-           }
-         });
+					const plaintext = await gcm.decrypt(
+						iv,
+						fromHex(expectedCipherText),
+						aad
+					);
+					expect(plaintext).toEqual(message);
+				}
+			});
 
-      it('should generate different ciphertexts for different IVs',
-         async () => {
-           const key: Uint8Array = crypto.getRandomValues(new Uint8Array(16));
-           const aad: Uint8Array =
-               crypto.getRandomValues(new Uint8Array(AAD_LENGTH));
-           const gcm = await insecureIvAesGcmFromRawKey({key, prependIv});
+			it("should generate different ciphertexts for different IVs", async () => {
+				const key: Uint8Array = crypto.getRandomValues(
+					new Uint8Array(16)
+				);
+				const aad: Uint8Array = crypto.getRandomValues(
+					new Uint8Array(AAD_LENGTH)
+				);
+				const gcm = await insecureIvAesGcmFromRawKey({
+					key,
+					prependIv,
+				});
 
-           const message = crypto.getRandomValues(new Uint8Array(32));
-           const ciphertexts = new Set<string>();
+				const message = crypto.getRandomValues(new Uint8Array(32));
+				const ciphertexts = new Set<string>();
 
-           for (let i = 0; i < 100; i++) {
-             const iv: Uint8Array =
-                 crypto.getRandomValues(new Uint8Array(IV_SIZE_IN_BYTES));
-             const ciphertext: Uint8Array = await gcm.encrypt(iv, message, aad);
-             const ciphertextString: string = toHex(ciphertext);
-             expect(ciphertexts).not.toContain(ciphertextString);
-             ciphertexts.add(ciphertextString);
-           }
-         });
+				for (let i = 0; i < 100; i++) {
+					const iv: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(IV_SIZE_IN_BYTES)
+					);
+					const ciphertext: Uint8Array = await gcm.encrypt(
+						iv,
+						message,
+						aad
+					);
+					const ciphertextString: string = toHex(ciphertext);
+					expect(ciphertexts).not.toContain(ciphertextString);
+					ciphertexts.add(ciphertextString);
+				}
+			});
 
-      it('should fail with a modified ciphertext', async () => {
-        const aad: Uint8Array =
-            crypto.getRandomValues(new Uint8Array(AAD_LENGTH));
-        for (const keySize of KEY_SIZE_IN_BYTES) {
-          const key: Uint8Array =
-              crypto.getRandomValues(new Uint8Array(keySize));
-          const gcm = await insecureIvAesGcmFromRawKey({key, prependIv});
-          const message = crypto.getRandomValues(new Uint8Array(32));
-          const iv: Uint8Array =
-              crypto.getRandomValues(new Uint8Array(IV_SIZE_IN_BYTES));
-          const ciphertext: Uint8Array = await gcm.encrypt(iv, message, aad);
-          // modify the ciphertext by toggling its first and last bits
-          ciphertext[0] ^= 1;
-          ciphertext[ciphertext.length - 1] ^= 1;
-          await expectAsync(gcm.decrypt(iv, ciphertext, aad))
-              .toBeRejectedWithError(SecurityException);
-        }
-      });
+			it("should fail with a modified ciphertext", async () => {
+				const aad: Uint8Array = crypto.getRandomValues(
+					new Uint8Array(AAD_LENGTH)
+				);
+				for (const keySize of KEY_SIZE_IN_BYTES) {
+					const key: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(keySize)
+					);
+					const gcm = await insecureIvAesGcmFromRawKey({
+						key,
+						prependIv,
+					});
+					const message = crypto.getRandomValues(new Uint8Array(32));
+					const iv: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(IV_SIZE_IN_BYTES)
+					);
+					const ciphertext: Uint8Array = await gcm.encrypt(
+						iv,
+						message,
+						aad
+					);
+					// modify the ciphertext by toggling its first and last bits
+					ciphertext[0] ^= 1;
+					ciphertext[ciphertext.length - 1] ^= 1;
+					await expectAsync(
+						gcm.decrypt(iv, ciphertext, aad)
+					).toBeRejectedWithError(SecurityException);
+				}
+			});
 
-      it('should fail with a truncated ciphertext', async () => {
-        const aad: Uint8Array =
-            crypto.getRandomValues(new Uint8Array(AAD_LENGTH));
-        for (const keySize of KEY_SIZE_IN_BYTES) {
-          const key: Uint8Array =
-              crypto.getRandomValues(new Uint8Array(keySize));
-          const gcm = await insecureIvAesGcmFromRawKey({key, prependIv});
-          const message = new Uint8Array(0);
-          const iv: Uint8Array =
-              crypto.getRandomValues(new Uint8Array(IV_SIZE_IN_BYTES));
-          const ciphertext: Uint8Array = await gcm.encrypt(iv, message, aad);
-          const truncated = ciphertext.subarray(0, ciphertext.length - 1);
-          await expectAsync(gcm.decrypt(iv, truncated, aad))
-              .toBeRejectedWithError(SecurityException);
-        }
-      });
-    });
-  }
+			it("should fail with a truncated ciphertext", async () => {
+				const aad: Uint8Array = crypto.getRandomValues(
+					new Uint8Array(AAD_LENGTH)
+				);
+				for (const keySize of KEY_SIZE_IN_BYTES) {
+					const key: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(keySize)
+					);
+					const gcm = await insecureIvAesGcmFromRawKey({
+						key,
+						prependIv,
+					});
+					const message = new Uint8Array(0);
+					const iv: Uint8Array = crypto.getRandomValues(
+						new Uint8Array(IV_SIZE_IN_BYTES)
+					);
+					const ciphertext: Uint8Array = await gcm.encrypt(
+						iv,
+						message,
+						aad
+					);
+					const truncated = ciphertext.subarray(
+						0,
+						ciphertext.length - 1
+					);
+					await expectAsync(
+						gcm.decrypt(iv, truncated, aad)
+					).toBeRejectedWithError(SecurityException);
+				}
+			});
+		});
+	}
 });

--- a/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.ts
+++ b/javascript/hybrid/ecies_aead_hkdf_private_key_manager_test.ts
@@ -4,505 +4,616 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {PbAesCtrKeyFormat, PbEciesAeadDemParams, PbEciesAeadHkdfKeyFormat, PbEciesAeadHkdfParams, PbEciesAeadHkdfPrivateKey, PbEciesAeadHkdfPublicKey, PbEciesHkdfKemParams, PbEllipticCurveType, PbHashType, PbKeyData, PbKeyTemplate, PbPointFormat} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
-import {assertExists, assertInstanceof, assertMessageEquals} from '../testing/internal/test_utils';
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import {
+	PbAesCtrKeyFormat,
+	PbEciesAeadDemParams,
+	PbEciesAeadHkdfKeyFormat,
+	PbEciesAeadHkdfParams,
+	PbEciesAeadHkdfPrivateKey,
+	PbEciesAeadHkdfPublicKey,
+	PbEciesHkdfKemParams,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyData,
+	PbKeyTemplate,
+	PbPointFormat,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
+import {
+	assertExists,
+	assertInstanceof,
+	assertMessageEquals,
+} from "../testing/internal/test_utils";
 
-import {EciesAeadHkdfPrivateKeyManager} from './ecies_aead_hkdf_private_key_manager';
-import {EciesAeadHkdfPublicKeyManager} from './ecies_aead_hkdf_public_key_manager';
-import {HybridDecrypt} from './internal/hybrid_decrypt';
-import {HybridEncrypt} from './internal/hybrid_encrypt';
+import { EciesAeadHkdfPrivateKeyManager } from "./ecies_aead_hkdf_private_key_manager";
+import { EciesAeadHkdfPublicKeyManager } from "./ecies_aead_hkdf_public_key_manager";
+import { HybridDecrypt } from "./internal/hybrid_decrypt";
+import { HybridEncrypt } from "./internal/hybrid_encrypt";
 
 const PRIVATE_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EciesAeadHkdfPrivateKey';
+	"type.googleapis.com/google.crypto.tink.EciesAeadHkdfPrivateKey";
 const PRIVATE_KEY_MATERIAL_TYPE = PbKeyData.KeyMaterialType.ASYMMETRIC_PRIVATE;
 const VERSION = 0;
 const PRIVATE_KEY_MANAGER_PRIMITIVE = HybridDecrypt;
 
 const PUBLIC_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey';
+	"type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey";
 const PUBLIC_KEY_MATERIAL_TYPE = PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC;
 const PUBLIC_KEY_MANAGER_PRIMITIVE = HybridEncrypt;
 
-describe('ecies aead hkdf private key manager test', function() {
-  beforeEach(function() {
-    AeadConfig.register();
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies aead hkdf private key manager test", () => {
+	beforeEach(() => {
+		AeadConfig.register();
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new key, empty key format', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key, empty key format", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidSerializedKeyFormat()
+			);
+		}
+	});
 
-  it('new key, invalid serialized key format', async function() {
-    const invalidSerializedKeyFormat = new Uint8Array(0);
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key, invalid serialized key format", async () => {
+		const invalidSerializedKeyFormat = new Uint8Array(0);
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidSerializedKeyFormat()
+			);
+		}
+	});
 
-  it('new key, unsupported key format proto', async function() {
-    const unsupportedKeyFormatProto = new PbAesCtrKeyFormat();
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key, unsupported key format proto", async () => {
+		const unsupportedKeyFormatProto = new PbAesCtrKeyFormat();
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyFormat());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyFormat());
+		}
+	});
 
-  it('new key, invalid format, missing params', async function() {
-    const invalidFormat = new PbEciesAeadHkdfKeyFormat();
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key, invalid format, missing params", async () => {
+		const invalidFormat = new PbEciesAeadHkdfKeyFormat();
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidKeyFormatMissingParams());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidKeyFormatMissingParams()
+			);
+		}
+	});
 
-  it('new key, invalid format, invalid params', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key, invalid format, invalid params", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    // unknown point format
-    const invalidFormat = createKeyFormat();
-    invalidFormat.getParams()?.setEcPointFormat(PbPointFormat.UNKNOWN_FORMAT);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
-    }
-    invalidFormat.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
+		// unknown point format
+		const invalidFormat = createKeyFormat();
+		invalidFormat
+			.getParams()
+			?.setEcPointFormat(PbPointFormat.UNKNOWN_FORMAT);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
+		}
+		invalidFormat.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
 
-    // missing KEM params
-    invalidFormat.getParams()?.setKemParams(null);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKemParams());
-    }
-    invalidFormat.getParams()?.setKemParams(createKemParams());
+		// missing KEM params
+		invalidFormat.getParams()?.setKemParams(null);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKemParams());
+		}
+		invalidFormat.getParams()?.setKemParams(createKemParams());
 
-    // unsupported AEAD template
-    const templateTypeUrl = 'UNSUPPORTED_KEY_TYPE_URL';
-    invalidFormat.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(
-        templateTypeUrl);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyTemplate(templateTypeUrl));
-    }
-  });
+		// unsupported AEAD template
+		const templateTypeUrl = "UNSUPPORTED_KEY_TYPE_URL";
+		invalidFormat
+			.getParams()
+			?.getDemParams()
+			?.getAeadDem()
+			?.setTypeUrl(templateTypeUrl);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyTemplate(templateTypeUrl)
+			);
+		}
+	});
 
-  it('new key, via key format', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    for (const keyFormat of keyFormats) {
-      const key = await manager.getKeyFactory().newKey(keyFormat);
+	it("new key, via key format", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		for (const keyFormat of keyFormats) {
+			const key = await manager.getKeyFactory().newKey(keyFormat);
 
-      expect(key.getPublicKey()?.getParams()).toEqual(keyFormat.getParams());
-      // The keys are tested more in tests for getPrimitive method below, where
-      // the primitive based on the created key is tested.
-    }
-  });
+			expect(key.getPublicKey()?.getParams()).toEqual(
+				keyFormat.getParams()
+			);
+			// The keys are tested more in tests for getPrimitive method below, where
+			// the primitive based on the created key is tested.
+		}
+	});
 
-  it('new key data, invalid serialized key format', async function() {
-    const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("new key data, invalid serialized key format", async () => {
+		const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    const serializedKeyFormatsLength = serializedKeyFormats.length;
-    for (let i = 0; i < serializedKeyFormatsLength; i++) {
-      try {
-        await manager.getKeyFactory().newKeyData(serializedKeyFormats[i]);
-        fail(
-            'An exception should be thrown for the string: ' +
-            serializedKeyFormats[i]);
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-        continue;
-      }
-    }
-  });
+		const serializedKeyFormatsLength = serializedKeyFormats.length;
+		for (let i = 0; i < serializedKeyFormatsLength; i++) {
+			try {
+				await manager
+					.getKeyFactory()
+					.newKeyData(serializedKeyFormats[i]);
+				fail(
+					"An exception should be thrown for the string: " +
+						serializedKeyFormats[i]
+				);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					ExceptionText.invalidSerializedKeyFormat()
+				);
+				continue;
+			}
+		}
+	});
 
-  it('new key data, from valid key format', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    for (const keyFormat of keyFormats) {
-      const serializedKeyFormat = keyFormat.serializeBinary();
-      const keyData =
-          await manager.getKeyFactory().newKeyData(serializedKeyFormat);
-      expect(keyData.getTypeUrl()).toBe(PRIVATE_KEY_TYPE);
-      expect(keyData.getKeyMaterialType()).toBe(PRIVATE_KEY_MATERIAL_TYPE);
+	it("new key data, from valid key format", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		for (const keyFormat of keyFormats) {
+			const serializedKeyFormat = keyFormat.serializeBinary();
+			const keyData = await manager
+				.getKeyFactory()
+				.newKeyData(serializedKeyFormat);
+			expect(keyData.getTypeUrl()).toBe(PRIVATE_KEY_TYPE);
+			expect(keyData.getKeyMaterialType()).toBe(
+				PRIVATE_KEY_MATERIAL_TYPE
+			);
 
-      const key =
-          PbEciesAeadHkdfPrivateKey.deserializeBinary(keyData.getValue());
-      assertMessageEquals(
-          key.getPublicKey()?.getParams()!, keyFormat.getParams()!);
-      // The keys are tested more in tests for getPrimitive method below, where
-      // the primitive based on the created key is tested.
-    }
-  });
+			const key = PbEciesAeadHkdfPrivateKey.deserializeBinary(
+				keyData.getValue()
+			);
+			assertMessageEquals(
+				key.getPublicKey()?.getParams()!,
+				keyFormat.getParams()!
+			);
+			// The keys are tested more in tests for getPrimitive method below, where
+			// the primitive based on the created key is tested.
+		}
+	});
 
-  it('get public key data, invalid private key serialization', function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
+	it("get public key data, invalid private key serialization", () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
 
-    const privateKey = new Uint8Array([0, 1]);  // not a serialized private key
-    try {
-      const factory = manager.getKeyFactory();
-      factory.getPublicKeyData(privateKey);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-    }
-  });
+		const privateKey = new Uint8Array([0, 1]); // not a serialized private key
+		try {
+			const factory = manager.getKeyFactory();
+			factory.getPublicKeyData(privateKey);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+		}
+	});
 
-  it('get public key data, should work', async function() {
-    const keyFormat = createKeyFormat();
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const privateKey = await manager.getKeyFactory().newKey(keyFormat);
-    const factory = manager.getKeyFactory();
-    const publicKeyData =
-        factory.getPublicKeyData(privateKey.serializeBinary());
+	it("get public key data, should work", async () => {
+		const keyFormat = createKeyFormat();
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const privateKey = await manager.getKeyFactory().newKey(keyFormat);
+		const factory = manager.getKeyFactory();
+		const publicKeyData = factory.getPublicKeyData(
+			privateKey.serializeBinary()
+		);
 
-    expect(publicKeyData.getTypeUrl()).toBe(PUBLIC_KEY_TYPE);
-    expect(publicKeyData.getKeyMaterialType()).toBe(PUBLIC_KEY_MATERIAL_TYPE);
-    const publicKey =
-        PbEciesAeadHkdfPublicKey.deserializeBinary(publicKeyData.getValue());
-    expect(publicKey.getVersion())
-        .toEqual(assertExists(privateKey.getPublicKey()).getVersion());
-    assertMessageEquals(
-        publicKey.getParams()!,
-        assertExists(privateKey.getPublicKey()).getParams()!);
-    expect(bytesAsU8(publicKey.getX()))
-        .toEqual(bytesAsU8(assertExists(privateKey.getPublicKey()).getX()));
-    expect(bytesAsU8(publicKey.getY()))
-        .toEqual(bytesAsU8(assertExists(privateKey.getPublicKey()).getY()));
-  });
+		expect(publicKeyData.getTypeUrl()).toBe(PUBLIC_KEY_TYPE);
+		expect(publicKeyData.getKeyMaterialType()).toBe(
+			PUBLIC_KEY_MATERIAL_TYPE
+		);
+		const publicKey = PbEciesAeadHkdfPublicKey.deserializeBinary(
+			publicKeyData.getValue()
+		);
+		expect(publicKey.getVersion()).toEqual(
+			assertExists(privateKey.getPublicKey()).getVersion()
+		);
+		assertMessageEquals(
+			publicKey.getParams()!,
+			assertExists(privateKey.getPublicKey()).getParams()!
+		);
+		expect(bytesAsU8(publicKey.getX())).toEqual(
+			bytesAsU8(assertExists(privateKey.getPublicKey()).getX())
+		);
+		expect(bytesAsU8(publicKey.getY())).toEqual(
+			bytesAsU8(assertExists(privateKey.getPublicKey()).getY())
+		);
+	});
 
-  it('get primitive, unsupported key data type', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const keyData =
-        (await manager.getKeyFactory().newKeyData(keyFormat.serializeBinary()))
-            .setTypeUrl('unsupported_key_type_url');
+	it("get primitive, unsupported key data type", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const keyData = (
+			await manager
+				.getKeyFactory()
+				.newKeyData(keyFormat.serializeBinary())
+		).setTypeUrl("unsupported_key_type_url");
 
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyType(keyData.getTypeUrl()));
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyType(keyData.getTypeUrl())
+			);
+		}
+	});
 
-  it('get primitive, unsupported key type', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const key = new PbEciesAeadHkdfPublicKey();
+	it("get primitive, unsupported key type", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const key = new PbEciesAeadHkdfPublicKey();
 
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
+		}
+	});
 
-  it('get primitive, high version', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const version = manager.getVersion() + 1;
-    const keyFormat = createKeyFormat();
-    const key = assertInstanceof(
-                    await manager.getKeyFactory().newKey(keyFormat),
-                    PbEciesAeadHkdfPrivateKey)
-                    .setVersion(version);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
-    }
-  });
+	it("get primitive, high version", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const version = manager.getVersion() + 1;
+		const keyFormat = createKeyFormat();
+		const key = assertInstanceof(
+			await manager.getKeyFactory().newKey(keyFormat),
+			PbEciesAeadHkdfPrivateKey
+		).setVersion(version);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
+		}
+	});
 
-  it('get primitive, invalid params', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const key = assertInstanceof(
-        await manager.getKeyFactory().newKey(keyFormat),
-        PbEciesAeadHkdfPrivateKey);
+	it("get primitive, invalid params", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const key = assertInstanceof(
+			await manager.getKeyFactory().newKey(keyFormat),
+			PbEciesAeadHkdfPrivateKey
+		);
 
-    // missing KEM params
-    key.getPublicKey()?.getParams()?.setKemParams(null);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKemParams());
-    }
-    key.getPublicKey()?.getParams()?.setKemParams(createKemParams());
+		// missing KEM params
+		key.getPublicKey()?.getParams()?.setKemParams(null);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKemParams());
+		}
+		key.getPublicKey()?.getParams()?.setKemParams(createKemParams());
 
-    // unsupported AEAD key template type URL
-    const templateTypeUrl = 'UNSUPPORTED_KEY_TYPE_URL';
-    key.getPublicKey()?.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(
-        templateTypeUrl);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyTemplate(templateTypeUrl));
-    }
-  });
+		// unsupported AEAD key template type URL
+		const templateTypeUrl = "UNSUPPORTED_KEY_TYPE_URL";
+		key.getPublicKey()
+			?.getParams()
+			?.getDemParams()
+			?.getAeadDem()
+			?.setTypeUrl(templateTypeUrl);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyTemplate(templateTypeUrl)
+			);
+		}
+	});
 
-  it('get primitive, invalid serialized key', async function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const keyData =
-        await manager.getKeyFactory().newKeyData(keyFormat.serializeBinary());
+	it("get primitive, invalid serialized key", async () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const keyData = await manager
+			.getKeyFactory()
+			.newKeyData(keyFormat.serializeBinary());
 
+		for (let i = 0; i < 2; ++i) {
+			// Set the value of keyData to something which is not a serialization of a
+			// proper key.
+			keyData.setValue(new Uint8Array(i));
+			try {
+				await manager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					keyData
+				);
+				fail("An exception should be thrown " + i.toString());
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+			}
+		}
+	});
 
-    for (let i = 0; i < 2; ++i) {
-      // Set the value of keyData to something which is not a serialization of a
-      // proper key.
-      keyData.setValue(new Uint8Array(i));
-      try {
-        await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
-        fail('An exception should be thrown ' + i.toString());
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-      }
-    }
-  });
+	it("get primitive, from key", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const privateKeyManager = new EciesAeadHkdfPrivateKeyManager();
+		const publicKeyManager = new EciesAeadHkdfPublicKeyManager();
 
-  it('get primitive, from key', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const privateKeyManager = new EciesAeadHkdfPrivateKeyManager();
-    const publicKeyManager = new EciesAeadHkdfPublicKeyManager();
+		for (const keyFormat of keyFormats) {
+			const key = assertInstanceof(
+				await privateKeyManager.getKeyFactory().newKey(keyFormat),
+				PbEciesAeadHkdfPrivateKey
+			);
+			const hybridEncrypt: HybridEncrypt = assertExists(
+				await publicKeyManager.getPrimitive(
+					PUBLIC_KEY_MANAGER_PRIMITIVE,
+					assertExists(key.getPublicKey())
+				)
+			);
+			const hybridDecrypt: HybridDecrypt = assertExists(
+				await privateKeyManager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					key
+				)
+			);
 
-    for (const keyFormat of keyFormats) {
-      const key = assertInstanceof(
-          await privateKeyManager.getKeyFactory().newKey(keyFormat),
-          PbEciesAeadHkdfPrivateKey);
-      const hybridEncrypt: HybridEncrypt =
-          assertExists(await publicKeyManager.getPrimitive(
-              PUBLIC_KEY_MANAGER_PRIMITIVE, assertExists(key.getPublicKey())));
-      const hybridDecrypt: HybridDecrypt =
-          assertExists(await privateKeyManager.getPrimitive(
-              PRIVATE_KEY_MANAGER_PRIMITIVE, key));
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await hybridEncrypt.encrypt(plaintext);
+			const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
 
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await hybridEncrypt.encrypt(plaintext);
-      const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
+			expect(decryptedCiphertext).toEqual(plaintext);
+		}
+	});
 
-      expect(decryptedCiphertext).toEqual(plaintext);
-    }
-  });
+	it("get primitive, from key data", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const privateKeyManager = new EciesAeadHkdfPrivateKeyManager();
+		const publicKeyManager = new EciesAeadHkdfPublicKeyManager();
 
-  it('get primitive, from key data', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const privateKeyManager = new EciesAeadHkdfPrivateKeyManager();
-    const publicKeyManager = new EciesAeadHkdfPublicKeyManager();
+		for (const keyFormat of keyFormats) {
+			const serializedKeyFormat = keyFormat.serializeBinary();
+			const keyData = await privateKeyManager
+				.getKeyFactory()
+				.newKeyData(serializedKeyFormat);
+			const factory = privateKeyManager.getKeyFactory();
+			const publicKeyData = factory.getPublicKeyData(
+				bytesAsU8(keyData.getValue())
+			);
+			const hybridEncrypt: HybridEncrypt = assertExists(
+				await publicKeyManager.getPrimitive(
+					PUBLIC_KEY_MANAGER_PRIMITIVE,
+					publicKeyData
+				)
+			);
+			const hybridDecrypt: HybridDecrypt = assertExists(
+				await privateKeyManager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					keyData
+				)
+			);
 
-    for (const keyFormat of keyFormats) {
-      const serializedKeyFormat = keyFormat.serializeBinary();
-      const keyData = await privateKeyManager.getKeyFactory().newKeyData(
-          serializedKeyFormat);
-      const factory = privateKeyManager.getKeyFactory();
-      const publicKeyData =
-          factory.getPublicKeyData(bytesAsU8(keyData.getValue()));
-      const hybridEncrypt: HybridEncrypt =
-          assertExists(await publicKeyManager.getPrimitive(
-              PUBLIC_KEY_MANAGER_PRIMITIVE, publicKeyData));
-      const hybridDecrypt: HybridDecrypt =
-          assertExists(await privateKeyManager.getPrimitive(
-              PRIVATE_KEY_MANAGER_PRIMITIVE, keyData));
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await hybridEncrypt.encrypt(plaintext);
+			const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
 
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await hybridEncrypt.encrypt(plaintext);
-      const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
+			expect(decryptedCiphertext).toEqual(plaintext);
+		}
+	});
 
-      expect(decryptedCiphertext).toEqual(plaintext);
-    }
-  });
+	it("does support", () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		expect(manager.doesSupport(PRIVATE_KEY_TYPE)).toBe(true);
+	});
 
-  it('does support', function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    expect(manager.doesSupport(PRIVATE_KEY_TYPE)).toBe(true);
-  });
+	it("get key type", () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		expect(manager.getKeyType()).toBe(PRIVATE_KEY_TYPE);
+	});
 
-  it('get key type', function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    expect(manager.getKeyType()).toBe(PRIVATE_KEY_TYPE);
-  });
+	it("get primitive type", () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		expect(manager.getPrimitiveType()).toBe(PRIVATE_KEY_MANAGER_PRIMITIVE);
+	});
 
-  it('get primitive type', function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    expect(manager.getPrimitiveType()).toBe(PRIVATE_KEY_MANAGER_PRIMITIVE);
-  });
-
-  it('get version', function() {
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    expect(manager.getVersion()).toBe(VERSION);
-  });
+	it("get version", () => {
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		expect(manager.getVersion()).toBe(VERSION);
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static nullKeyFormat(): string {
-    return 'SecurityException: Key format has to be non-null.';
-  }
+	static nullKeyFormat(): string {
+		return "SecurityException: Key format has to be non-null.";
+	}
 
-  static invalidSerializedKeyFormat(): string {
-    return 'SecurityException: Input cannot be parsed as ' + PRIVATE_KEY_TYPE +
-        ' key format proto.';
-  }
+	static invalidSerializedKeyFormat(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			PRIVATE_KEY_TYPE +
+			" key format proto."
+		);
+	}
 
-  static unsupportedPrimitive(): string {
-    return 'SecurityException: Requested primitive type which is not supported by ' +
-        'this key manager.';
-  }
+	static unsupportedPrimitive(): string {
+		return (
+			"SecurityException: Requested primitive type which is not supported by " +
+			"this key manager."
+		);
+	}
 
-  static unsupportedKeyFormat(): string {
-    return 'SecurityException: Expected ' + PRIVATE_KEY_TYPE +
-        ' key format proto.';
-  }
+	static unsupportedKeyFormat(): string {
+		return (
+			"SecurityException: Expected " +
+			PRIVATE_KEY_TYPE +
+			" key format proto."
+		);
+	}
 
-  static unsupportedKeyType(opt_requestedKeyType?: string): string {
-    const prefix = 'SecurityException: Key type';
-    const suffix =
-        'is not supported. This key manager supports ' + PRIVATE_KEY_TYPE + '.';
-    if (opt_requestedKeyType) {
-      return prefix + ' ' + opt_requestedKeyType + ' ' + suffix;
-    } else {
-      return prefix + ' ' + suffix;
-    }
-  }
+	static unsupportedKeyType(opt_requestedKeyType?: string): string {
+		const prefix = "SecurityException: Key type";
+		const suffix =
+			"is not supported. This key manager supports " +
+			PRIVATE_KEY_TYPE +
+			".";
+		if (opt_requestedKeyType) {
+			return prefix + " " + opt_requestedKeyType + " " + suffix;
+		} else {
+			return prefix + " " + suffix;
+		}
+	}
 
-  static versionOutOfBounds(): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        VERSION + '.';
-  }
+	static versionOutOfBounds(): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			VERSION +
+			"."
+		);
+	}
 
-  static invalidKeyFormatMissingParams(): string {
-    return 'SecurityException: Invalid key format - missing key params.';
-  }
+	static invalidKeyFormatMissingParams(): string {
+		return "SecurityException: Invalid key format - missing key params.";
+	}
 
-  static unknownPointFormat(): string {
-    return 'SecurityException: Invalid key params - unknown EC point format.';
-  }
+	static unknownPointFormat(): string {
+		return "SecurityException: Invalid key params - unknown EC point format.";
+	}
 
-  static missingKemParams(): string {
-    return 'SecurityException: Invalid params - missing KEM params.';
-  }
+	static missingKemParams(): string {
+		return "SecurityException: Invalid params - missing KEM params.";
+	}
 
-  static unsupportedKeyTemplate(templateTypeUrl: string): string {
-    return 'SecurityException: Invalid DEM params - ' + templateTypeUrl +
-        ' template is not supported by ECIES AEAD HKDF.';
-  }
+	static unsupportedKeyTemplate(templateTypeUrl: string): string {
+		return (
+			"SecurityException: Invalid DEM params - " +
+			templateTypeUrl +
+			" template is not supported by ECIES AEAD HKDF."
+		);
+	}
 
-  static invalidSerializedKey(): string {
-    return 'SecurityException: Input cannot be parsed as ' + PRIVATE_KEY_TYPE +
-        ' key-proto.';
-  }
+	static invalidSerializedKey(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			PRIVATE_KEY_TYPE +
+			" key-proto."
+		);
+	}
 }
 
 function createKemParams(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256): PbEciesHkdfKemParams {
-  const kemParams = new PbEciesHkdfKemParams()
-                        .setCurveType(opt_curveType)
-                        .setHkdfHashType(opt_hashType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256
+): PbEciesHkdfKemParams {
+	const kemParams = new PbEciesHkdfKemParams()
+		.setCurveType(opt_curveType)
+		.setHkdfHashType(opt_hashType);
 
-  return kemParams;
+	return kemParams;
 }
 
-function createDemParams(opt_keyTemplate?: PbKeyTemplate):
-    PbEciesAeadDemParams {
-  if (!opt_keyTemplate) {
-    opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-  }
+function createDemParams(
+	opt_keyTemplate?: PbKeyTemplate
+): PbEciesAeadDemParams {
+	if (!opt_keyTemplate) {
+		opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+	}
 
-  const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
+	const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
 
-  return demParams;
+	return demParams;
 }
 
 function createKeyParams(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat: PbPointFormat =
-        PbPointFormat.UNCOMPRESSED): PbEciesAeadHkdfParams {
-  const params = new PbEciesAeadHkdfParams()
-                     .setKemParams(createKemParams(opt_curveType, opt_hashType))
-                     .setDemParams(createDemParams(opt_keyTemplate))
-                     .setEcPointFormat(opt_pointFormat);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat: PbPointFormat = PbPointFormat.UNCOMPRESSED
+): PbEciesAeadHkdfParams {
+	const params = new PbEciesAeadHkdfParams()
+		.setKemParams(createKemParams(opt_curveType, opt_hashType))
+		.setDemParams(createDemParams(opt_keyTemplate))
+		.setEcPointFormat(opt_pointFormat);
 
-  return params;
+	return params;
 }
 
 function createKeyFormat(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): PbEciesAeadHkdfKeyFormat {
-  const keyFormat = new PbEciesAeadHkdfKeyFormat().setParams(createKeyParams(
-      opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat));
-  return keyFormat;
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): PbEciesAeadHkdfKeyFormat {
+	const keyFormat = new PbEciesAeadHkdfKeyFormat().setParams(
+		createKeyParams(
+			opt_curveType,
+			opt_hashType,
+			opt_keyTemplate,
+			opt_pointFormat
+		)
+	);
+	return keyFormat;
 }
 
 /**
  * Create set of key formats with all possible predefined/supported parameters.
  */
 function createTestSetOfKeyFormats(): PbEciesAeadHkdfKeyFormat[] {
-  const curveTypes = [
-    PbEllipticCurveType.NIST_P256, PbEllipticCurveType.NIST_P384,
-    PbEllipticCurveType.NIST_P521
-  ];
-  const hashTypes = [PbHashType.SHA1, PbHashType.SHA256, PbHashType.SHA512];
-  const keyTemplates = [
-    AeadKeyTemplates.aes128CtrHmacSha256(),
-    AeadKeyTemplates.aes256CtrHmacSha256()
-  ];
-  const pointFormats = [PbPointFormat.UNCOMPRESSED];
-  const keyFormats: PbEciesAeadHkdfKeyFormat[] = [];
-  for (const curve of curveTypes) {
-    for (const hkdfHash of hashTypes) {
-      for (const keyTemplate of keyTemplates) {
-        for (const pointFormat of pointFormats) {
-          const keyFormat =
-              createKeyFormat(curve, hkdfHash, keyTemplate, pointFormat);
-          keyFormats.push(keyFormat);
-        }
-      }
-    }
-  }
-  return keyFormats;
+	const curveTypes = [
+		PbEllipticCurveType.NIST_P256,
+		PbEllipticCurveType.NIST_P384,
+		PbEllipticCurveType.NIST_P521,
+	];
+	const hashTypes = [PbHashType.SHA1, PbHashType.SHA256, PbHashType.SHA512];
+	const keyTemplates = [
+		AeadKeyTemplates.aes128CtrHmacSha256(),
+		AeadKeyTemplates.aes256CtrHmacSha256(),
+	];
+	const pointFormats = [PbPointFormat.UNCOMPRESSED];
+	const keyFormats: PbEciesAeadHkdfKeyFormat[] = [];
+	for (const curve of curveTypes) {
+		for (const hkdfHash of hashTypes) {
+			for (const keyTemplate of keyTemplates) {
+				for (const pointFormat of pointFormats) {
+					const keyFormat = createKeyFormat(
+						curve,
+						hkdfHash,
+						keyTemplate,
+						pointFormat
+					);
+					keyFormats.push(keyFormat);
+				}
+			}
+		}
+	}
+	return keyFormats;
 }

--- a/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.ts
+++ b/javascript/hybrid/ecies_aead_hkdf_public_key_manager_test.ts
@@ -4,404 +4,461 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {PbAesCtrKey, PbEciesAeadDemParams, PbEciesAeadHkdfParams, PbEciesAeadHkdfPublicKey, PbEciesHkdfKemParams, PbEllipticCurveType, PbHashType, PbKeyData, PbKeyTemplate, PbPointFormat} from '../internal/proto';
-import * as Registry from '../internal/registry';
-import * as Util from '../internal/util';
-import * as Bytes from '../subtle/bytes';
-import * as EllipticCurves from '../subtle/elliptic_curves';
-import * as Random from '../subtle/random';
-import {assertExists} from '../testing/internal/test_utils';
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import {
+	PbAesCtrKey,
+	PbEciesAeadDemParams,
+	PbEciesAeadHkdfParams,
+	PbEciesAeadHkdfPublicKey,
+	PbEciesHkdfKemParams,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyData,
+	PbKeyTemplate,
+	PbPointFormat,
+} from "../internal/proto";
+import * as Registry from "../internal/registry";
+import * as Util from "../internal/util";
+import * as Bytes from "../subtle/bytes";
+import * as EllipticCurves from "../subtle/elliptic_curves";
+import * as Random from "../subtle/random";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {EciesAeadHkdfPublicKeyManager} from './ecies_aead_hkdf_public_key_manager';
-import {HybridEncrypt} from './internal/hybrid_encrypt';
+import { EciesAeadHkdfPublicKeyManager } from "./ecies_aead_hkdf_public_key_manager";
+import { HybridEncrypt } from "./internal/hybrid_encrypt";
 
 const KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey';
+	"type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey";
 const VERSION = 0;
 const PRIMITIVE = HybridEncrypt;
 
-describe('ecies aead hkdf public key manager test', function() {
-  beforeEach(function() {
-    AeadConfig.register();
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies aead hkdf public key manager test", () => {
+	beforeEach(() => {
+		AeadConfig.register();
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new key', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("new key", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    try {
-      manager.getKeyFactory().newKey(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notSupported());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKey(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.notSupported());
+		}
+	});
 
-  it('new key data', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("new key data", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    try {
-      manager.getKeyFactory().newKeyData(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notSupported());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKeyData(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.notSupported());
+		}
+	});
 
-  it('get primitive, unsupported key data type', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const keyData =
-        (await createKeyData()).setTypeUrl('unsupported_key_type_url');
+	it("get primitive, unsupported key data type", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const keyData = (await createKeyData()).setTypeUrl(
+			"unsupported_key_type_url"
+		);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, keyData);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyType(keyData.getTypeUrl()));
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, keyData);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyType(keyData.getTypeUrl())
+			);
+		}
+	});
 
-  it('get primitive, unsupported key type', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const key = new PbAesCtrKey();
+	it("get primitive, unsupported key type", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const key = new PbAesCtrKey();
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
+		}
+	});
 
-  it('get primitive, high version', async function() {
-    const version = 1;
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const key = (await createKey()).setVersion(version);
+	it("get primitive, high version", async () => {
+		const version = 1;
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const key = (await createKey()).setVersion(version);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
+		}
+	});
 
-  it('get primitive, missing params', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const key = (await createKey()).setParams(null);
+	it("get primitive, missing params", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const key = (await createKey()).setParams(null);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingParams());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingParams());
+		}
+	});
 
-  it('get primitive, invalid params', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const key = await createKey();
+	it("get primitive, invalid params", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const key = await createKey();
 
-    // unknown point format
-    key.getParams()?.setEcPointFormat(PbPointFormat.UNKNOWN_FORMAT);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
-    }
-    key.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
+		// unknown point format
+		key.getParams()?.setEcPointFormat(PbPointFormat.UNKNOWN_FORMAT);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
+		}
+		key.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
 
-    // missing KEM params
-    key.getParams()?.setKemParams(null);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKemParams());
-    }
-    key.getParams()?.setKemParams(createKemParams());
+		// missing KEM params
+		key.getParams()?.setKemParams(null);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKemParams());
+		}
+		key.getParams()?.setKemParams(createKemParams());
 
-    // unsupported AEAD key template
-    const typeUrl = 'UNSUPPORTED_KEY_TYPE_URL';
-    key.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(typeUrl);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyTemplate(typeUrl));
-    }
-  });
+		// unsupported AEAD key template
+		const typeUrl = "UNSUPPORTED_KEY_TYPE_URL";
+		key.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(typeUrl);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyTemplate(typeUrl)
+			);
+		}
+	});
 
-  it('get primitive, invalid key', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const key = (await createKey()).setX('');
+	it("get primitive, invalid key", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const key = (await createKey()).setX("");
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingXY());
-    }
-    key.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingXY());
+		}
+		key.getParams()?.setEcPointFormat(PbPointFormat.UNCOMPRESSED);
 
-    // missing KEM params
-    key.getParams()?.setKemParams(null);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKemParams());
-    }
-    key.getParams()?.setKemParams(createKemParams());
+		// missing KEM params
+		key.getParams()?.setKemParams(null);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKemParams());
+		}
+		key.getParams()?.setKemParams(createKemParams());
 
-    // unsupported AEAD key template
-    const typeUrl = 'UNSUPPORTED_KEY_TYPE_URL';
-    key.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(typeUrl);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyTemplate(typeUrl));
-    }
-  });
+		// unsupported AEAD key template
+		const typeUrl = "UNSUPPORTED_KEY_TYPE_URL";
+		key.getParams()?.getDemParams()?.getAeadDem()?.setTypeUrl(typeUrl);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyTemplate(typeUrl)
+			);
+		}
+	});
 
-  it('get primitive, invalid serialized key', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const keyData = await createKeyData();
+	it("get primitive, invalid serialized key", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const keyData = await createKeyData();
 
-    for (let i = 0; i < 2; ++i) {
-      // Set the value of keyData to something which is not a serialization of a
-      // proper key.
-      keyData.setValue(new Uint8Array(i));
-      try {
-        await manager.getPrimitive(PRIMITIVE, keyData);
-        fail('An exception should be thrown ' + i.toString());
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-      }
-    }
-  });
+		for (let i = 0; i < 2; ++i) {
+			// Set the value of keyData to something which is not a serialization of a
+			// proper key.
+			keyData.setValue(new Uint8Array(i));
+			try {
+				await manager.getPrimitive(PRIMITIVE, keyData);
+				fail("An exception should be thrown " + i.toString());
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+			}
+		}
+	});
 
-  // tests for getting primitive from valid key/keyData
-  it('get primitive, from key', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const keys = await createTestSetOfKeys();
-    for (const key of keys) {
-      const primitive: HybridEncrypt =
-          assertExists(await manager.getPrimitive(PRIMITIVE, key));
+	// tests for getting primitive from valid key/keyData
+	it("get primitive, from key", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const keys = await createTestSetOfKeys();
+		for (const key of keys) {
+			const primitive: HybridEncrypt = assertExists(
+				await manager.getPrimitive(PRIMITIVE, key)
+			);
 
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await primitive.encrypt(plaintext);
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await primitive.encrypt(plaintext);
 
-      expect(ciphertext).not.toEqual(plaintext);
-    }
-  });
+			expect(ciphertext).not.toEqual(plaintext);
+		}
+	});
 
-  it('get primitive, from key data', async function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
-    const keyDatas = await createTestSetOfKeyDatas();
+	it("get primitive, from key data", async () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
+		const keyDatas = await createTestSetOfKeyDatas();
 
-    for (const key of keyDatas) {
-      const primitive: HybridEncrypt =
-          assertExists(await manager.getPrimitive(PRIMITIVE, key));
+		for (const key of keyDatas) {
+			const primitive: HybridEncrypt = assertExists(
+				await manager.getPrimitive(PRIMITIVE, key)
+			);
 
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await primitive.encrypt(plaintext);
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await primitive.encrypt(plaintext);
 
-      expect(ciphertext).not.toEqual(plaintext);
-    }
-  });
+			expect(ciphertext).not.toEqual(plaintext);
+		}
+	});
 
-  it('does support', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("does support", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    expect(manager.doesSupport(KEY_TYPE)).toBe(true);
-  });
+		expect(manager.doesSupport(KEY_TYPE)).toBe(true);
+	});
 
-  it('get key type', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("get key type", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    expect(manager.getKeyType()).toBe(KEY_TYPE);
-  });
+		expect(manager.getKeyType()).toBe(KEY_TYPE);
+	});
 
-  it('get primitive type', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("get primitive type", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
-  });
+		expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
+	});
 
-  it('get version', function() {
-    const manager = new EciesAeadHkdfPublicKeyManager();
+	it("get version", () => {
+		const manager = new EciesAeadHkdfPublicKeyManager();
 
-    expect(manager.getVersion()).toBe(VERSION);
-  });
+		expect(manager.getVersion()).toBe(VERSION);
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static notSupported(): string {
-    return 'SecurityException: This operation is not supported for public keys. ' +
-        'Use EciesAeadHkdfPrivateKeyManager to generate new keys.';
-  }
+	static notSupported(): string {
+		return (
+			"SecurityException: This operation is not supported for public keys. " +
+			"Use EciesAeadHkdfPrivateKeyManager to generate new keys."
+		);
+	}
 
-  static unsupportedPrimitive(): string {
-    return 'SecurityException: Requested primitive type which is not supported by ' +
-        'this key manager.';
-  }
+	static unsupportedPrimitive(): string {
+		return (
+			"SecurityException: Requested primitive type which is not supported by " +
+			"this key manager."
+		);
+	}
 
-  static unsupportedKeyType(opt_requestedKeyType?: string): string {
-    const prefix = 'SecurityException: Key type';
-    const suffix =
-        'is not supported. This key manager supports ' + KEY_TYPE + '.';
-    if (opt_requestedKeyType) {
-      return prefix + ' ' + opt_requestedKeyType + ' ' + suffix;
-    } else {
-      return prefix + ' ' + suffix;
-    }
-  }
+	static unsupportedKeyType(opt_requestedKeyType?: string): string {
+		const prefix = "SecurityException: Key type";
+		const suffix =
+			"is not supported. This key manager supports " + KEY_TYPE + ".";
+		if (opt_requestedKeyType) {
+			return prefix + " " + opt_requestedKeyType + " " + suffix;
+		} else {
+			return prefix + " " + suffix;
+		}
+	}
 
-  static versionOutOfBounds(): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        VERSION + '.';
-  }
+	static versionOutOfBounds(): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			VERSION +
+			"."
+		);
+	}
 
-  static missingParams(): string {
-    return 'SecurityException: Invalid public key - missing key params.';
-  }
+	static missingParams(): string {
+		return "SecurityException: Invalid public key - missing key params.";
+	}
 
-  static unknownPointFormat(): string {
-    return 'SecurityException: Invalid key params - unknown EC point format.';
-  }
+	static unknownPointFormat(): string {
+		return "SecurityException: Invalid key params - unknown EC point format.";
+	}
 
-  static missingKemParams(): string {
-    return 'SecurityException: Invalid params - missing KEM params.';
-  }
+	static missingKemParams(): string {
+		return "SecurityException: Invalid params - missing KEM params.";
+	}
 
-  static unsupportedKeyTemplate(templateTypeUrl: string): string {
-    return 'SecurityException: Invalid DEM params - ' + templateTypeUrl +
-        ' template is not supported by ECIES AEAD HKDF.';
-  }
+	static unsupportedKeyTemplate(templateTypeUrl: string): string {
+		return (
+			"SecurityException: Invalid DEM params - " +
+			templateTypeUrl +
+			" template is not supported by ECIES AEAD HKDF."
+		);
+	}
 
-  static missingXY(): string {
-    return 'SecurityException: Invalid public key - missing value of X or Y.';
-  }
+	static missingXY(): string {
+		return "SecurityException: Invalid public key - missing value of X or Y.";
+	}
 
-  static invalidSerializedKey(): string {
-    return 'SecurityException: Input cannot be parsed as ' + KEY_TYPE +
-        ' key-proto.';
-  }
+	static invalidSerializedKey(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			KEY_TYPE +
+			" key-proto."
+		);
+	}
 }
 
 function createKemParams(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256): PbEciesHkdfKemParams {
-  const kemParams = new PbEciesHkdfKemParams()
-                        .setCurveType(opt_curveType)
-                        .setHkdfHashType(opt_hashType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256
+): PbEciesHkdfKemParams {
+	const kemParams = new PbEciesHkdfKemParams()
+		.setCurveType(opt_curveType)
+		.setHkdfHashType(opt_hashType);
 
-  return kemParams;
+	return kemParams;
 }
 
-function createDemParams(opt_keyTemplate?: PbKeyTemplate):
-    PbEciesAeadDemParams {
-  if (!opt_keyTemplate) {
-    opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-  }
+function createDemParams(
+	opt_keyTemplate?: PbKeyTemplate
+): PbEciesAeadDemParams {
+	if (!opt_keyTemplate) {
+		opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+	}
 
-  const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
+	const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
 
-  return demParams;
+	return demParams;
 }
 
 function createKeyParams(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat: PbPointFormat =
-        PbPointFormat.UNCOMPRESSED): PbEciesAeadHkdfParams {
-  const params = new PbEciesAeadHkdfParams()
-                     .setKemParams(createKemParams(opt_curveType, opt_hashType))
-                     .setDemParams(createDemParams(opt_keyTemplate))
-                     .setEcPointFormat(opt_pointFormat);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat: PbPointFormat = PbPointFormat.UNCOMPRESSED
+): PbEciesAeadHkdfParams {
+	const params = new PbEciesAeadHkdfParams()
+		.setKemParams(createKemParams(opt_curveType, opt_hashType))
+		.setDemParams(createDemParams(opt_keyTemplate))
+		.setEcPointFormat(opt_pointFormat);
 
-  return params;
+	return params;
 }
 
 async function createKey(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType?: PbHashType, opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): Promise<PbEciesAeadHkdfPublicKey> {
-  const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
-  const curveName = EllipticCurves.curveToString(curveSubtleType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): Promise<PbEciesAeadHkdfPublicKey> {
+	const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
+	const curveName = EllipticCurves.curveToString(curveSubtleType);
 
-  const key =
-      new PbEciesAeadHkdfPublicKey().setVersion(0).setParams(createKeyParams(
-          opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat));
+	const key = new PbEciesAeadHkdfPublicKey()
+		.setVersion(0)
+		.setParams(
+			createKeyParams(
+				opt_curveType,
+				opt_hashType,
+				opt_keyTemplate,
+				opt_pointFormat
+			)
+		);
 
+	const keyPair = await EllipticCurves.generateKeyPair("ECDH", curveName);
+	const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
+	key.setX(
+		Bytes.fromBase64(assertExists(publicKey["x"]), /* opt_webSafe = */ true)
+	);
+	key.setY(
+		Bytes.fromBase64(assertExists(publicKey["y"]), /* opt_webSafe = */ true)
+	);
 
-  const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
-  const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-  key.setX(
-      Bytes.fromBase64(assertExists(publicKey['x']), /* opt_webSafe = */ true));
-  key.setY(
-      Bytes.fromBase64(assertExists(publicKey['y']), /* opt_webSafe = */ true));
-
-  return key;
+	return key;
 }
 
 function createKeyDataFromKey(key: PbEciesAeadHkdfPublicKey): PbKeyData {
-  const keyData =
-      new PbKeyData()
-          .setTypeUrl(KEY_TYPE)
-          .setValue(key.serializeBinary())
-          .setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
+	const keyData = new PbKeyData()
+		.setTypeUrl(KEY_TYPE)
+		.setValue(key.serializeBinary())
+		.setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
 
-  return keyData;
+	return keyData;
 }
 
 async function createKeyData(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): Promise<PbKeyData> {
-  const key = await createKey(
-      opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat);
-  return createKeyDataFromKey(key);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): Promise<PbKeyData> {
+	const key = await createKey(
+		opt_curveType,
+		opt_hashType,
+		opt_keyTemplate,
+		opt_pointFormat
+	);
+	return createKeyDataFromKey(key);
 }
 
 /** Create set of keys with all possible predefined/supported parameters. */
 async function createTestSetOfKeys(): Promise<PbEciesAeadHkdfPublicKey[]> {
-  const curveTypes = [
-    PbEllipticCurveType.NIST_P256, PbEllipticCurveType.NIST_P384,
-    PbEllipticCurveType.NIST_P521
-  ];
-  const hashTypes = [PbHashType.SHA1, PbHashType.SHA256, PbHashType.SHA512];
-  const keyTemplates =
-      [AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes256Gcm()];
-  const pointFormats = [PbPointFormat.UNCOMPRESSED];
+	const curveTypes = [
+		PbEllipticCurveType.NIST_P256,
+		PbEllipticCurveType.NIST_P384,
+		PbEllipticCurveType.NIST_P521,
+	];
+	const hashTypes = [PbHashType.SHA1, PbHashType.SHA256, PbHashType.SHA512];
+	const keyTemplates = [
+		AeadKeyTemplates.aes128CtrHmacSha256(),
+		AeadKeyTemplates.aes256Gcm(),
+	];
+	const pointFormats = [PbPointFormat.UNCOMPRESSED];
 
-  const keys: PbEciesAeadHkdfPublicKey[] = [];
-  for (const curve of curveTypes) {
-    for (const hkdfHash of hashTypes) {
-      for (const keyTemplate of keyTemplates) {
-        for (const pointFormat of pointFormats) {
-          const key =
-              await createKey(curve, hkdfHash, keyTemplate, pointFormat);
-          keys.push(key);
-        }
-      }
-    }
-  }
-  return keys;
+	const keys: PbEciesAeadHkdfPublicKey[] = [];
+	for (const curve of curveTypes) {
+		for (const hkdfHash of hashTypes) {
+			for (const keyTemplate of keyTemplates) {
+				for (const pointFormat of pointFormats) {
+					const key = await createKey(
+						curve,
+						hkdfHash,
+						keyTemplate,
+						pointFormat
+					);
+					keys.push(key);
+				}
+			}
+		}
+	}
+	return keys;
 }
 
 /**
@@ -409,13 +466,13 @@ async function createTestSetOfKeys(): Promise<PbEciesAeadHkdfPublicKey[]> {
  * parameters.
  */
 async function createTestSetOfKeyDatas(): Promise<PbKeyData[]> {
-  const keys = await createTestSetOfKeys();
+	const keys = await createTestSetOfKeys();
 
-  const keyDatas: PbKeyData[] = [];
-  for (const key of keys) {
-    const keyData = await createKeyDataFromKey(key);
-    keyDatas.push(keyData);
-  }
+	const keyDatas: PbKeyData[] = [];
+	for (const key of keys) {
+		const keyData = await createKeyDataFromKey(key);
+		keyDatas.push(keyData);
+	}
 
-  return keyDatas;
+	return keyDatas;
 }

--- a/javascript/hybrid/ecies_aead_hkdf_util_test.ts
+++ b/javascript/hybrid/ecies_aead_hkdf_util_test.ts
@@ -4,221 +4,297 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {PbEciesAeadDemParams, PbEciesAeadHkdfParams, PbEciesAeadHkdfPrivateKey, PbEciesAeadHkdfPublicKey, PbEciesHkdfKemParams, PbEllipticCurveType, PbHashType, PbKeyTemplate, PbPointFormat} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import * as Util from '../internal/util';
-import * as Bytes from '../subtle/bytes';
-import * as EllipticCurves from '../subtle/elliptic_curves';
-import {assertExists} from '../testing/internal/test_utils';
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import {
+	PbEciesAeadDemParams,
+	PbEciesAeadHkdfParams,
+	PbEciesAeadHkdfPrivateKey,
+	PbEciesAeadHkdfPublicKey,
+	PbEciesHkdfKemParams,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyTemplate,
+	PbPointFormat,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import * as Util from "../internal/util";
+import * as Bytes from "../subtle/bytes";
+import * as EllipticCurves from "../subtle/elliptic_curves";
+import { assertExists } from "../testing/internal/test_utils";
 
-import * as EciesAeadHkdfUtil from './ecies_aead_hkdf_util';
+import * as EciesAeadHkdfUtil from "./ecies_aead_hkdf_util";
 
-describe('ecies aead hkdf util test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies aead hkdf util test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('get json web key from proto, public key', async function() {
-    for (const curve
-             of [PbEllipticCurveType.NIST_P256,
-                 PbEllipticCurveType.NIST_P384,
-                 PbEllipticCurveType.NIST_P521,
-    ]) {
-      const key = await createKey(curve);
-      const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(
-          assertExists(key.getPublicKey()));
+	it("get json web key from proto, public key", async () => {
+		for (const curve of [
+			PbEllipticCurveType.NIST_P256,
+			PbEllipticCurveType.NIST_P384,
+			PbEllipticCurveType.NIST_P521,
+		]) {
+			const key = await createKey(curve);
+			const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(
+				assertExists(key.getPublicKey())
+			);
 
-      // Test the returned jwk.
-      const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
-      const curveTypeString = EllipticCurves.curveToString(curveTypeSubtle);
-      expect(jwk?.['kty']).toBe('EC');
-      expect(jwk?.['crv']).toBe(curveTypeString);
-      expect(Bytes.fromBase64(assertExists(jwk['x']), /* opt_webSafe = */ true))
-          .toEqual(bytesAsU8(assertExists(key.getPublicKey()).getX()));
-      expect(Bytes.fromBase64(assertExists(jwk['y']), /* opt_webSafe = */ true))
-          .toEqual(bytesAsU8(assertExists(key.getPublicKey()).getY()));
-      expect(jwk?.['d']).toEqual(undefined);
-      expect(jwk?.['ext']).toBe(true);
-    }
-  });
+			// Test the returned jwk.
+			const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
+			const curveTypeString =
+				EllipticCurves.curveToString(curveTypeSubtle);
+			expect(jwk?.["kty"]).toBe("EC");
+			expect(jwk?.["crv"]).toBe(curveTypeString);
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["x"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(assertExists(key.getPublicKey()).getX()));
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["y"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(assertExists(key.getPublicKey()).getY()));
+			expect(jwk?.["d"]).toEqual(undefined);
+			expect(jwk?.["ext"]).toBe(true);
+		}
+	});
 
-  it('get json web key from proto, public key, with leading zeros',
-     async function() {
-       for (const curve
-                of [PbEllipticCurveType.NIST_P256,
-                    PbEllipticCurveType.NIST_P384,
-                    PbEllipticCurveType.NIST_P521,
-       ]) {
-         const key = await createKey(curve);
+	it("get json web key from proto, public key, with leading zeros", async () => {
+		for (const curve of [
+			PbEllipticCurveType.NIST_P256,
+			PbEllipticCurveType.NIST_P384,
+			PbEllipticCurveType.NIST_P521,
+		]) {
+			const key = await createKey(curve);
 
-         // Add leading zeros to x and y value of key.
-         const x = bytesAsU8(assertExists(key.getPublicKey()).getX());
-         const y = bytesAsU8(assertExists(key.getPublicKey()).getY());
-         key.getPublicKey()?.setX(
-             Bytes.concat(new Uint8Array([0, 0, 0, 0, 0]), x));
-         key.getPublicKey()?.setY(Bytes.concat(new Uint8Array([0, 0, 0]), y));
-         const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(
-             assertExists(key.getPublicKey()));
+			// Add leading zeros to x and y value of key.
+			const x = bytesAsU8(assertExists(key.getPublicKey()).getX());
+			const y = bytesAsU8(assertExists(key.getPublicKey()).getY());
+			key.getPublicKey()?.setX(
+				Bytes.concat(new Uint8Array([0, 0, 0, 0, 0]), x)
+			);
+			key.getPublicKey()?.setY(
+				Bytes.concat(new Uint8Array([0, 0, 0]), y)
+			);
+			const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(
+				assertExists(key.getPublicKey())
+			);
 
-         // Test the returned jwk.
-         const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
-         const curveTypeString = EllipticCurves.curveToString(curveTypeSubtle);
-         expect(jwk?.['kty']).toBe('EC');
-         expect(jwk?.['crv']).toBe(curveTypeString);
-         expect(
-             Bytes.fromBase64(assertExists(jwk['x']), /* opt_webSafe = */ true))
-             .toEqual(x);
-         expect(
-             Bytes.fromBase64(assertExists(jwk['y']), /* opt_webSafe = */ true))
-             .toEqual(y);
-         expect(jwk?.['d']).toEqual(undefined);
-         expect(jwk?.['ext']).toBe(true);
-       }
-     });
+			// Test the returned jwk.
+			const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
+			const curveTypeString =
+				EllipticCurves.curveToString(curveTypeSubtle);
+			expect(jwk?.["kty"]).toBe("EC");
+			expect(jwk?.["crv"]).toBe(curveTypeString);
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["x"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(x);
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["y"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(y);
+			expect(jwk?.["d"]).toEqual(undefined);
+			expect(jwk?.["ext"]).toBe(true);
+		}
+	});
 
-  it('get json web key from proto, public key, leading nonzero',
-     async function() {
-       const curve = PbEllipticCurveType.NIST_P256;
-       const key = await createKey(curve);
-       const publicKey = assertExists(key.getPublicKey());
-       const x = bytesAsU8(publicKey.getX());
-       publicKey.setX(Bytes.concat(new Uint8Array([1, 0]), x));
-       try {
-         EciesAeadHkdfUtil.getJsonWebKeyFromProto(publicKey);
-         fail('An exception should be thrown.');
-       } catch (e: any) {
-         expect(e.toString())
-             .toBe(
-                 'SecurityException: Number needs more bytes to be represented.');
-       }
-     });
+	it("get json web key from proto, public key, leading nonzero", async () => {
+		const curve = PbEllipticCurveType.NIST_P256;
+		const key = await createKey(curve);
+		const publicKey = assertExists(key.getPublicKey());
+		const x = bytesAsU8(publicKey.getX());
+		publicKey.setX(Bytes.concat(new Uint8Array([1, 0]), x));
+		try {
+			EciesAeadHkdfUtil.getJsonWebKeyFromProto(publicKey);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Number needs more bytes to be represented."
+			);
+		}
+	});
 
-  it('get json web key from proto, private key', async function() {
-    for (const curve
-             of [PbEllipticCurveType.NIST_P256,
-                 PbEllipticCurveType.NIST_P384,
-                 PbEllipticCurveType.NIST_P521,
-    ]) {
-      const key = await createKey(curve);
-      const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(key);
+	it("get json web key from proto, private key", async () => {
+		for (const curve of [
+			PbEllipticCurveType.NIST_P256,
+			PbEllipticCurveType.NIST_P384,
+			PbEllipticCurveType.NIST_P521,
+		]) {
+			const key = await createKey(curve);
+			const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(key);
 
-      // Test the returned jwk.
-      const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
-      const curveTypeString = EllipticCurves.curveToString(curveTypeSubtle);
-      const publicKey = assertExists(key.getPublicKey());
-      expect(jwk?.['kty']).toBe('EC');
-      expect(jwk?.['crv']).toBe(curveTypeString);
-      expect(Bytes.fromBase64(assertExists(jwk['x']), /* opt_webSafe = */ true))
-          .toEqual(bytesAsU8(publicKey.getX()));
-      expect(Bytes.fromBase64(assertExists(jwk['y']), /* opt_webSafe = */ true))
-          .toEqual(bytesAsU8(publicKey.getY()));
-      expect(Bytes.fromBase64(assertExists(jwk['d']), /* opt_webSafe = */ true))
-          .toEqual(bytesAsU8(key.getKeyValue()));
-      expect(jwk?.['ext']).toBe(true);
-    }
-  });
+			// Test the returned jwk.
+			const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
+			const curveTypeString =
+				EllipticCurves.curveToString(curveTypeSubtle);
+			const publicKey = assertExists(key.getPublicKey());
+			expect(jwk?.["kty"]).toBe("EC");
+			expect(jwk?.["crv"]).toBe(curveTypeString);
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["x"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(publicKey.getX()));
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["y"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(publicKey.getY()));
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["d"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(key.getKeyValue()));
+			expect(jwk?.["ext"]).toBe(true);
+		}
+	});
 
-  it('get json web key from proto, private key, leading zeros',
-     async function() {
-       for (const curve
-                of [PbEllipticCurveType.NIST_P256,
-                    PbEllipticCurveType.NIST_P384,
-                    PbEllipticCurveType.NIST_P521,
-       ]) {
-         const key = await createKey(curve);
-         const d = bytesAsU8(key.getKeyValue());
-         key.setKeyValue(Bytes.concat(new Uint8Array([0, 0, 0]), d));
-         const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(key);
+	it("get json web key from proto, private key, leading zeros", async () => {
+		for (const curve of [
+			PbEllipticCurveType.NIST_P256,
+			PbEllipticCurveType.NIST_P384,
+			PbEllipticCurveType.NIST_P521,
+		]) {
+			const key = await createKey(curve);
+			const d = bytesAsU8(key.getKeyValue());
+			key.setKeyValue(Bytes.concat(new Uint8Array([0, 0, 0]), d));
+			const jwk = EciesAeadHkdfUtil.getJsonWebKeyFromProto(key);
 
-         // Test the returned jwk.
-         const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
-         const curveTypeString = EllipticCurves.curveToString(curveTypeSubtle);
+			// Test the returned jwk.
+			const curveTypeSubtle = Util.curveTypeProtoToSubtle(curve);
+			const curveTypeString =
+				EllipticCurves.curveToString(curveTypeSubtle);
 
-         const publicKey = assertExists(key.getPublicKey());
-         expect(jwk?.['kty']).toBe('EC');
-         expect(jwk?.['crv']).toBe(curveTypeString);
-         expect(
-             Bytes.fromBase64(assertExists(jwk['x']), /* opt_webSafe = */ true))
-             .toEqual(bytesAsU8(publicKey.getX()));
-         expect(
-             Bytes.fromBase64(assertExists(jwk['y']), /* opt_webSafe = */ true))
-             .toEqual(bytesAsU8(publicKey.getY()));
-         expect(
-             Bytes.fromBase64(assertExists(jwk['d']), /* opt_webSafe = */ true))
-             .toEqual(d);
-         expect(jwk['ext']).toBe(true);
-       }
-     });
+			const publicKey = assertExists(key.getPublicKey());
+			expect(jwk?.["kty"]).toBe("EC");
+			expect(jwk?.["crv"]).toBe(curveTypeString);
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["x"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(publicKey.getX()));
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["y"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(bytesAsU8(publicKey.getY()));
+			expect(
+				Bytes.fromBase64(
+					assertExists(jwk["d"]),
+					/* opt_webSafe = */ true
+				)
+			).toEqual(d);
+			expect(jwk["ext"]).toBe(true);
+		}
+	});
 });
 
 function createKemParams(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256): PbEciesHkdfKemParams {
-  const kemParams = new PbEciesHkdfKemParams()
-                        .setCurveType(opt_curveType)
-                        .setHkdfHashType(opt_hashType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256
+): PbEciesHkdfKemParams {
+	const kemParams = new PbEciesHkdfKemParams()
+		.setCurveType(opt_curveType)
+		.setHkdfHashType(opt_hashType);
 
-  return kemParams;
+	return kemParams;
 }
 
-function createDemParams(opt_keyTemplate?: PbKeyTemplate):
-    PbEciesAeadDemParams {
-  if (!opt_keyTemplate) {
-    opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-  }
+function createDemParams(
+	opt_keyTemplate?: PbKeyTemplate
+): PbEciesAeadDemParams {
+	if (!opt_keyTemplate) {
+		opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+	}
 
-  const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
+	const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
 
-  return demParams;
+	return demParams;
 }
 
 function createKeyParams(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat: PbPointFormat =
-        PbPointFormat.UNCOMPRESSED): PbEciesAeadHkdfParams {
-  const params = new PbEciesAeadHkdfParams()
-                     .setKemParams(createKemParams(opt_curveType, opt_hashType))
-                     .setDemParams(createDemParams(opt_keyTemplate))
-                     .setEcPointFormat(opt_pointFormat);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat: PbPointFormat = PbPointFormat.UNCOMPRESSED
+): PbEciesAeadHkdfParams {
+	const params = new PbEciesAeadHkdfParams()
+		.setKemParams(createKemParams(opt_curveType, opt_hashType))
+		.setDemParams(createDemParams(opt_keyTemplate))
+		.setEcPointFormat(opt_pointFormat);
 
-  return params;
+	return params;
 }
 
 async function createKey(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType?: PbHashType, opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): Promise<PbEciesAeadHkdfPrivateKey> {
-  const curveTypeSubtle = Util.curveTypeProtoToSubtle((opt_curveType));
-  const curveName = EllipticCurves.curveToString(curveTypeSubtle);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): Promise<PbEciesAeadHkdfPrivateKey> {
+	const curveTypeSubtle = Util.curveTypeProtoToSubtle(opt_curveType);
+	const curveName = EllipticCurves.curveToString(curveTypeSubtle);
 
-  const publicKeyProto =
-      new PbEciesAeadHkdfPublicKey().setVersion(0).setParams(createKeyParams(
-          opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat));
+	const publicKeyProto = new PbEciesAeadHkdfPublicKey()
+		.setVersion(0)
+		.setParams(
+			createKeyParams(
+				opt_curveType,
+				opt_hashType,
+				opt_keyTemplate,
+				opt_pointFormat
+			)
+		);
 
+	const keyPair = await EllipticCurves.generateKeyPair("ECDH", curveName);
+	const publicKeyJson = await EllipticCurves.exportCryptoKey(
+		keyPair.publicKey!
+	);
+	publicKeyProto.setX(
+		Bytes.fromBase64(
+			assertExists(publicKeyJson["x"]),
+			/* opt_webSafe = */ true
+		)
+	);
+	publicKeyProto.setY(
+		Bytes.fromBase64(
+			assertExists(publicKeyJson["y"]),
+			/* opt_webSafe = */ true
+		)
+	);
 
-  const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
-  const publicKeyJson =
-      await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-  publicKeyProto.setX(Bytes.fromBase64(
-      assertExists(publicKeyJson['x']), /* opt_webSafe = */ true));
-  publicKeyProto.setY(Bytes.fromBase64(
-      assertExists(publicKeyJson['y']), /* opt_webSafe = */ true));
+	const privateKeyProto = new PbEciesAeadHkdfPrivateKey();
+	const privateKeyJson = await EllipticCurves.exportCryptoKey(
+		keyPair.privateKey!
+	);
+	privateKeyProto.setKeyValue(
+		Bytes.fromBase64(
+			assertExists(privateKeyJson["d"]),
+			/* opt_webSafe = */ true
+		)
+	);
+	privateKeyProto.setVersion(0);
+	privateKeyProto.setPublicKey(publicKeyProto);
 
-  const privateKeyProto = new PbEciesAeadHkdfPrivateKey();
-  const privateKeyJson =
-      await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-  privateKeyProto.setKeyValue(Bytes.fromBase64(
-      assertExists(privateKeyJson['d']), /* opt_webSafe = */ true));
-  privateKeyProto.setVersion(0);
-  privateKeyProto.setPublicKey(publicKeyProto);
-
-  return privateKeyProto;
+	return privateKeyProto;
 }

--- a/javascript/hybrid/ecies_aead_hkdf_validators_test.ts
+++ b/javascript/hybrid/ecies_aead_hkdf_validators_test.ts
@@ -4,427 +4,495 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {PbEciesAeadDemParams, PbEciesAeadHkdfKeyFormat, PbEciesAeadHkdfParams, PbEciesAeadHkdfPrivateKey, PbEciesAeadHkdfPublicKey, PbEciesHkdfKemParams, PbEllipticCurveType, PbHashType, PbKeyTemplate, PbPointFormat} from '../internal/proto';
-import * as Util from '../internal/util';
-import * as Bytes from '../subtle/bytes';
-import * as EllipticCurves from '../subtle/elliptic_curves';
-import {assertExists} from '../testing/internal/test_utils';
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import {
+	PbEciesAeadDemParams,
+	PbEciesAeadHkdfKeyFormat,
+	PbEciesAeadHkdfParams,
+	PbEciesAeadHkdfPrivateKey,
+	PbEciesAeadHkdfPublicKey,
+	PbEciesHkdfKemParams,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyTemplate,
+	PbPointFormat,
+} from "../internal/proto";
+import * as Util from "../internal/util";
+import * as Bytes from "../subtle/bytes";
+import * as EllipticCurves from "../subtle/elliptic_curves";
+import { assertExists } from "../testing/internal/test_utils";
 
-import * as EciesAeadHkdfValidators from './ecies_aead_hkdf_validators';
+import * as EciesAeadHkdfValidators from "./ecies_aead_hkdf_validators";
 
+describe("ecies aead hkdf validators test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-describe('ecies aead hkdf validators test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	it("validate params, missing kem params", () => {
+		const invalidParams = createParams().setKemParams(null);
 
-  it('validate params, missing kem params', function() {
-    const invalidParams = createParams().setKemParams(null);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKemParams());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKemParams());
-    }
-  });
+	it("validate params, invalid kem params, unknown hash type", () => {
+		const invalidParams = createParams();
+		invalidParams.getKemParams()?.setHkdfHashType(PbHashType.UNKNOWN_HASH);
 
-  it('validate params, invalid kem params, unknown hash type', function() {
-    const invalidParams = createParams();
-    invalidParams.getKemParams()?.setHkdfHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHashType());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHashType());
-    }
-  });
+	it("validate params, invalid kem params, unknown curve type", () => {
+		const invalidParams = createParams();
+		invalidParams
+			.getKemParams()
+			?.setCurveType(PbEllipticCurveType.UNKNOWN_CURVE);
 
-  it('validate params, invalid kem params, unknown curve type', function() {
-    const invalidParams = createParams();
-    invalidParams.getKemParams()?.setCurveType(
-        PbEllipticCurveType.UNKNOWN_CURVE);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownCurveType());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownCurveType());
-    }
-  });
+	it("validate params, missing dem params", () => {
+		const invalidParams = createParams().setDemParams(null);
 
-  it('validate params, missing dem params', function() {
-    const invalidParams = createParams().setDemParams(null);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingDemParams());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingDemParams());
-    }
-  });
+	it("validate params, invalid dem params, missing aead template", () => {
+		const invalidParams = createParams();
+		invalidParams.getDemParams()?.setAeadDem(null);
 
-  it('validate params, invalid dem params, missing aead template', function() {
-    const invalidParams = createParams();
-    invalidParams.getDemParams()?.setAeadDem(null);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingAeadTemplate());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingAeadTemplate());
-    }
-  });
+	it("validate params, invalid dem params, unsupported aead template", () => {
+		const unsupportedTypeUrl = "UNSUPPORTED_KEY_TYPE_URL";
+		const invalidParams = createParams();
+		invalidParams
+			.getDemParams()
+			?.getAeadDem()
+			?.setTypeUrl(unsupportedTypeUrl);
 
-  it('validate params, invalid dem params, unsupported aead template',
-     function() {
-       const unsupportedTypeUrl = 'UNSUPPORTED_KEY_TYPE_URL';
-       const invalidParams = createParams();
-       invalidParams.getDemParams()?.getAeadDem()?.setTypeUrl(
-           unsupportedTypeUrl);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyTemplate(unsupportedTypeUrl)
+			);
+		}
+	});
 
-       try {
-         EciesAeadHkdfValidators.validateParams(invalidParams);
-         fail('An exception should be thrown.');
-       } catch (e: any) {
-         expect(e.toString())
-             .toBe(ExceptionText.unsupportedKeyTemplate(unsupportedTypeUrl));
-       }
-     });
+	it("validate params, unknown point format", () => {
+		const invalidParams = createParams().setEcPointFormat(
+			PbPointFormat.UNKNOWN_FORMAT
+		);
 
-  it('validate params, unknown point format', function() {
-    const invalidParams =
-        createParams().setEcPointFormat(PbPointFormat.UNKNOWN_FORMAT);
+		try {
+			EciesAeadHkdfValidators.validateParams(invalidParams);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
+		}
+	});
+	it("validate params, different valid values", () => {
+		for (const curve of [
+			PbEllipticCurveType.NIST_P256,
+			PbEllipticCurveType.NIST_P384,
+			PbEllipticCurveType.NIST_P521,
+		]) {
+			for (const hashType of [
+				PbHashType.SHA1,
+				PbHashType.SHA384,
+				PbHashType.SHA256,
+				PbHashType.SHA512,
+			]) {
+				for (const keyTemplate of [
+					AeadKeyTemplates.aes128CtrHmacSha256(),
+					AeadKeyTemplates.aes128Gcm(),
+				]) {
+					for (const pointFormat of [
+						PbPointFormat.UNCOMPRESSED,
+						PbPointFormat.COMPRESSED,
+						PbPointFormat.DO_NOT_USE_CRUNCHY_UNCOMPRESSED,
+					]) {
+						const params = createParams(
+							curve,
+							hashType,
+							keyTemplate,
+							pointFormat
+						);
+						EciesAeadHkdfValidators.validateParams(params);
+					}
+				}
+			}
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateParams(invalidParams);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownPointFormat());
-    }
-  });
-  it('validate params, different valid values', function() {
-    for (const curve
-             of [PbEllipticCurveType.NIST_P256,
-                 PbEllipticCurveType.NIST_P384,
-                 PbEllipticCurveType.NIST_P521,
-    ]) {
-      for (const hashType
-               of [PbHashType.SHA1,
-                   PbHashType.SHA384,
-                   PbHashType.SHA256,
-                   PbHashType.SHA512,
-      ]) {
-        for (const keyTemplate
-                 of [AeadKeyTemplates.aes128CtrHmacSha256(),
-                     AeadKeyTemplates.aes128Gcm(),
-        ]) {
-          for (const pointFormat
-                   of [PbPointFormat.UNCOMPRESSED,
-                       PbPointFormat.COMPRESSED,
-                       PbPointFormat.DO_NOT_USE_CRUNCHY_UNCOMPRESSED,
-          ]) {
-            const params =
-                createParams(curve, hashType, keyTemplate, pointFormat);
-            EciesAeadHkdfValidators.validateParams(params);
-          }
-        }
-      }
-    }
-  });
+	it("validate key format, missing params", () => {
+		const invalidKeyFormat = new PbEciesAeadHkdfKeyFormat();
 
-  it('validate key format, missing params', function() {
-    const invalidKeyFormat = new PbEciesAeadHkdfKeyFormat();
+		try {
+			EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingFormatParams());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingFormatParams());
-    }
-  });
+	it("validate key format, invalid params", () => {
+		const invalidKeyFormat = new PbEciesAeadHkdfKeyFormat().setParams(
+			createParams()
+		);
 
-  it('validate key format, invalid params', function() {
-    const invalidKeyFormat =
-        new PbEciesAeadHkdfKeyFormat().setParams(createParams());
+		// Check that also params were checked.
+		// Test missing DEM params.
+		invalidKeyFormat.getParams()?.setDemParams(null);
+		try {
+			EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingDemParams());
+		}
+		invalidKeyFormat.getParams()?.setDemParams(createDemParams());
 
-    // Check that also params were checked.
-    // Test missing DEM params.
-    invalidKeyFormat.getParams()?.setDemParams(null);
-    try {
-      EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingDemParams());
-    }
-    invalidKeyFormat.getParams()?.setDemParams(createDemParams());
+		// Test UNKNOWN_HASH in KEM params.
+		invalidKeyFormat
+			.getParams()
+			?.getKemParams()
+			?.setHkdfHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHashType());
+		}
+	});
 
-    // Test UNKNOWN_HASH in KEM params.
-    invalidKeyFormat.getParams()?.getKemParams()?.setHkdfHashType(
-        PbHashType.UNKNOWN_HASH);
-    try {
-      EciesAeadHkdfValidators.validateKeyFormat(invalidKeyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHashType());
-    }
-  });
+	it("validate public key, missing params", () => {
+		const invalidPublicKey = new PbEciesAeadHkdfPublicKey();
 
-  it('validate public key, missing params', function() {
-    const invalidPublicKey = new PbEciesAeadHkdfPublicKey();
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKeyParams());
+		}
+	});
 
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKeyParams());
-    }
-  });
+	it("validate public key, missing values x y", () => {
+		const invalidPublicKey = new PbEciesAeadHkdfPublicKey().setParams(
+			createParams()
+		);
 
-  it('validate public key, missing values x y', function() {
-    const invalidPublicKey =
-        new PbEciesAeadHkdfPublicKey().setParams(createParams());
+		// Both X and Y are set to empty.
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingXY());
+		}
 
-    // Both X and Y are set to empty.
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingXY());
-    }
+		// The key with only Y set to empty is also invalid.
+		invalidPublicKey.setX(new Uint8Array(10));
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingXY());
+		}
 
-    // The key with only Y set to empty is also invalid.
-    invalidPublicKey.setX(new Uint8Array(10));
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingXY());
-    }
+		// The key with only X set to empty is also invalid.
+		invalidPublicKey.setY(new Uint8Array(10));
+		invalidPublicKey.setX(new Uint8Array(0));
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingXY());
+		}
+	});
 
-    // The key with only X set to empty is also invalid.
-    invalidPublicKey.setY(new Uint8Array(10));
-    invalidPublicKey.setX(new Uint8Array(0));
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingXY());
-    }
-  });
+	it("validate public key, invalid params", async () => {
+		const invalidPublicKey = await createPublicKey();
 
-  it('validate public key, invalid params', async function() {
-    const invalidPublicKey = await createPublicKey();
+		// Check that also params were checked.
+		// Test missing DEM params.
+		invalidPublicKey.getParams()?.setDemParams(null);
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingDemParams());
+		}
+		invalidPublicKey.getParams()?.setDemParams(createDemParams());
 
-    // Check that also params were checked.
-    // Test missing DEM params.
-    invalidPublicKey.getParams()?.setDemParams(null);
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingDemParams());
-    }
-    invalidPublicKey.getParams()?.setDemParams(createDemParams());
+		// Test UNKNOWN_HASH in KEM params.
+		invalidPublicKey
+			.getParams()
+			?.getKemParams()
+			?.setHkdfHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHashType());
+		}
+	});
 
-    // Test UNKNOWN_HASH in KEM params.
-    invalidPublicKey.getParams()?.getKemParams()?.setHkdfHashType(
-        PbHashType.UNKNOWN_HASH);
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(invalidPublicKey, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHashType());
-    }
-  });
+	it("validate public key, version out of bounds", async () => {
+		const managerVersion = 0;
+		const invalidPublicKey = (await createPublicKey()).setVersion(1);
+		try {
+			EciesAeadHkdfValidators.validatePublicKey(
+				invalidPublicKey,
+				managerVersion
+			);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.versionOutOfBounds(managerVersion)
+			);
+		}
+	});
 
-  it('validate public key, version out of bounds', async function() {
-    const managerVersion = 0;
-    const invalidPublicKey = (await createPublicKey()).setVersion(1);
-    try {
-      EciesAeadHkdfValidators.validatePublicKey(
-          invalidPublicKey, managerVersion);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.versionOutOfBounds(managerVersion));
-    }
-  });
+	it("validate private key, missing public key", async () => {
+		const invalidPrivateKey = (await createPrivateKey()).setPublicKey(null);
+		try {
+			EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingPublicKey());
+		}
+	});
 
-  it('validate private key, missing public key', async function() {
-    const invalidPrivateKey = (await createPrivateKey()).setPublicKey(null);
-    try {
-      EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingPublicKey());
-    }
-  });
+	it("validate private key, invalid public key", async () => {
+		const invalidPrivateKey = await createPrivateKey();
+		invalidPrivateKey.getPublicKey()?.setParams(null);
+		try {
+			EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingKeyParams());
+		}
+	});
 
-  it('validate private key, invalid public key', async function() {
-    const invalidPrivateKey = await createPrivateKey();
-    invalidPrivateKey.getPublicKey()?.setParams(null);
-    try {
-      EciesAeadHkdfValidators.validatePrivateKey(invalidPrivateKey, 0, 0);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingKeyParams());
-    }
-  });
+	it("validate private key, should work", async () => {
+		const privateKey = await createPrivateKey();
+		EciesAeadHkdfValidators.validatePrivateKey(privateKey, 0, 0);
+	});
 
-  it('validate private key, should work', async function() {
-    const privateKey = await createPrivateKey();
-    EciesAeadHkdfValidators.validatePrivateKey(privateKey, 0, 0);
-  });
-
-  it('validate private key, version out of bounds', async function() {
-    const managerVersion = 0;
-    const invalidPrivateKey = (await createPrivateKey()).setVersion(1);
-    try {
-      EciesAeadHkdfValidators.validatePrivateKey(
-          invalidPrivateKey, managerVersion, managerVersion);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.versionOutOfBounds(managerVersion));
-    }
-  });
+	it("validate private key, version out of bounds", async () => {
+		const managerVersion = 0;
+		const invalidPrivateKey = (await createPrivateKey()).setVersion(1);
+		try {
+			EciesAeadHkdfValidators.validatePrivateKey(
+				invalidPrivateKey,
+				managerVersion,
+				managerVersion
+			);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.versionOutOfBounds(managerVersion)
+			);
+		}
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static missingFormatParams(): string {
-    return 'SecurityException: Invalid key format - missing key params.';
-  }
+	static missingFormatParams(): string {
+		return "SecurityException: Invalid key format - missing key params.";
+	}
 
-  static missingKeyParams(): string {
-    return 'SecurityException: Invalid public key - missing key params.';
-  }
+	static missingKeyParams(): string {
+		return "SecurityException: Invalid public key - missing key params.";
+	}
 
-  static unknownPointFormat(): string {
-    return 'SecurityException: Invalid key params - unknown EC point format.';
-  }
+	static unknownPointFormat(): string {
+		return "SecurityException: Invalid key params - unknown EC point format.";
+	}
 
-  static missingKemParams(): string {
-    return 'SecurityException: Invalid params - missing KEM params.';
-  }
+	static missingKemParams(): string {
+		return "SecurityException: Invalid params - missing KEM params.";
+	}
 
-  static unknownHashType(): string {
-    return 'SecurityException: Invalid KEM params - unknown hash type.';
-  }
+	static unknownHashType(): string {
+		return "SecurityException: Invalid KEM params - unknown hash type.";
+	}
 
-  static unknownCurveType(): string {
-    return 'SecurityException: Invalid KEM params - unknown curve type.';
-  }
+	static unknownCurveType(): string {
+		return "SecurityException: Invalid KEM params - unknown curve type.";
+	}
 
-  static missingDemParams(): string {
-    return 'SecurityException: Invalid params - missing DEM params.';
-  }
+	static missingDemParams(): string {
+		return "SecurityException: Invalid params - missing DEM params.";
+	}
 
-  static missingAeadTemplate(): string {
-    return 'SecurityException: Invalid DEM params - missing AEAD key template.';
-  }
+	static missingAeadTemplate(): string {
+		return "SecurityException: Invalid DEM params - missing AEAD key template.";
+	}
 
-  static unsupportedKeyTemplate(templateTypeUrl: string): string {
-    return 'SecurityException: Invalid DEM params - ' + templateTypeUrl +
-        ' template is not supported by ECIES AEAD HKDF.';
-  }
+	static unsupportedKeyTemplate(templateTypeUrl: string): string {
+		return (
+			"SecurityException: Invalid DEM params - " +
+			templateTypeUrl +
+			" template is not supported by ECIES AEAD HKDF."
+		);
+	}
 
-  static missingXY(): string {
-    return 'SecurityException: Invalid public key - missing value of X or Y.';
-  }
+	static missingXY(): string {
+		return "SecurityException: Invalid public key - missing value of X or Y.";
+	}
 
-  static missingPublicKey(): string {
-    return 'SecurityException: Invalid private key - missing public key information.';
-  }
+	static missingPublicKey(): string {
+		return "SecurityException: Invalid private key - missing public key information.";
+	}
 
-  static missingPrivateKeyValue(): string {
-    return 'SecurityException: Invalid private key - missing private key value.';
-  }
+	static missingPrivateKeyValue(): string {
+		return "SecurityException: Invalid private key - missing private key value.";
+	}
 
-  static versionOutOfBounds(version: number): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        version + '.';
-  }
+	static versionOutOfBounds(version: number): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			version +
+			"."
+		);
+	}
 }
 
 function createKemParams(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256): PbEciesHkdfKemParams {
-  const kemParams = new PbEciesHkdfKemParams()
-                        .setCurveType(opt_curveType)
-                        .setHkdfHashType(opt_hashType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256
+): PbEciesHkdfKemParams {
+	const kemParams = new PbEciesHkdfKemParams()
+		.setCurveType(opt_curveType)
+		.setHkdfHashType(opt_hashType);
 
-  return kemParams;
+	return kemParams;
 }
 
-function createDemParams(opt_keyTemplate?: PbKeyTemplate):
-    PbEciesAeadDemParams {
-  if (!opt_keyTemplate) {
-    opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-  }
+function createDemParams(
+	opt_keyTemplate?: PbKeyTemplate
+): PbEciesAeadDemParams {
+	if (!opt_keyTemplate) {
+		opt_keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+	}
 
-  const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
+	const demParams = new PbEciesAeadDemParams().setAeadDem(opt_keyTemplate);
 
-  return demParams;
+	return demParams;
 }
 
 function createParams(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat: PbPointFormat =
-        PbPointFormat.UNCOMPRESSED): PbEciesAeadHkdfParams {
-  const params = new PbEciesAeadHkdfParams()
-                     .setKemParams(createKemParams(opt_curveType, opt_hashType))
-                     .setDemParams(createDemParams(opt_keyTemplate))
-                     .setEcPointFormat(opt_pointFormat);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat: PbPointFormat = PbPointFormat.UNCOMPRESSED
+): PbEciesAeadHkdfParams {
+	const params = new PbEciesAeadHkdfParams()
+		.setKemParams(createKemParams(opt_curveType, opt_hashType))
+		.setDemParams(createDemParams(opt_keyTemplate))
+		.setEcPointFormat(opt_pointFormat);
 
-  return params;
+	return params;
 }
 
 async function createPrivateKey(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType?: PbHashType, opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): Promise<PbEciesAeadHkdfPrivateKey> {
-  const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
-  const curveName = EllipticCurves.curveToString(curveSubtleType);
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): Promise<PbEciesAeadHkdfPrivateKey> {
+	const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
+	const curveName = EllipticCurves.curveToString(curveSubtleType);
 
-  const publicKeyProto =
-      new PbEciesAeadHkdfPublicKey().setVersion(0).setParams(createParams(
-          opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat));
-  const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
-  const jsonPublicKey =
-      await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-  publicKeyProto.setX(Bytes.fromBase64(
-      assertExists(jsonPublicKey['x']), /* opt_webSafe = */ true));
-  publicKeyProto.setY(Bytes.fromBase64(
-      assertExists(jsonPublicKey['y']), /* opt_webSafe = */ true));
+	const publicKeyProto = new PbEciesAeadHkdfPublicKey()
+		.setVersion(0)
+		.setParams(
+			createParams(
+				opt_curveType,
+				opt_hashType,
+				opt_keyTemplate,
+				opt_pointFormat
+			)
+		);
+	const keyPair = await EllipticCurves.generateKeyPair("ECDH", curveName);
+	const jsonPublicKey = await EllipticCurves.exportCryptoKey(
+		keyPair.publicKey!
+	);
+	publicKeyProto.setX(
+		Bytes.fromBase64(
+			assertExists(jsonPublicKey["x"]),
+			/* opt_webSafe = */ true
+		)
+	);
+	publicKeyProto.setY(
+		Bytes.fromBase64(
+			assertExists(jsonPublicKey["y"]),
+			/* opt_webSafe = */ true
+		)
+	);
 
+	const privateKeyProto = new PbEciesAeadHkdfPrivateKey()
+		.setVersion(0)
+		.setPublicKey(publicKeyProto);
+	const jsonPrivateKey = await EllipticCurves.exportCryptoKey(
+		keyPair.privateKey!
+	);
+	privateKeyProto.setKeyValue(
+		Bytes.fromBase64(
+			assertExists(jsonPrivateKey["d"]),
+			/* opt_webSafe = */ true
+		)
+	);
 
-  const privateKeyProto =
-      new PbEciesAeadHkdfPrivateKey().setVersion(0).setPublicKey(
-          publicKeyProto);
-  const jsonPrivateKey =
-      await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-  privateKeyProto.setKeyValue(Bytes.fromBase64(
-      assertExists(jsonPrivateKey['d']), /* opt_webSafe = */ true));
-
-  return privateKeyProto;
+	return privateKeyProto;
 }
 
 async function createPublicKey(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_keyTemplate?: PbKeyTemplate,
-    opt_pointFormat?: PbPointFormat): Promise<PbEciesAeadHkdfPublicKey> {
-  const key = await createPrivateKey(
-      opt_curveType, opt_hashType, opt_keyTemplate, opt_pointFormat);
-  return assertExists(key.getPublicKey());
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_keyTemplate?: PbKeyTemplate,
+	opt_pointFormat?: PbPointFormat
+): Promise<PbEciesAeadHkdfPublicKey> {
+	const key = await createPrivateKey(
+		opt_curveType,
+		opt_hashType,
+		opt_keyTemplate,
+		opt_pointFormat
+	);
+	return assertExists(key.getPublicKey());
 }

--- a/javascript/hybrid/hybrid_config_test.ts
+++ b/javascript/hybrid/hybrid_config_test.ts
@@ -4,110 +4,139 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {KeysetHandle} from '../internal/keyset_handle';
-import {PbKeyData, PbKeyset, PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
+import { KeysetHandle } from "../internal/keyset_handle";
+import {
+	PbKeyData,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
 
-import {EciesAeadHkdfPrivateKeyManager} from './ecies_aead_hkdf_private_key_manager';
-import {EciesAeadHkdfPublicKeyManager} from './ecies_aead_hkdf_public_key_manager';
-import * as HybridConfig from './hybrid_config';
-import {HybridKeyTemplates} from './hybrid_key_templates';
-import {HybridDecrypt} from './internal/hybrid_decrypt';
-import {HybridEncrypt} from './internal/hybrid_encrypt';
+import { EciesAeadHkdfPrivateKeyManager } from "./ecies_aead_hkdf_private_key_manager";
+import { EciesAeadHkdfPublicKeyManager } from "./ecies_aead_hkdf_public_key_manager";
+import * as HybridConfig from "./hybrid_config";
+import { HybridKeyTemplates } from "./hybrid_key_templates";
+import { HybridDecrypt } from "./internal/hybrid_decrypt";
+import { HybridEncrypt } from "./internal/hybrid_encrypt";
 
-describe('hybrid config test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("hybrid config test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('constants', function() {
-    expect(HybridConfig.ENCRYPT_PRIMITIVE_NAME).toBe(ENCRYPT_PRIMITIVE_NAME);
-    expect(HybridConfig.DECRYPT_PRIMITIVE_NAME).toBe(DECRYPT_PRIMITIVE_NAME);
+	it("constants", () => {
+		expect(HybridConfig.ENCRYPT_PRIMITIVE_NAME).toBe(
+			ENCRYPT_PRIMITIVE_NAME
+		);
+		expect(HybridConfig.DECRYPT_PRIMITIVE_NAME).toBe(
+			DECRYPT_PRIMITIVE_NAME
+		);
 
-    expect(HybridConfig.ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE)
-        .toBe(ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE);
-    expect(HybridConfig.ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE)
-        .toBe(ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE);
-  });
+		expect(HybridConfig.ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE).toBe(
+			ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE
+		);
+		expect(HybridConfig.ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE).toBe(
+			ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE
+		);
+	});
 
-  it('register, correct key managers were registered', function() {
-    HybridConfig.register();
+	it("register, correct key managers were registered", () => {
+		HybridConfig.register();
 
-    // Test that the corresponding key managers were registered.
-    const publicKeyManager =
-        Registry.getKeyManager(ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE);
-    expect(publicKeyManager instanceof EciesAeadHkdfPublicKeyManager)
-        .toBe(true);
+		// Test that the corresponding key managers were registered.
+		const publicKeyManager = Registry.getKeyManager(
+			ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE
+		);
+		expect(publicKeyManager instanceof EciesAeadHkdfPublicKeyManager).toBe(
+			true
+		);
 
-    const privateKeyManager =
-        Registry.getKeyManager(ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE);
-    expect(privateKeyManager instanceof EciesAeadHkdfPrivateKeyManager)
-        .toBe(true);
-  });
+		const privateKeyManager = Registry.getKeyManager(
+			ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE
+		);
+		expect(
+			privateKeyManager instanceof EciesAeadHkdfPrivateKeyManager
+		).toBe(true);
+	});
 
-  // Check that everything was registered correctly and thus new keys may be
-  // generated using the predefined key templates and then they may be used for
-  // encryption and decryption.
-  it('register, predefined templates should work', async function() {
-    HybridConfig.register();
-    let templates = [
-      HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm(),
-      HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128CtrHmacSha256()
-    ];
-    for (const template of templates) {
-      const privateKeyData = await Registry.newKeyData(template);
-      const privateKeysetHandle = createKeysetHandleFromKeyData(privateKeyData);
-      const hybridDecrypt =
-          await privateKeysetHandle.getPrimitive<HybridDecrypt>(HybridDecrypt);
+	// Check that everything was registered correctly and thus new keys may be
+	// generated using the predefined key templates and then they may be used for
+	// encryption and decryption.
+	it("register, predefined templates should work", async () => {
+		HybridConfig.register();
+		let templates = [
+			HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm(),
+			HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128CtrHmacSha256(),
+		];
+		for (const template of templates) {
+			const privateKeyData = await Registry.newKeyData(template);
+			const privateKeysetHandle =
+				createKeysetHandleFromKeyData(privateKeyData);
+			const hybridDecrypt =
+				await privateKeysetHandle.getPrimitive<HybridDecrypt>(
+					HybridDecrypt
+				);
 
-      const publicKeyData = Registry.getPublicKeyData(
-          privateKeyData.getTypeUrl(), bytesAsU8(privateKeyData.getValue()));
-      const publicKeysetHandle = createKeysetHandleFromKeyData(publicKeyData);
-      const hybridEncrypt =
-          await publicKeysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
+			const publicKeyData = Registry.getPublicKeyData(
+				privateKeyData.getTypeUrl(),
+				bytesAsU8(privateKeyData.getValue())
+			);
+			const publicKeysetHandle =
+				createKeysetHandleFromKeyData(publicKeyData);
+			const hybridEncrypt =
+				await publicKeysetHandle.getPrimitive<HybridEncrypt>(
+					HybridEncrypt
+				);
 
-      const plaintext = new Uint8Array(Random.randBytes(10));
-      const contextInfo = new Uint8Array(Random.randBytes(8));
-      const ciphertext = await hybridEncrypt.encrypt(plaintext, contextInfo);
-      const decryptedCiphertext =
-          await hybridDecrypt.decrypt(ciphertext, contextInfo);
+			const plaintext = new Uint8Array(Random.randBytes(10));
+			const contextInfo = new Uint8Array(Random.randBytes(8));
+			const ciphertext = await hybridEncrypt.encrypt(
+				plaintext,
+				contextInfo
+			);
+			const decryptedCiphertext = await hybridDecrypt.decrypt(
+				ciphertext,
+				contextInfo
+			);
 
-      expect(decryptedCiphertext).toEqual(plaintext);
-    }
-  });
+			expect(decryptedCiphertext).toEqual(plaintext);
+		}
+	});
 });
 
 // Constants used in tests.
-const ENCRYPT_PRIMITIVE_NAME = 'HybridEncrypt';
-const DECRYPT_PRIMITIVE_NAME = 'HybridDecrypt';
+const ENCRYPT_PRIMITIVE_NAME = "HybridEncrypt";
+const DECRYPT_PRIMITIVE_NAME = "HybridDecrypt";
 const ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey';
+	"type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey";
 const ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EciesAeadHkdfPrivateKey';
+	"type.googleapis.com/google.crypto.tink.EciesAeadHkdfPrivateKey";
 
 /**
  * Creates a keyset containing only the key given by keyData and returns it
  * wrapped in a KeysetHandle.
  */
 function createKeysetHandleFromKeyData(keyData: PbKeyData): KeysetHandle {
-  const keyId = 1;
-  const key = new PbKeysetKey()
-                  .setKeyData(keyData)
-                  .setStatus(PbKeyStatusType.ENABLED)
-                  .setKeyId(keyId)
-                  .setOutputPrefixType(PbOutputPrefixType.TINK);
+	const keyId = 1;
+	const key = new PbKeysetKey()
+		.setKeyData(keyData)
+		.setStatus(PbKeyStatusType.ENABLED)
+		.setKeyId(keyId)
+		.setOutputPrefixType(PbOutputPrefixType.TINK);
 
-  const keyset = new PbKeyset();
-  keyset.addKey(key);
-  keyset.setPrimaryKeyId(keyId);
-  return new KeysetHandle(keyset);
+	const keyset = new PbKeyset();
+	keyset.addKey(key);
+	keyset.setPrimaryKeyId(keyId);
+	return new KeysetHandle(keyset);
 }

--- a/javascript/hybrid/hybrid_decrypt_wrapper_test.ts
+++ b/javascript/hybrid/hybrid_decrypt_wrapper_test.ts
@@ -4,300 +4,351 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {SecurityException} from '../exception/security_exception';
-import * as PrimitiveSet from '../internal/primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Bytes from '../subtle/bytes';
-import * as Random from '../subtle/random';
+import { SecurityException } from "../exception/security_exception";
+import * as PrimitiveSet from "../internal/primitive_set";
+import {
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Bytes from "../subtle/bytes";
+import * as Random from "../subtle/random";
 
-import {HybridDecryptWrapper} from './hybrid_decrypt_wrapper';
-import {HybridEncryptWrapper} from './hybrid_encrypt_wrapper';
-import {HybridDecrypt} from './internal/hybrid_decrypt';
-import {HybridEncrypt} from './internal/hybrid_encrypt';
+import { HybridDecryptWrapper } from "./hybrid_decrypt_wrapper";
+import { HybridEncryptWrapper } from "./hybrid_encrypt_wrapper";
+import { HybridDecrypt } from "./internal/hybrid_decrypt";
+import { HybridEncrypt } from "./internal/hybrid_encrypt";
 
-describe('hybrid decrypt wrapper test', function() {
-  it('decrypt, invalid ciphertext', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
-    // Ciphertext which cannot be decrypted by any primitive in the primitive
-    // set.
-    const ciphertext = new Uint8Array([9, 8, 7, 6, 5, 4, 3]);
+describe("hybrid decrypt wrapper test", () => {
+	it("decrypt, invalid ciphertext", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
+		// Ciphertext which cannot be decrypted by any primitive in the primitive
+		// set.
+		const ciphertext = new Uint8Array([9, 8, 7, 6, 5, 4, 3]);
 
-    try {
-      await hybridDecrypt.decrypt(ciphertext);
-      fail('Should throw an exception');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-    }
-  });
+		try {
+			await hybridDecrypt.decrypt(ciphertext);
+			fail("Should throw an exception");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+		}
+	});
 
-  it('decrypt, should work', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const plaintext = Random.randBytes(10);
-    // As keys are just dummy keys which do not contain key data, the same key
-    // is used for both encrypt and decrypt.
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.TINK,
-        /** enabled = */ true);
-    const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xFF]);
+	it("decrypt, should work", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const plaintext = Random.randBytes(10);
+		// As keys are just dummy keys which do not contain key data, the same key
+		// is used for both encrypt and decrypt.
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.TINK,
+			/** enabled = */ true
+		);
+		const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xff]);
 
-    // Get the ciphertext.
-    const encryptPrimitiveSet = primitiveSets['encryptPrimitiveSet'];
-    const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
-    const entry = encryptPrimitiveSet.addPrimitive(encryptPrimitive, key);
-    // Has to be set to primary as then it is used in encryption.
-    encryptPrimitiveSet.setPrimary(entry);
-    const hybridEncrypt = new HybridEncryptWrapper().wrap(encryptPrimitiveSet);
-    const ciphertext = await hybridEncrypt.encrypt(plaintext);
+		// Get the ciphertext.
+		const encryptPrimitiveSet = primitiveSets["encryptPrimitiveSet"];
+		const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
+		const entry = encryptPrimitiveSet.addPrimitive(encryptPrimitive, key);
+		// Has to be set to primary as then it is used in encryption.
+		encryptPrimitiveSet.setPrimary(entry);
+		const hybridEncrypt = new HybridEncryptWrapper().wrap(
+			encryptPrimitiveSet
+		);
+		const ciphertext = await hybridEncrypt.encrypt(plaintext);
 
-    // Create a primitive set containing the primitive which can be used for
-    // encryption. Add also few more primitives with the same key as the
-    // primitive set should decrypt the ciphertext whenever there is at least
-    // one primitive which does not fail to decrypt the ciphertext.
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
-    decryptPrimitiveSet.addPrimitive(
-        new DummyHybridDecrypt(Random.randBytes(5)), key);
-    decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
-    decryptPrimitiveSet.addPrimitive(
-        new DummyHybridDecrypt(Random.randBytes(5)), key);
+		// Create a primitive set containing the primitive which can be used for
+		// encryption. Add also few more primitives with the same key as the
+		// primitive set should decrypt the ciphertext whenever there is at least
+		// one primitive which does not fail to decrypt the ciphertext.
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
+		decryptPrimitiveSet.addPrimitive(
+			new DummyHybridDecrypt(Random.randBytes(5)),
+			key
+		);
+		decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
+		decryptPrimitiveSet.addPrimitive(
+			new DummyHybridDecrypt(Random.randBytes(5)),
+			key
+		);
 
-    // Decrypt the ciphertext.
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
-    const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
+		// Decrypt the ciphertext.
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
+		const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
 
-    // Test that the result is the original plaintext.
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		// Test that the result is the original plaintext.
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 
-  it('decrypt, ciphertext encrypted by raw primitive', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const plaintext = Random.randBytes(10);
-    // As keys are just dummy keys which do not contain key data, the same key
-    // is used for both encrypt and decrypt.
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.RAW,
-        /** enabled = */ true);
-    const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xFF]);
+	it("decrypt, ciphertext encrypted by raw primitive", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const plaintext = Random.randBytes(10);
+		// As keys are just dummy keys which do not contain key data, the same key
+		// is used for both encrypt and decrypt.
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.RAW,
+			/** enabled = */ true
+		);
+		const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xff]);
 
-    // Get the ciphertext.
-    const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
-    const ciphertext = await encryptPrimitive.encrypt(plaintext);
+		// Get the ciphertext.
+		const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
+		const ciphertext = await encryptPrimitive.encrypt(plaintext);
 
-    // Decrypt the ciphertext.
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
-    decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
-    const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
+		// Decrypt the ciphertext.
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
+		decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
+		const decryptedCiphertext = await hybridDecrypt.decrypt(ciphertext);
 
-    // Test that the result is the original plaintext.
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		// Test that the result is the original plaintext.
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 
-  it('decrypt, with context info', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const plaintext = Random.randBytes(10);
-    const contextInfo = Random.randBytes(10);
-    // As keys are just dummy keys which do not contain key data, the same key
-    // is used for both encrypt and decrypt.
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.RAW,
-        /** enabled = */ true);
-    const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xFF]);
+	it("decrypt, with context info", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const plaintext = Random.randBytes(10);
+		const contextInfo = Random.randBytes(10);
+		// As keys are just dummy keys which do not contain key data, the same key
+		// is used for both encrypt and decrypt.
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.RAW,
+			/** enabled = */ true
+		);
+		const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xff]);
 
-    // Get the ciphertext.
-    const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
-    const ciphertext = await encryptPrimitive.encrypt(plaintext, contextInfo);
+		// Get the ciphertext.
+		const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
+		const ciphertext = await encryptPrimitive.encrypt(
+			plaintext,
+			contextInfo
+		);
 
-    // Get primitive for decryption.
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
-    decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
+		// Get primitive for decryption.
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
+		decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
 
-    // Check that contextInfo was passed correctly (decryption without
-    // contextInfo argument should not work, but with contextInfo it should work
-    // properly).
-    try {
-      await hybridDecrypt.decrypt(ciphertext);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-    }
-    const decryptedCiphertext =
-        await hybridDecrypt.decrypt(ciphertext, contextInfo);
+		// Check that contextInfo was passed correctly (decryption without
+		// contextInfo argument should not work, but with contextInfo it should work
+		// properly).
+		try {
+			await hybridDecrypt.decrypt(ciphertext);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+		}
+		const decryptedCiphertext = await hybridDecrypt.decrypt(
+			ciphertext,
+			contextInfo
+		);
 
-    // Test that the result is the original plaintext.
-    expect(decryptedCiphertext).toEqual(plaintext);
-  });
+		// Test that the result is the original plaintext.
+		expect(decryptedCiphertext).toEqual(plaintext);
+	});
 
-  it('decrypt, with disabled primitive', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const plaintext = Random.randBytes(10);
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.RAW,
-        /** enabled = */ false);
-    const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xFF]);
+	it("decrypt, with disabled primitive", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const plaintext = Random.randBytes(10);
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.RAW,
+			/** enabled = */ false
+		);
+		const ciphertextSuffix = new Uint8Array([0, 0, 0, 0xff]);
 
-    const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
-    const ciphertext = await encryptPrimitive.encrypt(plaintext);
+		const encryptPrimitive = new DummyHybridEncrypt(ciphertextSuffix);
+		const ciphertext = await encryptPrimitive.encrypt(plaintext);
 
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
-    decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const decryptPrimitive = new DummyHybridDecrypt(ciphertextSuffix);
+		decryptPrimitiveSet.addPrimitive(decryptPrimitive, key);
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
 
-    try {
-      await hybridDecrypt.decrypt(ciphertext);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-    }
-  });
+		try {
+			await hybridDecrypt.decrypt(ciphertext);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+		}
+	});
 
-  it('decrypt, with empty ciphertext', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const decryptPrimitiveSet = primitiveSets['decryptPrimitiveSet'];
-    const hybridDecrypt = new HybridDecryptWrapper().wrap(decryptPrimitiveSet);
+	it("decrypt, with empty ciphertext", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const decryptPrimitiveSet = primitiveSets["decryptPrimitiveSet"];
+		const hybridDecrypt = new HybridDecryptWrapper().wrap(
+			decryptPrimitiveSet
+		);
 
-    try {
-      await hybridDecrypt.decrypt(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
-    }
-  });
+		try {
+			await hybridDecrypt.decrypt(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.cannotBeDecrypted());
+		}
+	});
 });
 
 /** @final */
 class ExceptionText {
-  static nullPrimitiveSet(): string {
-    return 'SecurityException: Primitive set has to be non-null.';
-  }
+	static nullPrimitiveSet(): string {
+		return "SecurityException: Primitive set has to be non-null.";
+	}
 
-  static cannotBeDecrypted(): string {
-    return 'SecurityException: Decryption failed for the given ciphertext.';
-  }
+	static cannotBeDecrypted(): string {
+		return "SecurityException: Decryption failed for the given ciphertext.";
+	}
 
-  static nullCiphertext(): string {
-    return 'SecurityException: Ciphertext has to be non-null.';
-  }
+	static nullCiphertext(): string {
+		return "SecurityException: Ciphertext has to be non-null.";
+	}
 }
 
 /** Function for creating keys for testing purposes. */
 function createDummyKeysetKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  return key;
+	return key;
 }
 
 /**
  * Creates a primitive sets for HybridEncrypt and HybridDecrypt with
- * 'numberOfPrimitives' primitives. The keys corresponding to the primitives
+ * "numberOfPrimitives" primitives. The keys corresponding to the primitives
  * have ids from the set [1, ..., numberOfPrimitives] and the primitive
- * corresponding to key with id 'numberOfPrimitives' is set to be primary
+ * corresponding to key with id "numberOfPrimitives" is set to be primary
  * whenever opt_withPrimary is set to true (where true is the default value).
  */
 function createDummyPrimitiveSets(opt_withPrimary: boolean = true): {
-  encryptPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyHybridEncrypt>,
-  decryptPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyHybridDecrypt>
+	encryptPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyHybridEncrypt>;
+	decryptPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyHybridDecrypt>;
 } {
-  const numberOfPrimitives = 5;
+	const numberOfPrimitives = 5;
 
-  const encryptPrimitiveSet =
-      new PrimitiveSet.PrimitiveSet<DummyHybridEncrypt>(DummyHybridEncrypt);
-  const decryptPrimitiveSet =
-      new PrimitiveSet.PrimitiveSet<DummyHybridDecrypt>(DummyHybridDecrypt);
-  for (let i = 1; i < numberOfPrimitives; i++) {
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    const key =
-        createDummyKeysetKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
-    const ciphertextSuffix = new Uint8Array([0, 0, i]);
-    const hybridEncrypt = new DummyHybridEncrypt(ciphertextSuffix);
-    encryptPrimitiveSet.addPrimitive(hybridEncrypt, key);
-    const hybridDecrypt = new DummyHybridDecrypt(ciphertextSuffix);
-    decryptPrimitiveSet.addPrimitive(hybridDecrypt, key);
-  }
+	const encryptPrimitiveSet =
+		new PrimitiveSet.PrimitiveSet<DummyHybridEncrypt>(DummyHybridEncrypt);
+	const decryptPrimitiveSet =
+		new PrimitiveSet.PrimitiveSet<DummyHybridDecrypt>(DummyHybridDecrypt);
+	for (let i = 1; i < numberOfPrimitives; i++) {
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		const key = createDummyKeysetKey(
+			i,
+			outputPrefix,
+			/* enabled = */ i % 4 < 2
+		);
+		const ciphertextSuffix = new Uint8Array([0, 0, i]);
+		const hybridEncrypt = new DummyHybridEncrypt(ciphertextSuffix);
+		encryptPrimitiveSet.addPrimitive(hybridEncrypt, key);
+		const hybridDecrypt = new DummyHybridDecrypt(ciphertextSuffix);
+		decryptPrimitiveSet.addPrimitive(hybridDecrypt, key);
+	}
 
-  const key = createDummyKeysetKey(
-      numberOfPrimitives, PbOutputPrefixType.TINK, /* enabled = */ true);
-  const ciphertextSuffix = new Uint8Array([0, 0, numberOfPrimitives]);
-  const hybridEncrypt = new DummyHybridEncrypt(ciphertextSuffix);
-  const encryptEntry = encryptPrimitiveSet.addPrimitive(hybridEncrypt, key);
-  const hybridDecrypt = new DummyHybridDecrypt(ciphertextSuffix);
-  const decryptEntry = decryptPrimitiveSet.addPrimitive(hybridDecrypt, key);
-  if (opt_withPrimary) {
-    encryptPrimitiveSet.setPrimary(encryptEntry);
-    decryptPrimitiveSet.setPrimary(decryptEntry);
-  }
+	const key = createDummyKeysetKey(
+		numberOfPrimitives,
+		PbOutputPrefixType.TINK,
+		/* enabled = */ true
+	);
+	const ciphertextSuffix = new Uint8Array([0, 0, numberOfPrimitives]);
+	const hybridEncrypt = new DummyHybridEncrypt(ciphertextSuffix);
+	const encryptEntry = encryptPrimitiveSet.addPrimitive(hybridEncrypt, key);
+	const hybridDecrypt = new DummyHybridDecrypt(ciphertextSuffix);
+	const decryptEntry = decryptPrimitiveSet.addPrimitive(hybridDecrypt, key);
+	if (opt_withPrimary) {
+		encryptPrimitiveSet.setPrimary(encryptEntry);
+		decryptPrimitiveSet.setPrimary(decryptEntry);
+	}
 
-  return {
-    'encryptPrimitiveSet': encryptPrimitiveSet,
-    'decryptPrimitiveSet': decryptPrimitiveSet
-  };
+	return {
+		encryptPrimitiveSet: encryptPrimitiveSet,
+		decryptPrimitiveSet: decryptPrimitiveSet,
+	};
 }
 
 /** @final */
 class DummyHybridEncrypt extends HybridEncrypt {
-  constructor(private readonly ciphertextSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly ciphertextSuffix: Uint8Array) {
+		super();
+	}
 
-  async encrypt(plaintext: Uint8Array, opt_contextInfo?: Uint8Array) {
-    const ciphertext = Bytes.concat(plaintext, this.ciphertextSuffix);
-    if (opt_contextInfo) {
-      return Bytes.concat(ciphertext, opt_contextInfo);
-    }
-    return ciphertext;
-  }
+	async encrypt(plaintext: Uint8Array, opt_contextInfo?: Uint8Array) {
+		const ciphertext = Bytes.concat(plaintext, this.ciphertextSuffix);
+		if (opt_contextInfo) {
+			return Bytes.concat(ciphertext, opt_contextInfo);
+		}
+		return ciphertext;
+	}
 }
 
 /** @final */
 class DummyHybridDecrypt extends HybridDecrypt {
-  constructor(private readonly ciphertextSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly ciphertextSuffix: Uint8Array) {
+		super();
+	}
 
-  async decrypt(ciphertext: Uint8Array, opt_contextInfo?: Uint8Array) {
-    if (opt_contextInfo) {
-      const infoLength = opt_contextInfo.length;
-      const contextInfo =
-          ciphertext.slice(ciphertext.length - infoLength, ciphertext.length);
-      if ([...contextInfo].toString() !== [...opt_contextInfo].toString()) {
-        throw new SecurityException('Context info does not match.');
-      }
-      ciphertext = ciphertext.slice(0, ciphertext.length - infoLength);
-    }
-    const plaintext =
-        ciphertext.slice(0, ciphertext.length - this.ciphertextSuffix.length);
-    const suffix = ciphertext.slice(
-        ciphertext.length - this.ciphertextSuffix.length, ciphertext.length);
-    if ([...suffix].toString() === [...this.ciphertextSuffix].toString()) {
-      return plaintext;
-    }
-    throw new SecurityException(ExceptionText.cannotBeDecrypted());
-  }
+	async decrypt(ciphertext: Uint8Array, opt_contextInfo?: Uint8Array) {
+		if (opt_contextInfo) {
+			const infoLength = opt_contextInfo.length;
+			const contextInfo = ciphertext.slice(
+				ciphertext.length - infoLength,
+				ciphertext.length
+			);
+			if (
+				[...contextInfo].toString() !== [...opt_contextInfo].toString()
+			) {
+				throw new SecurityException("Context info does not match.");
+			}
+			ciphertext = ciphertext.slice(0, ciphertext.length - infoLength);
+		}
+		const plaintext = ciphertext.slice(
+			0,
+			ciphertext.length - this.ciphertextSuffix.length
+		);
+		const suffix = ciphertext.slice(
+			ciphertext.length - this.ciphertextSuffix.length,
+			ciphertext.length
+		);
+		if ([...suffix].toString() === [...this.ciphertextSuffix].toString()) {
+			return plaintext;
+		}
+		throw new SecurityException(ExceptionText.cannotBeDecrypted());
+	}
 }

--- a/javascript/hybrid/hybrid_encrypt_wrapper_test.ts
+++ b/javascript/hybrid/hybrid_encrypt_wrapper_test.ts
@@ -4,45 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {CryptoFormat} from '../internal/crypto_format';
-import * as PrimitiveSet from '../internal/primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Random from '../subtle/random';
-import {assertExists} from '../testing/internal/test_utils';
+import { CryptoFormat } from "../internal/crypto_format";
+import * as PrimitiveSet from "../internal/primitive_set";
+import {
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Random from "../subtle/random";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {HybridEncryptWrapper} from './hybrid_encrypt_wrapper';
-import {HybridEncrypt} from './internal/hybrid_encrypt';
+import { HybridEncryptWrapper } from "./hybrid_encrypt_wrapper";
+import { HybridEncrypt } from "./internal/hybrid_encrypt";
 
-describe('hybrid encrypt wrapper test', function() {
-  it('new hybrid encrypt, primitive set without primary', function() {
-    const primitiveSet = createDummyPrimitiveSet(/* opt_withPrimary = */ false);
-    try {
-      new HybridEncryptWrapper().wrap(primitiveSet);
-      fail('Should throw an exception.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.primitiveSetWithoutPrimary());
-    }
-  });
+describe("hybrid encrypt wrapper test", () => {
+	it("new hybrid encrypt, primitive set without primary", () => {
+		const primitiveSet = createDummyPrimitiveSet(
+			/* opt_withPrimary = */ false
+		);
+		try {
+			new HybridEncryptWrapper().wrap(primitiveSet);
+			fail("Should throw an exception.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.primitiveSetWithoutPrimary()
+			);
+		}
+	});
 
-  it('new hybrid encrypt, should work', function() {
-    const primitiveSet = createDummyPrimitiveSet();
-    const hybridEncrypt = new HybridEncryptWrapper().wrap(primitiveSet);
-    expect(hybridEncrypt != null && hybridEncrypt != undefined).toBe(true);
-  });
+	it("new hybrid encrypt, should work", () => {
+		const primitiveSet = createDummyPrimitiveSet();
+		const hybridEncrypt = new HybridEncryptWrapper().wrap(primitiveSet);
+		expect(hybridEncrypt != null && hybridEncrypt != undefined).toBe(true);
+	});
 
-  it('encrypt, should work', async function() {
-    const primitiveSet = createDummyPrimitiveSet();
-    const hybridEncrypt = new HybridEncryptWrapper().wrap(primitiveSet);
+	it("encrypt, should work", async () => {
+		const primitiveSet = createDummyPrimitiveSet();
+		const hybridEncrypt = new HybridEncryptWrapper().wrap(primitiveSet);
 
-    const plaintext = Random.randBytes(10);
+		const plaintext = Random.randBytes(10);
 
-    const ciphertext = await hybridEncrypt.encrypt(plaintext);
-    expect(ciphertext != null).toBe(true);
+		const ciphertext = await hybridEncrypt.encrypt(plaintext);
+		expect(ciphertext != null).toBe(true);
 
-    // Ciphertext should begin with primary key output prefix.
-    expect(ciphertext.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE))
-        .toEqual(assertExists(primitiveSet.getPrimary()).getIdentifier());
-  });
+		// Ciphertext should begin with primary key output prefix.
+		expect(
+			ciphertext.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE)
+		).toEqual(assertExists(primitiveSet.getPrimary()).getIdentifier());
+	});
 });
 
 /**
@@ -50,81 +59,91 @@ describe('hybrid encrypt wrapper test', function() {
  * @final
  */
 class ExceptionText {
-  static nullPrimitiveSet(): string {
-    return 'SecurityException: Primitive set has to be non-null.';
-  }
+	static nullPrimitiveSet(): string {
+		return "SecurityException: Primitive set has to be non-null.";
+	}
 
-  static primitiveSetWithoutPrimary(): string {
-    return 'SecurityException: Primary has to be non-null.';
-  }
+	static primitiveSetWithoutPrimary(): string {
+		return "SecurityException: Primary has to be non-null.";
+	}
 
-  static nullPlaintext(): string {
-    return 'SecurityException: Plaintext has to be non-null.';
-  }
+	static nullPlaintext(): string {
+		return "SecurityException: Plaintext has to be non-null.";
+	}
 }
 
 /** Function for creating keys for testing purposes. */
 function createDummyKeysetKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  return key;
+	return key;
 }
 
 /**
- * Creates a primitive set with 'numberOfPrimitives' primitives. The keys
+ * Creates a primitive set with "numberOfPrimitives" primitives. The keys
  * corresponding to the primitives have ids from the set
  * [1, ..., numberOfPrimitives] and the primitive corresponding to key with id
- * 'numberOfPrimitives' is set to be primary whenever opt_withPrimary is set to
+ * "numberOfPrimitives" is set to be primary whenever opt_withPrimary is set to
  * true (where true is the default value).
  */
-function createDummyPrimitiveSet(opt_withPrimary: boolean = true):
-    PrimitiveSet.PrimitiveSet<DummyHybridEncrypt> {
-  const numberOfPrimitives = 5;
-  const primitiveSet =
-      new PrimitiveSet.PrimitiveSet<HybridEncrypt>(HybridEncrypt);
-  for (let i = 1; i < numberOfPrimitives; i++) {
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    const key =
-        createDummyKeysetKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
-    const hybridEncrypt = new DummyHybridEncrypt();
-    primitiveSet.addPrimitive(hybridEncrypt, key);
-  }
+function createDummyPrimitiveSet(
+	opt_withPrimary: boolean = true
+): PrimitiveSet.PrimitiveSet<DummyHybridEncrypt> {
+	const numberOfPrimitives = 5;
+	const primitiveSet = new PrimitiveSet.PrimitiveSet<HybridEncrypt>(
+		HybridEncrypt
+	);
+	for (let i = 1; i < numberOfPrimitives; i++) {
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		const key = createDummyKeysetKey(
+			i,
+			outputPrefix,
+			/* enabled = */ i % 4 < 2
+		);
+		const hybridEncrypt = new DummyHybridEncrypt();
+		primitiveSet.addPrimitive(hybridEncrypt, key);
+	}
 
-  const key = createDummyKeysetKey(
-      numberOfPrimitives, PbOutputPrefixType.TINK, /* enabled = */ true);
-  const hybridEncrypt = new DummyHybridEncrypt();
-  const entry = primitiveSet.addPrimitive(hybridEncrypt, key);
-  if (opt_withPrimary) {
-    primitiveSet.setPrimary(entry);
-  }
+	const key = createDummyKeysetKey(
+		numberOfPrimitives,
+		PbOutputPrefixType.TINK,
+		/* enabled = */ true
+	);
+	const hybridEncrypt = new DummyHybridEncrypt();
+	const entry = primitiveSet.addPrimitive(hybridEncrypt, key);
+	if (opt_withPrimary) {
+		primitiveSet.setPrimary(entry);
+	}
 
-  return primitiveSet;
+	return primitiveSet;
 }
 
 /** @final */
 class DummyHybridEncrypt extends HybridEncrypt {
-  async encrypt(plaintext: Uint8Array, opt_contextInfo: Uint8Array) {
-    return plaintext;
-  }
+	async encrypt(plaintext: Uint8Array, opt_contextInfo: Uint8Array) {
+		return plaintext;
+	}
 }

--- a/javascript/hybrid/hybrid_key_templates_test.ts
+++ b/javascript/hybrid/hybrid_key_templates_test.ts
@@ -4,85 +4,94 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {PbEciesAeadHkdfKeyFormat, PbEllipticCurveType, PbHashType, PbOutputPrefixType, PbPointFormat} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import {assertMessageEquals} from '../testing/internal/test_utils';
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import {
+	PbEciesAeadHkdfKeyFormat,
+	PbEllipticCurveType,
+	PbHashType,
+	PbOutputPrefixType,
+	PbPointFormat,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import { assertMessageEquals } from "../testing/internal/test_utils";
 
-import {EciesAeadHkdfPrivateKeyManager} from './ecies_aead_hkdf_private_key_manager';
-import {HybridKeyTemplates} from './hybrid_key_templates';
+import { EciesAeadHkdfPrivateKeyManager } from "./ecies_aead_hkdf_private_key_manager";
+import { HybridKeyTemplates } from "./hybrid_key_templates";
 
-describe('hybrid key templates test', function() {
-  it('ecies p256 hkdf hmac sha256 aes128 gcm', function() {
-    // Expects function to create a key with following parameters.
-    const expectedCurve = PbEllipticCurveType.NIST_P256;
-    const expectedHkdfHashFunction = PbHashType.SHA256;
-    const expectedAeadTemplate = AeadKeyTemplates.aes128Gcm();
-    const expectedPointFormat = PbPointFormat.UNCOMPRESSED;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
+describe("hybrid key templates test", () => {
+	it("ecies p256 hkdf hmac sha256 aes128 gcm", () => {
+		// Expects function to create a key with following parameters.
+		const expectedCurve = PbEllipticCurveType.NIST_P256;
+		const expectedHkdfHashFunction = PbHashType.SHA256;
+		const expectedAeadTemplate = AeadKeyTemplates.aes128Gcm();
+		const expectedPointFormat = PbPointFormat.UNCOMPRESSED;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
 
-    // Expected type URL is the one supported by EciesAeadHkdfPrivateKeyManager.
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+		// Expected type URL is the one supported by EciesAeadHkdfPrivateKeyManager.
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm();
+		const keyTemplate =
+			HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test values in key format.
-    const keyFormat =
-        PbEciesAeadHkdfKeyFormat.deserializeBinary(keyTemplate.getValue());
-    const params = keyFormat.getParams();
-    expect(params!.getEcPointFormat()).toBe(expectedPointFormat);
+		// Test values in key format.
+		const keyFormat = PbEciesAeadHkdfKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		const params = keyFormat.getParams();
+		expect(params!.getEcPointFormat()).toBe(expectedPointFormat);
 
-    // Test KEM params.
-    const kemParams = params!.getKemParams();
-    expect(kemParams!.getCurveType()).toBe(expectedCurve);
-    expect(kemParams!.getHkdfHashType()).toBe(expectedHkdfHashFunction);
+		// Test KEM params.
+		const kemParams = params!.getKemParams();
+		expect(kemParams!.getCurveType()).toBe(expectedCurve);
+		expect(kemParams!.getHkdfHashType()).toBe(expectedHkdfHashFunction);
 
-    // Test DEM params.
-    const demParams = params!.getDemParams();
-    assertMessageEquals(demParams!.getAeadDem()!, expectedAeadTemplate);
+		// Test DEM params.
+		const demParams = params!.getDemParams();
+		assertMessageEquals(demParams!.getAeadDem()!, expectedAeadTemplate);
 
-    // Test that the template works with EciesAeadHkdfPrivateKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with EciesAeadHkdfPrivateKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 
-  it('ecies p256 hkdf hmac sha256 aes128 ctr hmac sha256', function() {
-    // Expects function to create a key with following parameters.
-    const expectedCurve = PbEllipticCurveType.NIST_P256;
-    const expectedHkdfHashFunction = PbHashType.SHA256;
-    const expectedAeadTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-    const expectedPointFormat = PbPointFormat.UNCOMPRESSED;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
+	it("ecies p256 hkdf hmac sha256 aes128 ctr hmac sha256", () => {
+		// Expects function to create a key with following parameters.
+		const expectedCurve = PbEllipticCurveType.NIST_P256;
+		const expectedHkdfHashFunction = PbHashType.SHA256;
+		const expectedAeadTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+		const expectedPointFormat = PbPointFormat.UNCOMPRESSED;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
 
-    // Expected type URL is the one supported by EciesAeadHkdfPrivateKeyManager.
-    const manager = new EciesAeadHkdfPrivateKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+		// Expected type URL is the one supported by EciesAeadHkdfPrivateKeyManager.
+		const manager = new EciesAeadHkdfPrivateKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate =
-        HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128CtrHmacSha256();
+		const keyTemplate =
+			HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128CtrHmacSha256();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test values in key format.
-    const keyFormat =
-        PbEciesAeadHkdfKeyFormat.deserializeBinary(keyTemplate.getValue());
-    const params = keyFormat.getParams();
-    expect(params!.getEcPointFormat()).toBe(expectedPointFormat);
+		// Test values in key format.
+		const keyFormat = PbEciesAeadHkdfKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		const params = keyFormat.getParams();
+		expect(params!.getEcPointFormat()).toBe(expectedPointFormat);
 
-    // Test KEM params.
-    const kemParams = params!.getKemParams();
-    expect(kemParams!.getCurveType()).toBe(expectedCurve);
-    expect(kemParams!.getHkdfHashType()).toBe(expectedHkdfHashFunction);
+		// Test KEM params.
+		const kemParams = params!.getKemParams();
+		expect(kemParams!.getCurveType()).toBe(expectedCurve);
+		expect(kemParams!.getHkdfHashType()).toBe(expectedHkdfHashFunction);
 
-    // Test DEM params.
-    const demParams = params!.getDemParams();
-    assertMessageEquals(demParams!.getAeadDem()!, expectedAeadTemplate);
+		// Test DEM params.
+		const demParams = params!.getDemParams();
+		assertMessageEquals(demParams!.getAeadDem()!, expectedAeadTemplate);
 
-    // Test that the template works with EciesAeadHkdfPrivateKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with EciesAeadHkdfPrivateKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 });

--- a/javascript/hybrid/internal/hpke/hkdf_hpke_kdf_test.ts
+++ b/javascript/hybrid/internal/hpke/hkdf_hpke_kdf_test.ts
@@ -4,219 +4,255 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import * as bytes from '../../../subtle/bytes';
-import * as ellipticCurves from '../../../subtle/elliptic_curves';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import * as bytes from "../../../subtle/bytes";
+import * as ellipticCurves from "../../../subtle/elliptic_curves";
 
-import {HkdfHpkeKdf} from './hkdf_hpke_kdf';
-import {HPKE_BORINGSSL_TEST_VECTORS} from './hpke_boringssl_test_vectors';
-import * as hpkeUtil from './hpke_util';
-import {parseTestVectors} from './testing/hpke_test_utils';
+import { HkdfHpkeKdf } from "./hkdf_hpke_kdf";
+import { HPKE_BORINGSSL_TEST_VECTORS } from "./hpke_boringssl_test_vectors";
+import * as hpkeUtil from "./hpke_util";
+import { parseTestVectors } from "./testing/hpke_test_utils";
 
-const AES_GCM_NONCE_LENGTH: number = 12;  // Nn
+const AES_GCM_NONCE_LENGTH: number = 12; // Nn
 
 interface TestVector {
-  mode: Uint8Array;
-  kemId: Uint8Array;
-  kdfId: Uint8Array;
-  aeadId: Uint8Array;
-  info: Uint8Array;
-  senderPublicKey: Uint8Array;
-  senderPrivateKey: Uint8Array;
-  recipientPublicKey: Uint8Array;
-  recipientPrivateKey: Uint8Array;
-  encapsulatedKey: Uint8Array;
-  sharedSecret: Uint8Array;
-  keyScheduleContext: Uint8Array;
-  secret: Uint8Array;
-  key: Uint8Array;
-  baseNonce: Uint8Array;
+	mode: Uint8Array;
+	kemId: Uint8Array;
+	kdfId: Uint8Array;
+	aeadId: Uint8Array;
+	info: Uint8Array;
+	senderPublicKey: Uint8Array;
+	senderPrivateKey: Uint8Array;
+	recipientPublicKey: Uint8Array;
+	recipientPrivateKey: Uint8Array;
+	encapsulatedKey: Uint8Array;
+	sharedSecret: Uint8Array;
+	keyScheduleContext: Uint8Array;
+	secret: Uint8Array;
+	key: Uint8Array;
+	baseNonce: Uint8Array;
 }
 
 const TEST_VECTORS: TestVector[] = [
-  /** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    mode: hpkeUtil.BASE_MODE,
-    kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
-    kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
-    aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
-    info: bytes.fromHex('4f6465206f6e2061204772656369616e2055726e'),
-    senderPublicKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    senderPrivateKey: bytes.fromHex(
-        '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-    recipientPublicKey: bytes.fromHex(
-        '04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0'),
-    recipientPrivateKey: bytes.fromHex(
-        'f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2'),
-    encapsulatedKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    sharedSecret: bytes.fromHex(
-        'c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8'),
-    keyScheduleContext: bytes.fromHex(
-        '00b88d4e6d91759e65e87c470e8b9141113e9ad5f0c8ceefc1e088c82e6980500798e486f9c9c09c9b5c753ac72d6005de254c607d1b534ed11d493ae1c1d9ac85'),
-    secret: bytes.fromHex(
-        '2eb7b6bf138f6b5aff857414a058a3f1750054a9ba1f72c2cf0684a6f20b10e1'),
-    key: bytes.fromHex('868c066ef58aae6dc589b6cfdd18f97e'),
-    baseNonce: bytes.fromHex('4e0bc5018beba4bf004cca59'),
-  },
-  /** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    mode: hpkeUtil.BASE_MODE,
-    kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
-    kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
-    aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
-    info: bytes.fromHex('4f6465206f6e2061204772656369616e2055726e'),
-    senderPublicKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    senderPrivateKey: bytes.fromHex(
-        '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-    recipientPublicKey: bytes.fromHex(
-        '0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64'),
-    recipientPrivateKey: bytes.fromHex(
-        '01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847'),
-    encapsulatedKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    sharedSecret: bytes.fromHex(
-        '776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818'),
-    keyScheduleContext: bytes.fromHex(
-        '0083a27c5b2358ab4dae1b2f5d8f57f10ccccc822a473326f543f239a70aee46347324e84e02d7651a10d08fb3dda739d22d50c53fbfa8122baacd0f9ae5913072ef45baa1f3a4b169e141feb957e48d03f28c837d8904c3d6775308c3d3faa75dd64adfa44e1a1141edf9349959b8f8e5291cbdc56f62b0ed6527d692e85b09a4'),
-    secret: bytes.fromHex(
-        '49fd9f53b0f93732555b2054edfdc0e3101000d75df714b98ce5aa295a37f1b18dfa86a1c37286d805d3ea09a20b72f93c21e83955a1f01eb7c5eead563d21e7'),
-    key: bytes.fromHex(
-        '751e346ce8f0ddb2305c8a2a85c70d5cf559c53093656be636b9406d4d7d1b70'),
-    baseNonce: bytes.fromHex('55ff7a7d739c69f44b25447b'),
-  },
-  ...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS)
+	/** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		mode: hpkeUtil.BASE_MODE,
+		kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
+		aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
+		info: bytes.fromHex("4f6465206f6e2061204772656369616e2055726e"),
+		senderPublicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		sharedSecret: bytes.fromHex(
+			"c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8"
+		),
+		keyScheduleContext: bytes.fromHex(
+			"00b88d4e6d91759e65e87c470e8b9141113e9ad5f0c8ceefc1e088c82e6980500798e486f9c9c09c9b5c753ac72d6005de254c607d1b534ed11d493ae1c1d9ac85"
+		),
+		secret: bytes.fromHex(
+			"2eb7b6bf138f6b5aff857414a058a3f1750054a9ba1f72c2cf0684a6f20b10e1"
+		),
+		key: bytes.fromHex("868c066ef58aae6dc589b6cfdd18f97e"),
+		baseNonce: bytes.fromHex("4e0bc5018beba4bf004cca59"),
+	},
+	/** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		mode: hpkeUtil.BASE_MODE,
+		kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
+		aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
+		info: bytes.fromHex("4f6465206f6e2061204772656369616e2055726e"),
+		senderPublicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		sharedSecret: bytes.fromHex(
+			"776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818"
+		),
+		keyScheduleContext: bytes.fromHex(
+			"0083a27c5b2358ab4dae1b2f5d8f57f10ccccc822a473326f543f239a70aee46347324e84e02d7651a10d08fb3dda739d22d50c53fbfa8122baacd0f9ae5913072ef45baa1f3a4b169e141feb957e48d03f28c837d8904c3d6775308c3d3faa75dd64adfa44e1a1141edf9349959b8f8e5291cbdc56f62b0ed6527d692e85b09a4"
+		),
+		secret: bytes.fromHex(
+			"49fd9f53b0f93732555b2054edfdc0e3101000d75df714b98ce5aa295a37f1b18dfa86a1c37286d805d3ea09a20b72f93c21e83955a1f01eb7c5eead563d21e7"
+		),
+		key: bytes.fromHex(
+			"751e346ce8f0ddb2305c8a2a85c70d5cf559c53093656be636b9406d4d7d1b70"
+		),
+		baseNonce: bytes.fromHex("55ff7a7d739c69f44b25447b"),
+	},
+	...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS),
 ];
 
-describe('HkdfHpkeKdf', () => {
-  for (const testInfo of TEST_VECTORS) {
-    let kdfHashFunction: 'SHA-256'|'SHA-512';
-    let kemHashFunction: 'SHA-256'|'SHA-512';
-    let curveType: ellipticCurves.CurveType.P256|ellipticCurves.CurveType.P521;
+describe("HkdfHpkeKdf", () => {
+	for (const testInfo of TEST_VECTORS) {
+		let kdfHashFunction: "SHA-256" | "SHA-512";
+		let kemHashFunction: "SHA-256" | "SHA-512";
+		let curveType:
+			| ellipticCurves.CurveType.P256
+			| ellipticCurves.CurveType.P521;
 
-    if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA256_KDF_ID)) {
-      kdfHashFunction = 'SHA-256';
-    } else if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA512_KDF_ID)) {
-      kdfHashFunction = 'SHA-512';
-    } else {
-      throw new InvalidArgumentsException(
-          `unsupported KDF id: ${testInfo.kdfId}`);
-    }
+		if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA256_KDF_ID)) {
+			kdfHashFunction = "SHA-256";
+		} else if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA512_KDF_ID)) {
+			kdfHashFunction = "SHA-512";
+		} else {
+			throw new InvalidArgumentsException(
+				`unsupported KDF id: ${testInfo.kdfId}`
+			);
+		}
 
-    if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P256;
-      kemHashFunction = 'SHA-256';
-    } else if (bytes.isEqual(
-                   testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P521;
-      kemHashFunction = 'SHA-512';
-    } else {
-      throw new InvalidArgumentsException(
-          `unsupported KEM id: ${testInfo.kemId}`);
-    }
+		if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
+			curveType = ellipticCurves.CurveType.P256;
+			kemHashFunction = "SHA-256";
+		} else if (
+			bytes.isEqual(testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)
+		) {
+			curveType = ellipticCurves.CurveType.P521;
+			kemHashFunction = "SHA-512";
+		} else {
+			throw new InvalidArgumentsException(
+				`unsupported KEM id: ${testInfo.kemId}`
+			);
+		}
 
-    describe('extract', () => {
-      it(`should work for ${kdfHashFunction}`, async () => {
-        const kdf = new HkdfHpkeKdf(kdfHashFunction);
+		describe("extract", () => {
+			it(`should work for ${kdfHashFunction}`, async () => {
+				const kdf = new HkdfHpkeKdf(kdfHashFunction);
 
-        const suiteId: Uint8Array = hpkeUtil.hpkeSuiteId({
-          kemId: testInfo.kemId,
-          kdfId: testInfo.kdfId,
-          aeadId: testInfo.aeadId
-        });
+				const suiteId: Uint8Array = hpkeUtil.hpkeSuiteId({
+					kemId: testInfo.kemId,
+					kdfId: testInfo.kdfId,
+					aeadId: testInfo.aeadId,
+				});
 
-        const defaultPskId = bytes.fromByteString('');
+				const defaultPskId = bytes.fromByteString("");
 
-        const pskIdHash: Uint8Array = await kdf.labeledExtract(
-            {ikm: defaultPskId, ikmLabel: 'psk_id_hash', suiteId});
+				const pskIdHash: Uint8Array = await kdf.labeledExtract({
+					ikm: defaultPskId,
+					ikmLabel: "psk_id_hash",
+					suiteId,
+				});
 
-        const infoHash: Uint8Array = await kdf.labeledExtract(
-            {ikm: testInfo.info, ikmLabel: 'info_hash', suiteId});
+				const infoHash: Uint8Array = await kdf.labeledExtract({
+					ikm: testInfo.info,
+					ikmLabel: "info_hash",
+					suiteId,
+				});
 
-        const keyScheduleContext =
-            bytes.concat(testInfo.mode, pskIdHash, infoHash);
+				const keyScheduleContext = bytes.concat(
+					testInfo.mode,
+					pskIdHash,
+					infoHash
+				);
 
-        const defaultPsk = bytes.fromByteString('');
+				const defaultPsk = bytes.fromByteString("");
 
-        const secret: Uint8Array = await kdf.labeledExtract({
-          ikm: defaultPsk,
-          ikmLabel: 'secret',
-          suiteId,
-          salt: testInfo.sharedSecret
-        });
+				const secret: Uint8Array = await kdf.labeledExtract({
+					ikm: defaultPsk,
+					ikmLabel: "secret",
+					suiteId,
+					salt: testInfo.sharedSecret,
+				});
 
-        expect(keyScheduleContext).toEqual(testInfo.keyScheduleContext);
-        expect(secret).toEqual(testInfo.secret);
-      });
-    });
+				expect(keyScheduleContext).toEqual(testInfo.keyScheduleContext);
+				expect(secret).toEqual(testInfo.secret);
+			});
+		});
 
-    describe('expand', () => {
-      it(`should work for ${kdfHashFunction}`, async () => {
-        const kdf = new HkdfHpkeKdf(kdfHashFunction);
+		describe("expand", () => {
+			it(`should work for ${kdfHashFunction}`, async () => {
+				const kdf = new HkdfHpkeKdf(kdfHashFunction);
 
-        const suiteId: Uint8Array = hpkeUtil.hpkeSuiteId({
-          kemId: testInfo.kemId,
-          kdfId: testInfo.kdfId,
-          aeadId: testInfo.aeadId
-        });
+				const suiteId: Uint8Array = hpkeUtil.hpkeSuiteId({
+					kemId: testInfo.kemId,
+					kdfId: testInfo.kdfId,
+					aeadId: testInfo.aeadId,
+				});
 
-        const key: Uint8Array = await kdf.labeledExpand({
-          prk: testInfo.secret,
-          info: testInfo.keyScheduleContext,
-          infoLabel: 'key',
-          suiteId,
-          length: testInfo.key.length as 16 | 32,
-        });
+				const key: Uint8Array = await kdf.labeledExpand({
+					prk: testInfo.secret,
+					info: testInfo.keyScheduleContext,
+					infoLabel: "key",
+					suiteId,
+					length: testInfo.key.length as 16 | 32,
+				});
 
-        const baseNonce: Uint8Array = await kdf.labeledExpand({
-          prk: testInfo.secret,
-          info: testInfo.keyScheduleContext,
-          infoLabel: 'base_nonce',
-          suiteId,
-          length: AES_GCM_NONCE_LENGTH,
-        });
+				const baseNonce: Uint8Array = await kdf.labeledExpand({
+					prk: testInfo.secret,
+					info: testInfo.keyScheduleContext,
+					infoLabel: "base_nonce",
+					suiteId,
+					length: AES_GCM_NONCE_LENGTH,
+				});
 
-        expect(key).toEqual(testInfo.key);
-        expect(baseNonce).toEqual(testInfo.baseNonce);
-      });
-    });
+				expect(key).toEqual(testInfo.key);
+				expect(baseNonce).toEqual(testInfo.baseNonce);
+			});
+		});
 
-    describe('extractAndExpand', () => {
-      it(`should work for ${kemHashFunction} KEM Shared Secret derivation`,
-         async () => {
-           const kdf = new HkdfHpkeKdf(kemHashFunction);
+		describe("extractAndExpand", () => {
+			it(`should work for ${kemHashFunction} KEM Shared Secret derivation`, async () => {
+				const kdf = new HkdfHpkeKdf(kemHashFunction);
 
-           const senderPrivateKey = await hpkeUtil.getPrivateKeyFromByteArray({
-             curveType: ellipticCurves.curveToString(curveType),
-             publicKey: testInfo.senderPublicKey,
-             privateKey: testInfo.senderPrivateKey
-           });
+				const senderPrivateKey =
+					await hpkeUtil.getPrivateKeyFromByteArray({
+						curveType: ellipticCurves.curveToString(curveType),
+						publicKey: testInfo.senderPublicKey,
+						privateKey: testInfo.senderPrivateKey,
+					});
 
-           const recipientPublicCryptoKey =
-               await hpkeUtil.getPublicKeyFromByteArray(
-                   ellipticCurves.curveToString(curveType),
-                   testInfo.recipientPublicKey);
+				const recipientPublicCryptoKey =
+					await hpkeUtil.getPublicKeyFromByteArray(
+						ellipticCurves.curveToString(curveType),
+						testInfo.recipientPublicKey
+					);
 
-           const dhSharedSecret: Uint8Array =
-               await ellipticCurves.computeEcdhSharedSecret(
-                   senderPrivateKey, recipientPublicCryptoKey);
+				const dhSharedSecret: Uint8Array =
+					await ellipticCurves.computeEcdhSharedSecret(
+						senderPrivateKey,
+						recipientPublicCryptoKey
+					);
 
-           const kemContext: Uint8Array = bytes.concat(
-               testInfo.senderPublicKey, testInfo.recipientPublicKey);
+				const kemContext: Uint8Array = bytes.concat(
+					testInfo.senderPublicKey,
+					testInfo.recipientPublicKey
+				);
 
-           const sharedSecret: Uint8Array = await kdf.extractAndExpand({
-             ikm: dhSharedSecret,
-             ikmLabel: 'eae_prk',
-             info: kemContext,
-             infoLabel: 'shared_secret',
-             suiteId: hpkeUtil.kemSuiteId(testInfo.kemId),
-             length: testInfo.sharedSecret.length,
-           });
+				const sharedSecret: Uint8Array = await kdf.extractAndExpand({
+					ikm: dhSharedSecret,
+					ikmLabel: "eae_prk",
+					info: kemContext,
+					infoLabel: "shared_secret",
+					suiteId: hpkeUtil.kemSuiteId(testInfo.kemId),
+					length: testInfo.sharedSecret.length,
+				});
 
-           expect(sharedSecret).toEqual(testInfo.sharedSecret);
-         });
-    });
-  }
+				expect(sharedSecret).toEqual(testInfo.sharedSecret);
+			});
+		});
+	}
 });

--- a/javascript/hybrid/internal/hpke/hpke_context_test.ts
+++ b/javascript/hybrid/internal/hpke/hpke_context_test.ts
@@ -4,287 +4,355 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import {SecurityException} from '../../../exception/security_exception';
-import * as bytes from '../../../subtle/bytes';
-import * as ellipticCurves from '../../../subtle/elliptic_curves';
-import {randBytes} from '../../../subtle/random';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import { SecurityException } from "../../../exception/security_exception";
+import * as bytes from "../../../subtle/bytes";
+import * as ellipticCurves from "../../../subtle/elliptic_curves";
+import { randBytes } from "../../../subtle/random";
 
-import {AesGcmHpkeAead} from './aes_gcm_hpke_aead';
-import {HkdfHpkeKdf} from './hkdf_hpke_kdf';
-import {HPKE_BORINGSSL_TEST_VECTORS} from './hpke_boringssl_test_vectors';
-import * as hpkeContext from './hpke_context';
-import * as hpkeUtil from './hpke_util';
-import {NistCurvesHpkeKem} from './nist_curves_hpke_kem';
-import {fromBytes} from './nist_curves_hpke_kem_private_key';
-import {parseTestVectors} from './testing/hpke_test_utils';
+import { AesGcmHpkeAead } from "./aes_gcm_hpke_aead";
+import { HkdfHpkeKdf } from "./hkdf_hpke_kdf";
+import { HPKE_BORINGSSL_TEST_VECTORS } from "./hpke_boringssl_test_vectors";
+import * as hpkeContext from "./hpke_context";
+import * as hpkeUtil from "./hpke_util";
+import { NistCurvesHpkeKem } from "./nist_curves_hpke_kem";
+import { fromBytes } from "./nist_curves_hpke_kem_private_key";
+import { parseTestVectors } from "./testing/hpke_test_utils";
 
-const
-    TEST_VECTORS =
-        [
-          /**
-           * Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
-           */
-          {
-            mode: hpkeUtil.BASE_MODE,
-            kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
-            kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
-            aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
-            info: bytes.fromHex('4f6465206f6e2061204772656369616e2055726e'),
-            senderPublicKey: bytes.fromHex(
-                '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-            senderPrivateKey: bytes.fromHex(
-                '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-            recipientPublicKey: bytes.fromHex(
-                '04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0'),
-            recipientPrivateKey: bytes.fromHex(
-                'f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2'),
-            encapsulatedKey: bytes.fromHex(
-                '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-            sharedSecret: bytes.fromHex(
-                'c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8'),
-            keyScheduleContext: bytes.fromHex(
-                '00b88d4e6d91759e65e87c470e8b9141113e9ad5f0c8ceefc1e088c82e6980500798e486f9c9c09c9b5c753ac72d6005de254c607d1b534ed11d493ae1c1d9ac85'),
-            secret: bytes.fromHex(
-                '2eb7b6bf138f6b5aff857414a058a3f1750054a9ba1f72c2cf0684a6f20b10e1'),
-            key: bytes.fromHex('868c066ef58aae6dc589b6cfdd18f97e'),
-            baseNonce: bytes.fromHex('4e0bc5018beba4bf004cca59'),
-            encryptions: [
-              {
-                nonce: bytes.fromHex('4e0bc5018beba4bf004cca59'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    '5ad590bb8baa577f8619db35a36311226a896e7342a6d836d8b7bcd2f20b6c7f9076ac232e3ab2523f39513434'),
-                associatedData: bytes.fromHex('436f756e742d30'),
-              },
-              {
-                nonce: bytes.fromHex('4e0bc5018beba4bf004cca58'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    'fa6f037b47fc21826b610172ca9637e82d6e5801eb31cbd3748271affd4ecb06646e0329cbdf3c3cd655b28e82'),
-                associatedData: bytes.fromHex('436f756e742d31'),
-              },
-              {
-                nonce: bytes.fromHex('4e0bc5018beba4bf004cca5b'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    '895cabfac50ce6c6eb02ffe6c048bf53b7f7be9a91fc559402cbc5b8dcaeb52b2ccc93e466c28fb55fed7a7fec'),
-                associatedData: bytes.fromHex('436f756e742d32'),
-              },
-            ],
-          },
+const TEST_VECTORS = [
+	/**
+	 * Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+	 */
+	{
+		mode: hpkeUtil.BASE_MODE,
+		kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
+		aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
+		info: bytes.fromHex("4f6465206f6e2061204772656369616e2055726e"),
+		senderPublicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		sharedSecret: bytes.fromHex(
+			"c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8"
+		),
+		keyScheduleContext: bytes.fromHex(
+			"00b88d4e6d91759e65e87c470e8b9141113e9ad5f0c8ceefc1e088c82e6980500798e486f9c9c09c9b5c753ac72d6005de254c607d1b534ed11d493ae1c1d9ac85"
+		),
+		secret: bytes.fromHex(
+			"2eb7b6bf138f6b5aff857414a058a3f1750054a9ba1f72c2cf0684a6f20b10e1"
+		),
+		key: bytes.fromHex("868c066ef58aae6dc589b6cfdd18f97e"),
+		baseNonce: bytes.fromHex("4e0bc5018beba4bf004cca59"),
+		encryptions: [
+			{
+				nonce: bytes.fromHex("4e0bc5018beba4bf004cca59"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"5ad590bb8baa577f8619db35a36311226a896e7342a6d836d8b7bcd2f20b6c7f9076ac232e3ab2523f39513434"
+				),
+				associatedData: bytes.fromHex("436f756e742d30"),
+			},
+			{
+				nonce: bytes.fromHex("4e0bc5018beba4bf004cca58"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"fa6f037b47fc21826b610172ca9637e82d6e5801eb31cbd3748271affd4ecb06646e0329cbdf3c3cd655b28e82"
+				),
+				associatedData: bytes.fromHex("436f756e742d31"),
+			},
+			{
+				nonce: bytes.fromHex("4e0bc5018beba4bf004cca5b"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"895cabfac50ce6c6eb02ffe6c048bf53b7f7be9a91fc559402cbc5b8dcaeb52b2ccc93e466c28fb55fed7a7fec"
+				),
+				associatedData: bytes.fromHex("436f756e742d32"),
+			},
+		],
+	},
 
-          /**
-           * Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM
-           */
-          {
-            mode: hpkeUtil.BASE_MODE,
-            kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
-            kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
-            aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
-            info: bytes.fromHex('4f6465206f6e2061204772656369616e2055726e'),
-            senderPublicKey: bytes.fromHex(
-                '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-            senderPrivateKey: bytes.fromHex(
-                '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-            recipientPublicKey: bytes.fromHex(
-                '0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64'),
-            recipientPrivateKey: bytes.fromHex(
-                '01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847'),
-            encapsulatedKey: bytes.fromHex(
-                '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-            sharedSecret: bytes.fromHex(
-                '776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818'),
-            keyScheduleContext: bytes
-                                    .fromHex(
-                                        '0083a27c5b2358ab4dae1b2f5d8f57f10ccccc822a473326f543f239a70aee46347324e84e02d7651a10d08fb3dda739d22d50c53fbfa8122baacd0f9ae5913072ef45baa1f3a4b169e141feb957e48d03f28c837d8904c3d6775308c3d3faa75dd64adfa44e1a1141edf9349959b8f8e5291cbdc56f62b0ed6527d692e85b09a4'),
-            secret: bytes.fromHex(
-                '49fd9f53b0f93732555b2054edfdc0e3101000d75df714b98ce5aa295a37f1b18dfa86a1c37286d805d3ea09a20b72f93c21e83955a1f01eb7c5eead563d21e7'),
-            key: bytes.fromHex(
-                '751e346ce8f0ddb2305c8a2a85c70d5cf559c53093656be636b9406d4d7d1b70'),
-            baseNonce: bytes.fromHex('55ff7a7d739c69f44b25447b'),
-            encryptions: [
-              {
-                nonce: bytes.fromHex('55ff7a7d739c69f44b25447b'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    '170f8beddfe949b75ef9c387e201baf4132fa7374593dfafa90768788b7b2b200aafcc6d80ea4c795a7c5b841a'),
-                associatedData: bytes.fromHex('436f756e742d30'),
-              },
-              {
-                nonce: bytes.fromHex('55ff7a7d739c69f44b25447a'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    'd9ee248e220ca24ac00bbbe7e221a832e4f7fa64c4fbab3945b6f3af0c5ecd5e16815b328be4954a05fd352256'),
-                associatedData: bytes.fromHex('436f756e742d31'),
-              },
-              {
-                nonce: bytes.fromHex('55ff7a7d739c69f44b254479'),
-                plaintext: bytes.fromHex(
-                    '4265617574792069732074727574682c20747275746820626561757479'),
-                ciphertext: bytes.fromHex(
-                    '142cf1e02d1f58d9285f2af7dcfa44f7c3f2d15c73d460c48c6e0e506a3144bae35284e7e221105b61d24e1c7a'),
-                associatedData: bytes.fromHex('436f756e742d32'),
-              },
-            ],
-          },
-          ...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS)
-        ];
+	/**
+	 * Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM
+	 */
+	{
+		mode: hpkeUtil.BASE_MODE,
+		kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
+		aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
+		info: bytes.fromHex("4f6465206f6e2061204772656369616e2055726e"),
+		senderPublicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		sharedSecret: bytes.fromHex(
+			"776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818"
+		),
+		keyScheduleContext: bytes.fromHex(
+			"0083a27c5b2358ab4dae1b2f5d8f57f10ccccc822a473326f543f239a70aee46347324e84e02d7651a10d08fb3dda739d22d50c53fbfa8122baacd0f9ae5913072ef45baa1f3a4b169e141feb957e48d03f28c837d8904c3d6775308c3d3faa75dd64adfa44e1a1141edf9349959b8f8e5291cbdc56f62b0ed6527d692e85b09a4"
+		),
+		secret: bytes.fromHex(
+			"49fd9f53b0f93732555b2054edfdc0e3101000d75df714b98ce5aa295a37f1b18dfa86a1c37286d805d3ea09a20b72f93c21e83955a1f01eb7c5eead563d21e7"
+		),
+		key: bytes.fromHex(
+			"751e346ce8f0ddb2305c8a2a85c70d5cf559c53093656be636b9406d4d7d1b70"
+		),
+		baseNonce: bytes.fromHex("55ff7a7d739c69f44b25447b"),
+		encryptions: [
+			{
+				nonce: bytes.fromHex("55ff7a7d739c69f44b25447b"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"170f8beddfe949b75ef9c387e201baf4132fa7374593dfafa90768788b7b2b200aafcc6d80ea4c795a7c5b841a"
+				),
+				associatedData: bytes.fromHex("436f756e742d30"),
+			},
+			{
+				nonce: bytes.fromHex("55ff7a7d739c69f44b25447a"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"d9ee248e220ca24ac00bbbe7e221a832e4f7fa64c4fbab3945b6f3af0c5ecd5e16815b328be4954a05fd352256"
+				),
+				associatedData: bytes.fromHex("436f756e742d31"),
+			},
+			{
+				nonce: bytes.fromHex("55ff7a7d739c69f44b254479"),
+				plaintext: bytes.fromHex(
+					"4265617574792069732074727574682c20747275746820626561757479"
+				),
+				ciphertext: bytes.fromHex(
+					"142cf1e02d1f58d9285f2af7dcfa44f7c3f2d15c73d460c48c6e0e506a3144bae35284e7e221105b61d24e1c7a"
+				),
+				associatedData: bytes.fromHex("436f756e742d32"),
+			},
+		],
+	},
+	...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS),
+];
 
-describe('HpkeContext', () => {
-  for (const testInfo of TEST_VECTORS) {
-    let hashFunction: 'SHA-256'|'SHA-512';
-    let curveType: ellipticCurves.CurveType.P256|ellipticCurves.CurveType.P521;
+describe("HpkeContext", () => {
+	for (const testInfo of TEST_VECTORS) {
+		let hashFunction: "SHA-256" | "SHA-512";
+		let curveType:
+			| ellipticCurves.CurveType.P256
+			| ellipticCurves.CurveType.P521;
 
-    if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA256_KDF_ID)) {
-      hashFunction = 'SHA-256';
-    } else if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA512_KDF_ID)) {
-      hashFunction = 'SHA-512';
-    } else {
-      throw new InvalidArgumentsException(
-          `unsupported KDF id: ${testInfo.kdfId}`);
-    }
+		if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA256_KDF_ID)) {
+			hashFunction = "SHA-256";
+		} else if (bytes.isEqual(testInfo.kdfId, hpkeUtil.HKDF_SHA512_KDF_ID)) {
+			hashFunction = "SHA-512";
+		} else {
+			throw new InvalidArgumentsException(
+				`unsupported KDF id: ${testInfo.kdfId}`
+			);
+		}
 
-    if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P256;
-    } else if (bytes.isEqual(
-                   testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P521;
-    } else {
-      throw new InvalidArgumentsException(
-          `unsupported KEM id: ${testInfo.kemId}`);
-    }
+		if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
+			curveType = ellipticCurves.CurveType.P256;
+		} else if (
+			bytes.isEqual(testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)
+		) {
+			curveType = ellipticCurves.CurveType.P521;
+		} else {
+			throw new InvalidArgumentsException(
+				`unsupported KEM id: ${testInfo.kemId}`
+			);
+		}
 
-    const kem = NistCurvesHpkeKem.fromCurve(curveType);
-    const kdf = new HkdfHpkeKdf(hashFunction);
-    const aead = new AesGcmHpkeAead(testInfo.key.length as 16 | 32);
+		const kem = NistCurvesHpkeKem.fromCurve(curveType);
+		const kdf = new HkdfHpkeKdf(hashFunction);
+		const aead = new AesGcmHpkeAead(testInfo.key.length as 16 | 32);
 
-    const suiteId = hpkeUtil.hpkeSuiteId({
-      kemId: testInfo.kemId,
-      kdfId: testInfo.kdfId,
-      aeadId: testInfo.aeadId
-    });
+		const suiteId = hpkeUtil.hpkeSuiteId({
+			kemId: testInfo.kemId,
+			kdfId: testInfo.kdfId,
+			aeadId: testInfo.aeadId,
+		});
 
-    describe('SenderAndRecipientContexts', () => {
-      it(`should seal and open random messages correctly for HPKE suite id ${
-             suiteId}`,
-         async () => {
-           const senderContext = await hpkeContext.createSenderContext(
-               testInfo.recipientPublicKey, kem, kdf, aead, testInfo.info);
+		describe("SenderAndRecipientContexts", () => {
+			it(`should seal and open random messages correctly for HPKE suite id ${suiteId}`, async () => {
+				const senderContext = await hpkeContext.createSenderContext(
+					testInfo.recipientPublicKey,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-           const recipientKemPrivateKey = await fromBytes({
-             privateKey: testInfo.recipientPrivateKey,
-             publicKey: testInfo.recipientPublicKey,
-             curveType
-           });
+				const recipientKemPrivateKey = await fromBytes({
+					privateKey: testInfo.recipientPrivateKey,
+					publicKey: testInfo.recipientPublicKey,
+					curveType,
+				});
 
-           const recipientContext = await hpkeContext.createRecipientContext(
-               senderContext.getEncapsulatedKey(), recipientKemPrivateKey, kem,
-               kdf, aead, testInfo.info);
+				const recipientContext =
+					await hpkeContext.createRecipientContext(
+						senderContext.getEncapsulatedKey(),
+						recipientKemPrivateKey,
+						kem,
+						kdf,
+						aead,
+						testInfo.info
+					);
 
-           const plaintext = randBytes(200);
-           const aad = randBytes(100);
+				const plaintext = randBytes(200);
+				const aad = randBytes(100);
 
-           const ciphertext = await senderContext.seal(plaintext, aad);
-           const decrypted = await recipientContext.open(ciphertext, aad);
-           expect(decrypted).toEqual(plaintext);
-         });
-    });
+				const ciphertext = await senderContext.seal(plaintext, aad);
+				const decrypted = await recipientContext.open(ciphertext, aad);
+				expect(decrypted).toEqual(plaintext);
+			});
+		});
 
-    describe('createContext', () => {
-      it(`should intialize key and baseNonce correctly for HPKE suite id ${
-             suiteId}`,
-         async () => {
-           const context = await hpkeContext.createContext(
-               testInfo.encapsulatedKey, testInfo.sharedSecret, kem, kdf, aead,
-               testInfo.info);
+		describe("createContext", () => {
+			it(`should intialize key and baseNonce correctly for HPKE suite id ${suiteId}`, async () => {
+				const context = await hpkeContext.createContext(
+					testInfo.encapsulatedKey,
+					testInfo.sharedSecret,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-           expect(context.getKey()).toEqual(testInfo.key);
-           expect(context.getBaseNonce()).toEqual(testInfo.baseNonce);
-         });
+				expect(context.getKey()).toEqual(testInfo.key);
+				expect(context.getBaseNonce()).toEqual(testInfo.baseNonce);
+			});
 
-      describe('seal', () => {
-        const contextPromise = hpkeContext.createContext(
-            testInfo.encapsulatedKey, testInfo.sharedSecret, kem, kdf, aead,
-            testInfo.info);
+			describe("seal", () => {
+				const contextPromise = hpkeContext.createContext(
+					testInfo.encapsulatedKey,
+					testInfo.sharedSecret,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-        for (let i = 0; i < testInfo.encryptions.length; i++) {
-          const encryption = testInfo.encryptions[i];
+				for (let i = 0; i < testInfo.encryptions.length; i++) {
+					const encryption = testInfo.encryptions[i];
 
-          it(`should seal correctly for HPKE suite id ${suiteId}, encryption #${
-                 i}`,
-             async () => {
-               const context = await contextPromise;
-               await expectAsync(
-                   context.seal(
-                       encryption.plaintext, encryption.associatedData))
-                   .toBeResolvedTo(encryption.ciphertext);
-             });
-        }
-      });
+					it(`should seal correctly for HPKE suite id ${suiteId}, encryption #${i}`, async () => {
+						const context = await contextPromise;
+						await expectAsync(
+							context.seal(
+								encryption.plaintext,
+								encryption.associatedData
+							)
+						).toBeResolvedTo(encryption.ciphertext);
+					});
+				}
+			});
 
-      describe('open', () => {
-        let contextPromise = hpkeContext.createContext(
-            testInfo.encapsulatedKey, testInfo.sharedSecret, kem, kdf, aead,
-            testInfo.info);
+			describe("open", () => {
+				let contextPromise = hpkeContext.createContext(
+					testInfo.encapsulatedKey,
+					testInfo.sharedSecret,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-        for (let i = 0; i < testInfo.encryptions.length; i++) {
-          const encryption = testInfo.encryptions[i];
+				for (let i = 0; i < testInfo.encryptions.length; i++) {
+					const encryption = testInfo.encryptions[i];
 
-          it(`should open correctly for HPKE suite id ${suiteId}, encryption #${
-                 i}`,
-             async () => {
-               const context = await contextPromise;
-               await expectAsync(
-                   context.open(
-                       encryption.ciphertext, encryption.associatedData))
-                   .toBeResolvedTo(encryption.plaintext);
-             });
-        }
+					it(`should open correctly for HPKE suite id ${suiteId}, encryption #${i}`, async () => {
+						const context = await contextPromise;
+						await expectAsync(
+							context.open(
+								encryption.ciphertext,
+								encryption.associatedData
+							)
+						).toBeResolvedTo(encryption.plaintext);
+					});
+				}
 
-        contextPromise = hpkeContext.createContext(
-            testInfo.encapsulatedKey, testInfo.sharedSecret, kem, kdf, aead,
-            testInfo.info);
+				contextPromise = hpkeContext.createContext(
+					testInfo.encapsulatedKey,
+					testInfo.sharedSecret,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-        for (let i = 0; i < testInfo.encryptions.length; i++) {
-          const encryption = testInfo.encryptions[i];
-          const wrongAssociatedData =
-              randBytes(encryption.associatedData.length);
+				for (let i = 0; i < testInfo.encryptions.length; i++) {
+					const encryption = testInfo.encryptions[i];
+					const wrongAssociatedData = randBytes(
+						encryption.associatedData.length
+					);
 
-          it(`should fail with an incorrect associated data for HPKE suite id ${
-                 suiteId}, encryption #${i}`,
-             async () => {
-               const context = await contextPromise;
+					it(`should fail with an incorrect associated data for HPKE suite id ${suiteId}, encryption #${i}`, async () => {
+						const context = await contextPromise;
 
-               await expectAsync(
-                   context.open(encryption.ciphertext, wrongAssociatedData))
-                   .toBeRejectedWithError(SecurityException);
-             });
-        }
+						await expectAsync(
+							context.open(
+								encryption.ciphertext,
+								wrongAssociatedData
+							)
+						).toBeRejectedWithError(SecurityException);
+					});
+				}
 
-        contextPromise = hpkeContext.createContext(
-            testInfo.encapsulatedKey, testInfo.sharedSecret, kem, kdf, aead,
-            testInfo.info);
+				contextPromise = hpkeContext.createContext(
+					testInfo.encapsulatedKey,
+					testInfo.sharedSecret,
+					kem,
+					kdf,
+					aead,
+					testInfo.info
+				);
 
-        for (let i = 0; i < testInfo.encryptions.length; i++) {
-          const encryption = testInfo.encryptions[i];
-          const wrongCiphertext = randBytes(encryption.ciphertext.length);
+				for (let i = 0; i < testInfo.encryptions.length; i++) {
+					const encryption = testInfo.encryptions[i];
+					const wrongCiphertext = randBytes(
+						encryption.ciphertext.length
+					);
 
-          it(`should fail with an incorrect ciphertext but correct associated data for HPKE suite id ${
-                 suiteId}, encryption #${i}`,
-             async () => {
-               const context = await contextPromise;
-               await expectAsync(
-                   context.open(wrongCiphertext, encryption.associatedData))
-                   .toBeRejectedWithError(SecurityException);
-             });
-        }
-      });
-    });
-  }
+					it(`should fail with an incorrect ciphertext but correct associated data for HPKE suite id ${suiteId}, encryption #${i}`, async () => {
+						const context = await contextPromise;
+						await expectAsync(
+							context.open(
+								wrongCiphertext,
+								encryption.associatedData
+							)
+						).toBeRejectedWithError(SecurityException);
+					});
+				}
+			});
+		});
+	}
 });

--- a/javascript/hybrid/internal/hpke/hpke_kem_key_factory_test.ts
+++ b/javascript/hybrid/internal/hpke/hpke_kem_key_factory_test.ts
@@ -4,18 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import {PbHpkeAead, PbHpkeKdf, PbHpkeKem, PbHpkeParams, PbHpkePrivateKey, PbHpkePublicKey} from '../../../internal/proto';
-import * as bytes from '../../../subtle/bytes';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import {
+	PbHpkeAead,
+	PbHpkeKdf,
+	PbHpkeKem,
+	PbHpkeParams,
+	PbHpkePrivateKey,
+	PbHpkePublicKey,
+} from "../../../internal/proto";
+import * as bytes from "../../../subtle/bytes";
 
-import {HpkeKemKeyFactory} from './hpke_kem_key_factory';
+import { HpkeKemKeyFactory } from "./hpke_kem_key_factory";
 
 interface TestVector {
-  kem: PbHpkeKem;
-  kdf: PbHpkeKdf;
-  aead: PbHpkeAead;
-  senderPublicKey: Uint8Array;
-  senderPrivateKey: Uint8Array;
+	kem: PbHpkeKem;
+	kdf: PbHpkeKdf;
+	aead: PbHpkeAead;
+	senderPublicKey: Uint8Array;
+	senderPrivateKey: Uint8Array;
 }
 
 const VERSION = 0;
@@ -24,80 +31,107 @@ const VERSION = 0;
  * Test vectors as described in @see https://www.rfc-editor.org/rfc/rfc9180.html#appendix-A
  */
 const TEST_VECTORS: TestVector[] = [
-  /** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    kem: PbHpkeKem.DHKEM_P256_HKDF_SHA256,
-    kdf: PbHpkeKdf.HKDF_SHA256,
-    aead: PbHpkeAead.AES_128_GCM,
-    senderPublicKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    senderPrivateKey: bytes.fromHex(
-        '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-  },
-  /** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    kem: PbHpkeKem.DHKEM_P521_HKDF_SHA512,
-    kdf: PbHpkeKdf.HKDF_SHA512,
-    aead: PbHpkeAead.AES_256_GCM,
-    senderPublicKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    senderPrivateKey: bytes.fromHex(
-        '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-  }
+	/** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		kem: PbHpkeKem.DHKEM_P256_HKDF_SHA256,
+		kdf: PbHpkeKdf.HKDF_SHA256,
+		aead: PbHpkeAead.AES_128_GCM,
+		senderPublicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+	},
+	/** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		kem: PbHpkeKem.DHKEM_P521_HKDF_SHA512,
+		kdf: PbHpkeKdf.HKDF_SHA512,
+		aead: PbHpkeAead.AES_256_GCM,
+		senderPublicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+	},
 ];
 
 function createHpkePrivateKey(
-    kem: PbHpkeKem, kdf: PbHpkeKdf, aead: PbHpkeAead,
-    publicKeyBytes: Uint8Array, privateKeyBytes: Uint8Array): PbHpkePrivateKey {
-  const hpkeParams = new PbHpkeParams().setKem(kem).setKdf(kdf).setAead(aead);
-  const hpkePublicKey = new PbHpkePublicKey()
-                            .setParams(hpkeParams)
-                            .setPublicKey(publicKeyBytes)
-                            .setVersion(VERSION);
+	kem: PbHpkeKem,
+	kdf: PbHpkeKdf,
+	aead: PbHpkeAead,
+	publicKeyBytes: Uint8Array,
+	privateKeyBytes: Uint8Array
+): PbHpkePrivateKey {
+	const hpkeParams = new PbHpkeParams().setKem(kem).setKdf(kdf).setAead(aead);
+	const hpkePublicKey = new PbHpkePublicKey()
+		.setParams(hpkeParams)
+		.setPublicKey(publicKeyBytes)
+		.setVersion(VERSION);
 
-  return new PbHpkePrivateKey()
-      .setPrivateKey(privateKeyBytes)
-      .setPublicKey(hpkePublicKey)
-      .setVersion(VERSION);
+	return new PbHpkePrivateKey()
+		.setPrivateKey(privateKeyBytes)
+		.setPublicKey(hpkePublicKey)
+		.setVersion(VERSION);
 }
 
-describe('HpkeKemKeyFactory', () => {
-  for (const testInfo of TEST_VECTORS) {
-    const hpkePrivateKey = createHpkePrivateKey(
-        testInfo.kem, testInfo.kdf, testInfo.aead, testInfo.senderPublicKey,
-        testInfo.senderPrivateKey);
-    it('should create kem private key from valid hpke private key',
-       async () => {
-         const kemPrivateKey =
-             await HpkeKemKeyFactory.createPrivate(hpkePrivateKey);
-         expect(await kemPrivateKey.getSerializedPublicKey())
-             .toEqual(testInfo.senderPublicKey);
-       });
-    describe('fails to create kem private key from invalid', () => {
-      it('public key', async () => {
-        const invalidHpkePrivateKey = createHpkePrivateKey(
-            testInfo.kem, testInfo.kdf, testInfo.aead, new Uint8Array(0),
-            testInfo.senderPrivateKey);
-        try {
-          await HpkeKemKeyFactory.createPrivate(invalidHpkePrivateKey);
-          fail('An exception should be thrown.');
-        } catch (e: unknown) {
-          expect((e as InvalidArgumentsException).message)
-              .toBe('invalid point');
-        }
-      });
-      it('kem params', async () => {
-        const invalidHpkePrivateKey = createHpkePrivateKey(
-            PbHpkeKem.KEM_UNKNOWN, testInfo.kdf, testInfo.aead,
-            testInfo.senderPublicKey, testInfo.senderPrivateKey);
-        try {
-          await HpkeKemKeyFactory.createPrivate(invalidHpkePrivateKey);
-          fail('An exception should be thrown.');
-        } catch (e: unknown) {
-          expect((e as InvalidArgumentsException).message)
-              .toBe('Unrecognized HPKE KEM identifier');
-        }
-      });
-    });
-  }
+describe("HpkeKemKeyFactory", () => {
+	for (const testInfo of TEST_VECTORS) {
+		const hpkePrivateKey = createHpkePrivateKey(
+			testInfo.kem,
+			testInfo.kdf,
+			testInfo.aead,
+			testInfo.senderPublicKey,
+			testInfo.senderPrivateKey
+		);
+		it("should create kem private key from valid hpke private key", async () => {
+			const kemPrivateKey = await HpkeKemKeyFactory.createPrivate(
+				hpkePrivateKey
+			);
+			expect(await kemPrivateKey.getSerializedPublicKey()).toEqual(
+				testInfo.senderPublicKey
+			);
+		});
+		describe("fails to create kem private key from invalid", () => {
+			it("public key", async () => {
+				const invalidHpkePrivateKey = createHpkePrivateKey(
+					testInfo.kem,
+					testInfo.kdf,
+					testInfo.aead,
+					new Uint8Array(0),
+					testInfo.senderPrivateKey
+				);
+				try {
+					await HpkeKemKeyFactory.createPrivate(
+						invalidHpkePrivateKey
+					);
+					fail("An exception should be thrown.");
+				} catch (e: unknown) {
+					expect((e as InvalidArgumentsException).message).toBe(
+						"invalid point"
+					);
+				}
+			});
+			it("kem params", async () => {
+				const invalidHpkePrivateKey = createHpkePrivateKey(
+					PbHpkeKem.KEM_UNKNOWN,
+					testInfo.kdf,
+					testInfo.aead,
+					testInfo.senderPublicKey,
+					testInfo.senderPrivateKey
+				);
+				try {
+					await HpkeKemKeyFactory.createPrivate(
+						invalidHpkePrivateKey
+					);
+					fail("An exception should be thrown.");
+				} catch (e: unknown) {
+					expect((e as InvalidArgumentsException).message).toBe(
+						"Unrecognized HPKE KEM identifier"
+					);
+				}
+			});
+		});
+	}
 });

--- a/javascript/hybrid/internal/hpke/hpke_primitive_factory_test.ts
+++ b/javascript/hybrid/internal/hpke/hpke_primitive_factory_test.ts
@@ -4,139 +4,156 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import {PbHpkeAead, PbHpkeKdf, PbHpkeKem, PbHpkeParams} from '../../../internal/proto';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import {
+	PbHpkeAead,
+	PbHpkeKdf,
+	PbHpkeKem,
+	PbHpkeParams,
+} from "../../../internal/proto";
 
-import {AesGcmHpkeAead} from './aes_gcm_hpke_aead';
-import {HkdfHpkeKdf} from './hkdf_hpke_kdf';
-import {HpkePrimitiveFactory} from './hpke_primitive_factory';
-import * as hpkeUtil from './hpke_util';
-import {NistCurvesHpkeKem} from './nist_curves_hpke_kem';
+import { AesGcmHpkeAead } from "./aes_gcm_hpke_aead";
+import { HkdfHpkeKdf } from "./hkdf_hpke_kdf";
+import { HpkePrimitiveFactory } from "./hpke_primitive_factory";
+import * as hpkeUtil from "./hpke_util";
+import { NistCurvesHpkeKem } from "./nist_curves_hpke_kem";
 
 interface TestVector {
-  kemId: Uint8Array;
-  kdfId: Uint8Array;
-  aeadId: Uint8Array;
-  params: PbHpkeParams;
+	kemId: Uint8Array;
+	kdfId: Uint8Array;
+	aeadId: Uint8Array;
+	params: PbHpkeParams;
 }
 
 const TEST_VECTORS: TestVector[] = [
-  /** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
-    kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
-    aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
-    params: new PbHpkeParams()
-                .setKem(PbHpkeKem.DHKEM_P256_HKDF_SHA256)
-                .setKdf(PbHpkeKdf.HKDF_SHA256)
-                .setAead(PbHpkeAead.AES_128_GCM)
-  },
-  /** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
-    kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
-    aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
-    params: new PbHpkeParams()
-                .setKem(PbHpkeKem.DHKEM_P521_HKDF_SHA512)
-                .setKdf(PbHpkeKdf.HKDF_SHA512)
-                .setAead(PbHpkeAead.AES_256_GCM)
-  }
+	/** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA256_KDF_ID,
+		aeadId: hpkeUtil.AES_128_GCM_AEAD_ID,
+		params: new PbHpkeParams()
+			.setKem(PbHpkeKem.DHKEM_P256_HKDF_SHA256)
+			.setKdf(PbHpkeKdf.HKDF_SHA256)
+			.setAead(PbHpkeAead.AES_128_GCM),
+	},
+	/** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
+		kdfId: hpkeUtil.HKDF_SHA512_KDF_ID,
+		aeadId: hpkeUtil.AES_256_GCM_AEAD_ID,
+		params: new PbHpkeParams()
+			.setKem(PbHpkeKem.DHKEM_P521_HKDF_SHA512)
+			.setKdf(PbHpkeKdf.HKDF_SHA512)
+			.setAead(PbHpkeAead.AES_256_GCM),
+	},
 ];
 
-describe('HpkePrimitiveFactory', () => {
-  for (const testInfo of TEST_VECTORS) {
-    it('should create valid kem from valid kemId', async () => {
-      const kem = HpkePrimitiveFactory.createKemFromId(testInfo.kemId);
-      expect(kem instanceof NistCurvesHpkeKem).toBe(true);
-      expect(kem.getKemId()).toEqual(testInfo.kemId);
-    });
+describe("HpkePrimitiveFactory", () => {
+	for (const testInfo of TEST_VECTORS) {
+		it("should create valid kem from valid kemId", async () => {
+			const kem = HpkePrimitiveFactory.createKemFromId(testInfo.kemId);
+			expect(kem instanceof NistCurvesHpkeKem).toBe(true);
+			expect(kem.getKemId()).toEqual(testInfo.kemId);
+		});
 
-    it('should create valid kdf from valid kdfId', async () => {
-      const kdf = HpkePrimitiveFactory.createKdfFromId(testInfo.kdfId);
-      expect(kdf instanceof HkdfHpkeKdf).toBe(true);
-      expect(kdf.getKdfId()).toEqual(testInfo.kdfId);
-    });
+		it("should create valid kdf from valid kdfId", async () => {
+			const kdf = HpkePrimitiveFactory.createKdfFromId(testInfo.kdfId);
+			expect(kdf instanceof HkdfHpkeKdf).toBe(true);
+			expect(kdf.getKdfId()).toEqual(testInfo.kdfId);
+		});
 
-    it('should create valid aead from valid aeadId', async () => {
-      const aead = HpkePrimitiveFactory.createAeadFromId(testInfo.aeadId);
-      expect(aead instanceof AesGcmHpkeAead).toBe(true);
-      expect(aead.getAeadId()).toEqual(testInfo.aeadId);
-    });
-    it('should create valid kem from valid kem param', async () => {
-      const kem = HpkePrimitiveFactory.createKemFromParams(testInfo.params);
-      expect(kem instanceof NistCurvesHpkeKem).toBe(true);
-      expect(kem.getKemId()).toEqual(testInfo.kemId);
-    });
-    it('should create valid kdf from valid kdf param', async () => {
-      const kdf = HpkePrimitiveFactory.createKdfFromParams(testInfo.params);
-      expect(kdf instanceof HkdfHpkeKdf).toBe(true);
-      expect(kdf.getKdfId()).toEqual(testInfo.kdfId);
-    });
-    it('should create valid aead from valid aead param', async () => {
-      const aead = HpkePrimitiveFactory.createAeadFromParams(testInfo.params);
-      expect(aead instanceof AesGcmHpkeAead).toBe(true);
-      expect(aead.getAeadId()).toEqual(testInfo.aeadId);
-    });
-  }
+		it("should create valid aead from valid aeadId", async () => {
+			const aead = HpkePrimitiveFactory.createAeadFromId(testInfo.aeadId);
+			expect(aead instanceof AesGcmHpkeAead).toBe(true);
+			expect(aead.getAeadId()).toEqual(testInfo.aeadId);
+		});
+		it("should create valid kem from valid kem param", async () => {
+			const kem = HpkePrimitiveFactory.createKemFromParams(
+				testInfo.params
+			);
+			expect(kem instanceof NistCurvesHpkeKem).toBe(true);
+			expect(kem.getKemId()).toEqual(testInfo.kemId);
+		});
+		it("should create valid kdf from valid kdf param", async () => {
+			const kdf = HpkePrimitiveFactory.createKdfFromParams(
+				testInfo.params
+			);
+			expect(kdf instanceof HkdfHpkeKdf).toBe(true);
+			expect(kdf.getKdfId()).toEqual(testInfo.kdfId);
+		});
+		it("should create valid aead from valid aead param", async () => {
+			const aead = HpkePrimitiveFactory.createAeadFromParams(
+				testInfo.params
+			);
+			expect(aead instanceof AesGcmHpkeAead).toBe(true);
+			expect(aead.getAeadId()).toEqual(testInfo.aeadId);
+		});
+	}
 
-  describe('fails to instantiate from invalid', () => {
-    const invalidHpkeParam = new PbHpkeParams()
-                                 .setKem(PbHpkeKem.KEM_UNKNOWN)
-                                 .setKdf(PbHpkeKdf.KDF_UNKNOWN)
-                                 .setAead(PbHpkeAead.AEAD_UNKNOWN);
-    it('kem id', async () => {
-      try {
-        HpkePrimitiveFactory.createKemFromId(new Uint8Array(0));
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE KEM identifier');
-      }
-    });
-    it('kdf id', async () => {
-      try {
-        HpkePrimitiveFactory.createKdfFromId(new Uint8Array(0));
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE KDF identifier');
-      }
-    });
-    it('aead id', async () => {
-      try {
-        HpkePrimitiveFactory.createAeadFromId(new Uint8Array(0));
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE AEAD identifier');
-      }
-    });
-    it('kem param', async () => {
-      try {
-        HpkePrimitiveFactory.createKemFromParams(invalidHpkeParam);
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE KEM identifier');
-      }
-    });
-    it('kdf param', async () => {
-      try {
-        HpkePrimitiveFactory.createKdfFromParams(invalidHpkeParam);
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE KDF identifier');
-      }
-    });
-    it('aead param', async () => {
-      try {
-        HpkePrimitiveFactory.createAeadFromParams(invalidHpkeParam);
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized HPKE AEAD identifier');
-      }
-    });
-  });
+	describe("fails to instantiate from invalid", () => {
+		const invalidHpkeParam = new PbHpkeParams()
+			.setKem(PbHpkeKem.KEM_UNKNOWN)
+			.setKdf(PbHpkeKdf.KDF_UNKNOWN)
+			.setAead(PbHpkeAead.AEAD_UNKNOWN);
+		it("kem id", async () => {
+			try {
+				HpkePrimitiveFactory.createKemFromId(new Uint8Array(0));
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE KEM identifier"
+				);
+			}
+		});
+		it("kdf id", async () => {
+			try {
+				HpkePrimitiveFactory.createKdfFromId(new Uint8Array(0));
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE KDF identifier"
+				);
+			}
+		});
+		it("aead id", async () => {
+			try {
+				HpkePrimitiveFactory.createAeadFromId(new Uint8Array(0));
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE AEAD identifier"
+				);
+			}
+		});
+		it("kem param", async () => {
+			try {
+				HpkePrimitiveFactory.createKemFromParams(invalidHpkeParam);
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE KEM identifier"
+				);
+			}
+		});
+		it("kdf param", async () => {
+			try {
+				HpkePrimitiveFactory.createKdfFromParams(invalidHpkeParam);
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE KDF identifier"
+				);
+			}
+		});
+		it("aead param", async () => {
+			try {
+				HpkePrimitiveFactory.createAeadFromParams(invalidHpkeParam);
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized HPKE AEAD identifier"
+				);
+			}
+		});
+	});
 });

--- a/javascript/hybrid/internal/hpke/hpke_util_test.ts
+++ b/javascript/hybrid/internal/hpke/hpke_util_test.ts
@@ -4,253 +4,303 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import {PbHpkeKem} from '../../../internal/proto';
-import * as bytes from '../../../subtle/bytes';
-import * as ellipticCurves from '../../../subtle/elliptic_curves';
-import {randBytes} from '../../../subtle/random';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import { PbHpkeKem } from "../../../internal/proto";
+import * as bytes from "../../../subtle/bytes";
+import * as ellipticCurves from "../../../subtle/elliptic_curves";
+import { randBytes } from "../../../subtle/random";
 
-import * as hpkeUtil from './hpke_util';
+import * as hpkeUtil from "./hpke_util";
 
 /**
  * Test vectors as described in @see https://www.rfc-editor.org/rfc/rfc9180.html#appendix-A
  */
 const TEST_VECTORS = [
-  /** Sender keys for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    name: 'sender DHKEM(P-256, HKDF-SHA256)',
-    curveType: 'P-256',
-    publicKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    privateKey: bytes.fromHex(
-        '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-  },
-  /** Recipient keys for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    name: 'recipient DHKEM(P-256, HKDF-SHA256)',
-    curveType: 'P-256',
-    publicKey: bytes.fromHex(
-        '04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0'),
-    privateKey: bytes.fromHex(
-        'f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2'),
-  },
-  /** Sender keys for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    name: 'sender DHKEM(P-521, HKDF-SHA512)',
-    curveType: 'P-521',
-    publicKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    privateKey: bytes.fromHex(
-        '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-  },
-  /** Recipient keys for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    name: 'recipient DHKEM(P-521, HKDF-SHA512)',
-    curveType: 'P-521',
-    publicKey: bytes.fromHex(
-        '0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64'),
-    privateKey: bytes.fromHex(
-        '01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847'),
-  },
+	/** Sender keys for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		name: "sender DHKEM(P-256, HKDF-SHA256)",
+		curveType: "P-256",
+		publicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		privateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+	},
+	/** Recipient keys for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		name: "recipient DHKEM(P-256, HKDF-SHA256)",
+		curveType: "P-256",
+		publicKey: bytes.fromHex(
+			"04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+		),
+		privateKey: bytes.fromHex(
+			"f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
+		),
+	},
+	/** Sender keys for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		name: "sender DHKEM(P-521, HKDF-SHA512)",
+		curveType: "P-521",
+		publicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		privateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+	},
+	/** Recipient keys for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		name: "recipient DHKEM(P-521, HKDF-SHA512)",
+		curveType: "P-521",
+		publicKey: bytes.fromHex(
+			"0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64"
+		),
+		privateKey: bytes.fromHex(
+			"01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847"
+		),
+	},
 ];
 
-describe('HPKE Util', () => {
-  for (const testInfo of TEST_VECTORS) {
-    it(`should convert ${testInfo.name} public key bytes to CryptoKey and back`,
-       async () => {
-         const asCryptoKey: CryptoKey =
-             await hpkeUtil.getPublicKeyFromByteArray(
-                 testInfo.curveType, testInfo.publicKey);
+describe("HPKE Util", () => {
+	for (const testInfo of TEST_VECTORS) {
+		it(`should convert ${testInfo.name} public key bytes to CryptoKey and back`, async () => {
+			const asCryptoKey: CryptoKey =
+				await hpkeUtil.getPublicKeyFromByteArray(
+					testInfo.curveType,
+					testInfo.publicKey
+				);
 
-         expect(asCryptoKey.type).toEqual('public');
-         const alg: EcKeyGenParams = asCryptoKey.algorithm as EcKeyGenParams;
-         expect(alg.name).toEqual('ECDH');
-         expect(alg.namedCurve).toEqual(testInfo.curveType);
+			expect(asCryptoKey.type).toEqual("public");
+			const alg: EcKeyGenParams = asCryptoKey.algorithm as EcKeyGenParams;
+			expect(alg.name).toEqual("ECDH");
+			expect(alg.namedCurve).toEqual(testInfo.curveType);
 
-         const asByteArray: Uint8Array =
-             await hpkeUtil.getByteArrayFromPublicKey(asCryptoKey);
+			const asByteArray: Uint8Array =
+				await hpkeUtil.getByteArrayFromPublicKey(asCryptoKey);
 
-         expect(asByteArray).toEqual(testInfo.publicKey);
-       });
+			expect(asByteArray).toEqual(testInfo.publicKey);
+		});
 
-    it(`should convert ${
-           testInfo.name} private key bytes to CryptoKey and back`,
-       async () => {
-         const asCryptoKey: CryptoKey =
-             await hpkeUtil.getPrivateKeyFromByteArray({
-               curveType: testInfo.curveType,
-               publicKey: testInfo.publicKey,
-               privateKey: testInfo.privateKey
-             });
+		it(`should convert ${testInfo.name} private key bytes to CryptoKey and back`, async () => {
+			const asCryptoKey: CryptoKey =
+				await hpkeUtil.getPrivateKeyFromByteArray({
+					curveType: testInfo.curveType,
+					publicKey: testInfo.publicKey,
+					privateKey: testInfo.privateKey,
+				});
 
-         expect(asCryptoKey.type).toEqual('private');
-         const alg: EcKeyGenParams = asCryptoKey.algorithm as EcKeyGenParams;
-         expect(alg.name).toEqual('ECDH');
-         expect(alg.namedCurve).toEqual(testInfo.curveType);
+			expect(asCryptoKey.type).toEqual("private");
+			const alg: EcKeyGenParams = asCryptoKey.algorithm as EcKeyGenParams;
+			expect(alg.name).toEqual("ECDH");
+			expect(alg.namedCurve).toEqual(testInfo.curveType);
 
-         /* Since we cannot retrieve the private key bytes from a CryptoKey, we
-          * only compare the public key bytes. */
-         const asByteArray: Uint8Array =
-             await hpkeUtil.getByteArrayFromPublicKey(asCryptoKey);
+			/* Since we cannot retrieve the private key bytes from a CryptoKey, we
+			 * only compare the public key bytes. */
+			const asByteArray: Uint8Array =
+				await hpkeUtil.getByteArrayFromPublicKey(asCryptoKey);
 
-         expect(asByteArray).toEqual(testInfo.publicKey);
-       });
+			expect(asByteArray).toEqual(testInfo.publicKey);
+		});
 
-    describe('getPublicKeyFromByteArray', () => {
-      it('should fail when called with an invalid key', async () => {
-        await expectAsync(
-            hpkeUtil.getPublicKeyFromByteArray(
-                testInfo.curveType, randBytes(testInfo.publicKey.length - 1)))
-            .toBeRejectedWithError(InvalidArgumentsException);
-      });
-    });
+		describe("getPublicKeyFromByteArray", () => {
+			it("should fail when called with an invalid key", async () => {
+				await expectAsync(
+					hpkeUtil.getPublicKeyFromByteArray(
+						testInfo.curveType,
+						randBytes(testInfo.publicKey.length - 1)
+					)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
+		});
 
-    describe('getPrivateKeyFromByteArray', () => {
-      it('should fail when called with an invalid public key', async () => {
-        await expectAsync(hpkeUtil.getPrivateKeyFromByteArray({
-          curveType: testInfo.curveType,
-          publicKey: randBytes(testInfo.publicKey.length - 1),
-          privateKey: testInfo.privateKey,
-        })).toBeRejectedWithError(InvalidArgumentsException);
-      });
+		describe("getPrivateKeyFromByteArray", () => {
+			it("should fail when called with an invalid public key", async () => {
+				await expectAsync(
+					hpkeUtil.getPrivateKeyFromByteArray({
+						curveType: testInfo.curveType,
+						publicKey: randBytes(testInfo.publicKey.length - 1),
+						privateKey: testInfo.privateKey,
+					})
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it('should fail when called with an invalid private key', async () => {
-        await expectAsync(hpkeUtil.getPrivateKeyFromByteArray({
-          curveType: testInfo.curveType,
-          publicKey: testInfo.publicKey,
-          privateKey: new Uint8Array(0),
-        })).toBeRejectedWithError(DOMException);
-      });
-    });
-  }
+			it("should fail when called with an invalid private key", async () => {
+				await expectAsync(
+					hpkeUtil.getPrivateKeyFromByteArray({
+						curveType: testInfo.curveType,
+						publicKey: testInfo.publicKey,
+						privateKey: new Uint8Array(0),
+					})
+				).toBeRejectedWithError(DOMException);
+			});
+		});
+	}
 
-  describe('numberToByteArray', () => {
-    it('should convert values correctly', async () => {
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 0, 0))
-          .toEqual(new Uint8Array(0));
+	describe("numberToByteArray", () => {
+		it("should convert values correctly", async () => {
+			expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 0, 0)).toEqual(
+				new Uint8Array(0)
+			);
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 0))
-          .toEqual(Uint8Array.of(0x00));
+			expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 0)).toEqual(
+				Uint8Array.of(0x00)
+			);
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 0))
-          .toEqual(Uint8Array.of(0x00, 0x00));
+			expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 0)).toEqual(
+				Uint8Array.of(0x00, 0x00)
+			);
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 1))
-          .toEqual(Uint8Array.of(0x01));
+			expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 1)).toEqual(
+				Uint8Array.of(0x01)
+			);
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 1))
-          .toEqual(Uint8Array.of(0x00, 0x01));
+			expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 1)).toEqual(
+				Uint8Array.of(0x00, 0x01)
+			);
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 127))
-          .toEqual(Uint8Array.of(0x7F));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 127)
+			).toEqual(Uint8Array.of(0x7f));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 127))
-          .toEqual(Uint8Array.of(0x00, 0x7F));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 127)
+			).toEqual(Uint8Array.of(0x00, 0x7f));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 127))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x7F));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 127)
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x7f));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 128))
-          .toEqual(Uint8Array.of(0x80));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 128)
+			).toEqual(Uint8Array.of(0x80));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 128))
-          .toEqual(Uint8Array.of(0x00, 0x80));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 128)
+			).toEqual(Uint8Array.of(0x00, 0x80));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 128))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x80));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 128)
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x80));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 255))
-          .toEqual(Uint8Array.of(0xFF));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 1, 255)
+			).toEqual(Uint8Array.of(0xff));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 255))
-          .toEqual(Uint8Array.of(0x00, 0xFF));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 255)
+			).toEqual(Uint8Array.of(0x00, 0xff));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 255))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0xFF));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 3, 255)
+			).toEqual(Uint8Array.of(0x00, 0x00, 0xff));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 256))
-          .toEqual(Uint8Array.of(0x01, 0x00));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 256)
+			).toEqual(Uint8Array.of(0x01, 0x00));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 258))
-          .toEqual(Uint8Array.of(0x01, 0x02));
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 2, 258)
+			).toEqual(Uint8Array.of(0x01, 0x02));
 
-      expect(hpkeUtil.numberToByteArray(/*intendedLength*/ 4, 258))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x01, 0x02));
-    });
-  });
+			expect(
+				hpkeUtil.numberToByteArray(/*intendedLength*/ 4, 258)
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x01, 0x02));
+		});
+	});
 
-  describe('bigIntToByteArray', () => {
-    it('should convert values correctly', async () => {
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 0, BigInt(0)))
-          .toEqual(new Uint8Array(0));
+	describe("bigIntToByteArray", () => {
+		it("should convert values correctly", async () => {
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 0, BigInt(0))
+			).toEqual(new Uint8Array(0));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(0)))
-          .toEqual(Uint8Array.of(0x00));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(0))
+			).toEqual(Uint8Array.of(0x00));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(0)))
-          .toEqual(Uint8Array.of(0x00, 0x00));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(0))
+			).toEqual(Uint8Array.of(0x00, 0x00));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(1)))
-          .toEqual(Uint8Array.of(0x01));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(1))
+			).toEqual(Uint8Array.of(0x01));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(1)))
-          .toEqual(Uint8Array.of(0x00, 0x01));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(1))
+			).toEqual(Uint8Array.of(0x00, 0x01));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(127)))
-          .toEqual(Uint8Array.of(0x7F));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(127))
+			).toEqual(Uint8Array.of(0x7f));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(127)))
-          .toEqual(Uint8Array.of(0x00, 0x7F));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(127))
+			).toEqual(Uint8Array.of(0x00, 0x7f));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(127)))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x7F));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(127))
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x7f));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(128)))
-          .toEqual(Uint8Array.of(0x80));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(128))
+			).toEqual(Uint8Array.of(0x80));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(128)))
-          .toEqual(Uint8Array.of(0x00, 0x80));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(128))
+			).toEqual(Uint8Array.of(0x00, 0x80));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(128)))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x80));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(128))
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x80));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(255)))
-          .toEqual(Uint8Array.of(0xFF));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 1, BigInt(255))
+			).toEqual(Uint8Array.of(0xff));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(255)))
-          .toEqual(Uint8Array.of(0x00, 0xFF));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(255))
+			).toEqual(Uint8Array.of(0x00, 0xff));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(255)))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0xFF));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 3, BigInt(255))
+			).toEqual(Uint8Array.of(0x00, 0x00, 0xff));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(256)))
-          .toEqual(Uint8Array.of(0x01, 0x00));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(256))
+			).toEqual(Uint8Array.of(0x01, 0x00));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(258)))
-          .toEqual(Uint8Array.of(0x01, 0x02));
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 2, BigInt(258))
+			).toEqual(Uint8Array.of(0x01, 0x02));
 
-      expect(hpkeUtil.bigIntToByteArray(/*intendedLength*/ 4, BigInt(258)))
-          .toEqual(Uint8Array.of(0x00, 0x00, 0x01, 0x02));
-    });
-  });
+			expect(
+				hpkeUtil.bigIntToByteArray(/*intendedLength*/ 4, BigInt(258))
+			).toEqual(Uint8Array.of(0x00, 0x00, 0x01, 0x02));
+		});
+	});
 
-  describe('nistHpkeKemToCurve', () => {
-    it('should convert values correctly', async () => {
-      expect(hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.DHKEM_P256_HKDF_SHA256))
-          .toEqual(ellipticCurves.CurveType.P256);
+	describe("nistHpkeKemToCurve", () => {
+		it("should convert values correctly", async () => {
+			expect(
+				hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.DHKEM_P256_HKDF_SHA256)
+			).toEqual(ellipticCurves.CurveType.P256);
 
-      expect(hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.DHKEM_P521_HKDF_SHA512))
-          .toEqual(ellipticCurves.CurveType.P521);
-    });
+			expect(
+				hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.DHKEM_P521_HKDF_SHA512)
+			).toEqual(ellipticCurves.CurveType.P521);
+		});
 
-    it('should fail for unknown kem value', async () => {
-      try {
-        hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.KEM_UNKNOWN);
-        fail('An exception should be thrown.');
-      } catch (e: unknown) {
-        expect((e as InvalidArgumentsException).message)
-            .toBe('Unrecognized NIST HPKE KEM identifier');
-      }
-    });
-  });
+		it("should fail for unknown kem value", async () => {
+			try {
+				hpkeUtil.nistHpkeKemToCurve(PbHpkeKem.KEM_UNKNOWN);
+				fail("An exception should be thrown.");
+			} catch (e: unknown) {
+				expect((e as InvalidArgumentsException).message).toBe(
+					"Unrecognized NIST HPKE KEM identifier"
+				);
+			}
+		});
+	});
 });

--- a/javascript/hybrid/internal/hpke/nist_curves_hpke_kem_private_key_test.ts
+++ b/javascript/hybrid/internal/hpke/nist_curves_hpke_kem_private_key_test.ts
@@ -4,111 +4,134 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import * as bytes from '../../../subtle/bytes';
-import * as ellipticCurves from '../../../subtle/elliptic_curves';
-import {randBytes} from '../../../subtle/random';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import * as bytes from "../../../subtle/bytes";
+import * as ellipticCurves from "../../../subtle/elliptic_curves";
+import { randBytes } from "../../../subtle/random";
 
-import {fromBytes, fromCryptoKeyPair} from './nist_curves_hpke_kem_private_key';
+import {
+	fromBytes,
+	fromCryptoKeyPair,
+} from "./nist_curves_hpke_kem_private_key";
 
 interface TestVector {
-  name: string;
-  curveType: ellipticCurves.CurveType.P256|ellipticCurves.CurveType.P521;
-  senderPublicKey: Uint8Array;
-  senderPrivateKey: Uint8Array;
+	name: string;
+	curveType: ellipticCurves.CurveType.P256 | ellipticCurves.CurveType.P521;
+	senderPublicKey: Uint8Array;
+	senderPrivateKey: Uint8Array;
 }
 
 /**
  * Test vectors as described in @see https://www.rfc-editor.org/rfc/rfc9180.html#appendix-A
  */
 const TEST_VECTORS: TestVector[] = [
-  /** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    name: 'DHKEM(P-521, HKDF-SHA512)',
-    curveType: ellipticCurves.CurveType.P256,
-    senderPublicKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    senderPrivateKey: bytes.fromHex(
-        '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-  },
-  /** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    name: 'DHKEM(P-521, HKDF-SHA512)',
-    curveType: ellipticCurves.CurveType.P521,
-    senderPublicKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    senderPrivateKey: bytes.fromHex(
-        '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-  }
+	/** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		name: "DHKEM(P-521, HKDF-SHA512)",
+		curveType: ellipticCurves.CurveType.P256,
+		senderPublicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+	},
+	/** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		name: "DHKEM(P-521, HKDF-SHA512)",
+		curveType: ellipticCurves.CurveType.P521,
+		senderPublicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+	},
 ];
 
-describe('NistCurvesHpkeKemPrivateKey', () => {
-  for (const testInfo of TEST_VECTORS) {
-    it('should instantiate from key raw bytes and serialize public key correctly',
-       async () => {
-         const privateKey = await fromBytes({
-           privateKey: testInfo.senderPrivateKey,
-           publicKey: testInfo.senderPublicKey,
-           curveType: testInfo.curveType
-         });
-         const serialiazedPublicKey = await privateKey.getSerializedPublicKey();
-         expect(serialiazedPublicKey).toEqual(testInfo.senderPublicKey);
-       });
+describe("NistCurvesHpkeKemPrivateKey", () => {
+	for (const testInfo of TEST_VECTORS) {
+		it("should instantiate from key raw bytes and serialize public key correctly", async () => {
+			const privateKey = await fromBytes({
+				privateKey: testInfo.senderPrivateKey,
+				publicKey: testInfo.senderPublicKey,
+				curveType: testInfo.curveType,
+			});
+			const serialiazedPublicKey =
+				await privateKey.getSerializedPublicKey();
+			expect(serialiazedPublicKey).toEqual(testInfo.senderPublicKey);
+		});
 
-    describe('fails to instantiate from invalid', () => {
-      it('private key', async () => {
-        await expectAsync(fromBytes({
-          privateKey: new Uint8Array(0),
-          publicKey: testInfo.senderPublicKey,
-          curveType: testInfo.curveType
-        })).toBeRejectedWithError(DOMException);
-      });
+		describe("fails to instantiate from invalid", () => {
+			it("private key", async () => {
+				await expectAsync(
+					fromBytes({
+						privateKey: new Uint8Array(0),
+						publicKey: testInfo.senderPublicKey,
+						curveType: testInfo.curveType,
+					})
+				).toBeRejectedWithError(DOMException);
+			});
 
-      it('public key raw bytes', async () => {
-        await expectAsync(fromBytes({
-          privateKey: testInfo.senderPrivateKey,
-          publicKey: randBytes(testInfo.senderPublicKey.length),
-          curveType: testInfo.curveType
-        })).toBeRejectedWithError(InvalidArgumentsException);
-      });
+			it("public key raw bytes", async () => {
+				await expectAsync(
+					fromBytes({
+						privateKey: testInfo.senderPrivateKey,
+						publicKey: randBytes(testInfo.senderPublicKey.length),
+						curveType: testInfo.curveType,
+					})
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it('ECDH curve type', async () => {
-        const mismatchedCurveType =
-            testInfo.curveType === ellipticCurves.CurveType.P256 ?
-            ellipticCurves.CurveType.P521 :
-            ellipticCurves.CurveType.P256;
+			it("ECDH curve type", async () => {
+				const mismatchedCurveType =
+					testInfo.curveType === ellipticCurves.CurveType.P256
+						? ellipticCurves.CurveType.P521
+						: ellipticCurves.CurveType.P256;
 
-        await expectAsync(fromBytes({
-          privateKey: testInfo.senderPrivateKey,
-          publicKey: testInfo.senderPublicKey,
-          curveType: mismatchedCurveType,
-        })).toBeRejectedWithError(InvalidArgumentsException);
-      });
+				await expectAsync(
+					fromBytes({
+						privateKey: testInfo.senderPrivateKey,
+						publicKey: testInfo.senderPublicKey,
+						curveType: mismatchedCurveType,
+					})
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
+			it("algorithm in the CryptoKeyPair", async () => {
+				const invalidKeyPair: CryptoKeyPair =
+					await ellipticCurves.generateKeyPair(
+						"ECDSA",
+						ellipticCurves.curveToString(testInfo.curveType)
+					);
+				await expectAsync(
+					fromCryptoKeyPair(invalidKeyPair)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it('algorithm in the CryptoKeyPair', async () => {
-        const invalidKeyPair: CryptoKeyPair =
-            await ellipticCurves.generateKeyPair(
-                'ECDSA', ellipticCurves.curveToString(testInfo.curveType));
-        await expectAsync(fromCryptoKeyPair(invalidKeyPair))
-            .toBeRejectedWithError(InvalidArgumentsException);
-      });
+			it("key type on the private key in a CryptoKeyPair", async () => {
+				const keyPair: CryptoKeyPair =
+					await ellipticCurves.generateKeyPair(
+						"ECDH",
+						ellipticCurves.curveToString(testInfo.curveType)
+					);
+				keyPair.privateKey = keyPair.publicKey;
+				await expectAsync(
+					fromCryptoKeyPair(keyPair)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it('key type on the private key in a CryptoKeyPair', async () => {
-        const keyPair: CryptoKeyPair = await ellipticCurves.generateKeyPair(
-            'ECDH', ellipticCurves.curveToString(testInfo.curveType));
-        keyPair.privateKey = keyPair.publicKey;
-        await expectAsync(fromCryptoKeyPair(keyPair))
-            .toBeRejectedWithError(InvalidArgumentsException);
-      });
-
-      it('key type on the public key in a CryptoKeyPair', async () => {
-        const keyPair: CryptoKeyPair = await ellipticCurves.generateKeyPair(
-            'ECDH', ellipticCurves.curveToString(testInfo.curveType));
-        keyPair.publicKey = keyPair.privateKey;
-        await expectAsync(fromCryptoKeyPair(keyPair))
-            .toBeRejectedWithError(InvalidArgumentsException);
-      });
-    });
-  }
+			it("key type on the public key in a CryptoKeyPair", async () => {
+				const keyPair: CryptoKeyPair =
+					await ellipticCurves.generateKeyPair(
+						"ECDH",
+						ellipticCurves.curveToString(testInfo.curveType)
+					);
+				keyPair.publicKey = keyPair.privateKey;
+				await expectAsync(
+					fromCryptoKeyPair(keyPair)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
+		});
+	}
 });

--- a/javascript/hybrid/internal/hpke/nist_curves_hpke_kem_test.ts
+++ b/javascript/hybrid/internal/hpke/nist_curves_hpke_kem_test.ts
@@ -4,221 +4,255 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../../../exception/invalid_arguments_exception';
-import * as bytes from '../../../subtle/bytes';
-import * as ellipticCurves from '../../../subtle/elliptic_curves';
+import { InvalidArgumentsException } from "../../../exception/invalid_arguments_exception";
+import * as bytes from "../../../subtle/bytes";
+import * as ellipticCurves from "../../../subtle/elliptic_curves";
 
-import {HPKE_BORINGSSL_TEST_VECTORS} from './hpke_boringssl_test_vectors';
-import {HpkeKemEncapOutput} from './hpke_kem_encap_output';
-import * as hpkeUtil from './hpke_util';
-import {NistCurvesHpkeKem} from './nist_curves_hpke_kem';
-import {fromBytes} from './nist_curves_hpke_kem_private_key';
-import {parseTestVectors} from './testing/hpke_test_utils';
+import { HPKE_BORINGSSL_TEST_VECTORS } from "./hpke_boringssl_test_vectors";
+import { HpkeKemEncapOutput } from "./hpke_kem_encap_output";
+import * as hpkeUtil from "./hpke_util";
+import { NistCurvesHpkeKem } from "./nist_curves_hpke_kem";
+import { fromBytes } from "./nist_curves_hpke_kem_private_key";
+import { parseTestVectors } from "./testing/hpke_test_utils";
 
 interface TestVector {
-  kemId: Uint8Array;
-  senderPublicKey: Uint8Array;
-  senderPrivateKey: Uint8Array;
-  recipientPublicKey: Uint8Array;
-  recipientPrivateKey: Uint8Array;
-  encapsulatedKey: Uint8Array;
-  sharedSecret: Uint8Array;
+	kemId: Uint8Array;
+	senderPublicKey: Uint8Array;
+	senderPrivateKey: Uint8Array;
+	recipientPublicKey: Uint8Array;
+	recipientPrivateKey: Uint8Array;
+	encapsulatedKey: Uint8Array;
+	sharedSecret: Uint8Array;
 }
 
 /**
  * Test vectors as described in @see https://www.rfc-editor.org/rfc/rfc9180.html#appendix-A
  */
 const TEST_VECTORS: TestVector[] = [
-  /** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
-  {
-    kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
-    senderPublicKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    senderPrivateKey: bytes.fromHex(
-        '4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb'),
-    recipientPublicKey: bytes.fromHex(
-        '04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0'),
-    recipientPrivateKey: bytes.fromHex(
-        'f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2'),
-    encapsulatedKey: bytes.fromHex(
-        '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'),
-    sharedSecret: bytes.fromHex(
-        'c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8'),
-  },
-  /** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
-  {
-    kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
-    senderPublicKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    senderPrivateKey: bytes.fromHex(
-        '014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b'),
-    recipientPublicKey: bytes.fromHex(
-        '0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64'),
-    recipientPrivateKey: bytes.fromHex(
-        '01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847'),
-    encapsulatedKey: bytes.fromHex(
-        '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'),
-    sharedSecret: bytes.fromHex(
-        '776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818'),
-  },
-  ...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS)
+	/** Test vector for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM */
+	{
+		kemId: hpkeUtil.P256_HKDF_SHA256_KEM_ID,
+		senderPublicKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+		),
+		sharedSecret: bytes.fromHex(
+			"c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8"
+		),
+	},
+	/** Test vector for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM */
+	{
+		kemId: hpkeUtil.P521_HKDF_SHA512_KEM_ID,
+		senderPublicKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		senderPrivateKey: bytes.fromHex(
+			"014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d535415a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e374b"
+		),
+		recipientPublicKey: bytes.fromHex(
+			"0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64"
+		),
+		recipientPrivateKey: bytes.fromHex(
+			"01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c27196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b2462847"
+		),
+		encapsulatedKey: bytes.fromHex(
+			"040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0"
+		),
+		sharedSecret: bytes.fromHex(
+			"776ab421302f6eff7d7cb5cb1adaea0cd50872c71c2d63c30c4f1d5e43653336fef33b103c67e7a98add2d3b66e2fda95b5b2a667aa9dac7e59cc1d46d30e818"
+		),
+	},
+	...parseTestVectors(HPKE_BORINGSSL_TEST_VECTORS),
 ];
 
-describe('NIST curves HPKE KEM', () => {
-  for (const testInfo of TEST_VECTORS) {
-    let curveType: ellipticCurves.CurveType.P256|ellipticCurves.CurveType.P521;
+describe("NIST curves HPKE KEM", () => {
+	for (const testInfo of TEST_VECTORS) {
+		let curveType:
+			| ellipticCurves.CurveType.P256
+			| ellipticCurves.CurveType.P521;
 
-    if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P256;
-    } else if (bytes.isEqual(
-                   testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)) {
-      curveType = ellipticCurves.CurveType.P521;
-    } else {
-      throw new InvalidArgumentsException(
-          `unsupported KEM id: ${testInfo.kemId}`);
-    }
+		if (bytes.isEqual(testInfo.kemId, hpkeUtil.P256_HKDF_SHA256_KEM_ID)) {
+			curveType = ellipticCurves.CurveType.P256;
+		} else if (
+			bytes.isEqual(testInfo.kemId, hpkeUtil.P521_HKDF_SHA512_KEM_ID)
+		) {
+			curveType = ellipticCurves.CurveType.P521;
+		} else {
+			throw new InvalidArgumentsException(
+				`unsupported KEM id: ${testInfo.kemId}`
+			);
+		}
 
-    const curveString = ellipticCurves.curveToString(curveType);
-    describe('encapsulate', () => {
-      it(`should work for ${curveString}`, async () => {
-        const kem: NistCurvesHpkeKem = NistCurvesHpkeKem.fromCurve(curveType);
+		const curveString = ellipticCurves.curveToString(curveType);
+		describe("encapsulate", () => {
+			it(`should work for ${curveString}`, async () => {
+				const kem: NistCurvesHpkeKem =
+					NistCurvesHpkeKem.fromCurve(curveType);
 
-        const senderPrivateKeyPair = await fromBytes({
-          privateKey: testInfo.senderPrivateKey,
-          publicKey: testInfo.senderPublicKey,
-          curveType,
-        });
+				const senderPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.senderPrivateKey,
+					publicKey: testInfo.senderPublicKey,
+					curveType,
+				});
 
-        // use the encapsulateHelper test only function
-        const result: HpkeKemEncapOutput = await kem.TEST_ONLY(
-            testInfo.recipientPublicKey, senderPrivateKeyPair);
+				// use the encapsulateHelper test only function
+				const result: HpkeKemEncapOutput = await kem.TEST_ONLY(
+					testInfo.recipientPublicKey,
+					senderPrivateKeyPair
+				);
 
-        expect(result.sharedSecret).toEqual(testInfo.sharedSecret);
-        expect(result.encapsulatedKey).toEqual(testInfo.encapsulatedKey);
-      });
+				expect(result.sharedSecret).toEqual(testInfo.sharedSecret);
+				expect(result.encapsulatedKey).toEqual(
+					testInfo.encapsulatedKey
+				);
+			});
 
-      it(`should fail with an invalid ${curveString} recipient public key`,
-         async () => {
-           const kem = NistCurvesHpkeKem.fromCurve(curveType);
+			it(`should fail with an invalid ${curveString} recipient public key`, async () => {
+				const kem = NistCurvesHpkeKem.fromCurve(curveType);
 
-           const senderPrivateKeyPair = await fromBytes({
-             privateKey: testInfo.senderPrivateKey,
-             publicKey: testInfo.senderPublicKey,
-             curveType,
-           });
+				const senderPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.senderPrivateKey,
+					publicKey: testInfo.senderPublicKey,
+					curveType,
+				});
 
-           const invalidRecipientPublicKey =
-               bytes.concat(testInfo.recipientPublicKey, new Uint8Array(2));
+				const invalidRecipientPublicKey = bytes.concat(
+					testInfo.recipientPublicKey,
+					new Uint8Array(2)
+				);
 
-           await expectAsync(
-               kem.TEST_ONLY(invalidRecipientPublicKey, senderPrivateKeyPair))
-               .toBeRejectedWithError(InvalidArgumentsException);
-         });
+				await expectAsync(
+					kem.TEST_ONLY(
+						invalidRecipientPublicKey,
+						senderPrivateKeyPair
+					)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it(`should fail with a mismatched curve type for ${curveString}`,
-         async () => {
-           const mismatchedCurveType =
-               curveType === ellipticCurves.CurveType.P256 ?
-               ellipticCurves.CurveType.P521 :
-               ellipticCurves.CurveType.P256;
+			it(`should fail with a mismatched curve type for ${curveString}`, async () => {
+				const mismatchedCurveType =
+					curveType === ellipticCurves.CurveType.P256
+						? ellipticCurves.CurveType.P521
+						: ellipticCurves.CurveType.P256;
 
-           const kem = NistCurvesHpkeKem.fromCurve(mismatchedCurveType);
+				const kem = NistCurvesHpkeKem.fromCurve(mismatchedCurveType);
 
-           await expectAsync(kem.encapsulate(testInfo.recipientPublicKey))
-               .toBeRejectedWithError(InvalidArgumentsException);
-         });
+				await expectAsync(
+					kem.encapsulate(testInfo.recipientPublicKey)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it(`should not encapsulate the correct sharedSecret nor escapsulatedKey with a mismatched senderPrivateKeyPair for ${
-             curveString}`,
-         async () => {
-           const kem = NistCurvesHpkeKem.fromCurve(curveType);
+			it(`should not encapsulate the correct sharedSecret nor escapsulatedKey with a mismatched senderPrivateKeyPair for ${curveString}`, async () => {
+				const kem = NistCurvesHpkeKem.fromCurve(curveType);
 
-           // use recipientPrivateKeyPair as the senderPrivateKeyPair"
-           const recipientPrivateKeyPair = await fromBytes({
-             privateKey: testInfo.recipientPrivateKey,
-             publicKey: testInfo.recipientPublicKey,
-             curveType,
-           });
+				// use recipientPrivateKeyPair as the senderPrivateKeyPair"
+				const recipientPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.recipientPrivateKey,
+					publicKey: testInfo.recipientPublicKey,
+					curveType,
+				});
 
-           const result: HpkeKemEncapOutput = await kem.TEST_ONLY(
-               testInfo.recipientPublicKey, recipientPrivateKeyPair);
+				const result: HpkeKemEncapOutput = await kem.TEST_ONLY(
+					testInfo.recipientPublicKey,
+					recipientPrivateKeyPair
+				);
 
-           expect(result.sharedSecret).not.toEqual(testInfo.sharedSecret);
-           expect(result.encapsulatedKey).not.toEqual(testInfo.encapsulatedKey);
-         });
-    });
+				expect(result.sharedSecret).not.toEqual(testInfo.sharedSecret);
+				expect(result.encapsulatedKey).not.toEqual(
+					testInfo.encapsulatedKey
+				);
+			});
+		});
 
-    describe('decapsulate', () => {
-      it(`should work for ${curveString}`, async () => {
-        const kem = NistCurvesHpkeKem.fromCurve(curveType);
+		describe("decapsulate", () => {
+			it(`should work for ${curveString}`, async () => {
+				const kem = NistCurvesHpkeKem.fromCurve(curveType);
 
-        const recipientPrivateKeyPair = await fromBytes({
-          privateKey: testInfo.recipientPrivateKey,
-          publicKey: testInfo.recipientPublicKey,
-          curveType,
-        });
+				const recipientPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.recipientPrivateKey,
+					publicKey: testInfo.recipientPublicKey,
+					curveType,
+				});
 
-        const result: Uint8Array = await kem.decapsulate(
-            testInfo.encapsulatedKey, recipientPrivateKeyPair);
-        expect(result).toEqual(testInfo.sharedSecret);
-      });
+				const result: Uint8Array = await kem.decapsulate(
+					testInfo.encapsulatedKey,
+					recipientPrivateKeyPair
+				);
+				expect(result).toEqual(testInfo.sharedSecret);
+			});
 
-      it(`should fail with an invalid ${curveString} encapsulated key`,
-         async () => {
-           const kem = NistCurvesHpkeKem.fromCurve(curveType);
+			it(`should fail with an invalid ${curveString} encapsulated key`, async () => {
+				const kem = NistCurvesHpkeKem.fromCurve(curveType);
 
-           const recipientPrivateKeyPair = await fromBytes({
-             privateKey: testInfo.recipientPrivateKey,
-             publicKey: testInfo.recipientPublicKey,
-             curveType,
-           });
+				const recipientPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.recipientPrivateKey,
+					publicKey: testInfo.recipientPublicKey,
+					curveType,
+				});
 
-           const invalidEncapsulatedKey =
-               bytes.concat(testInfo.encapsulatedKey, new Uint8Array(2));
+				const invalidEncapsulatedKey = bytes.concat(
+					testInfo.encapsulatedKey,
+					new Uint8Array(2)
+				);
 
-           await expectAsync(
-               kem.decapsulate(invalidEncapsulatedKey, recipientPrivateKeyPair))
-               .toBeRejectedWithError(InvalidArgumentsException);
-         });
+				await expectAsync(
+					kem.decapsulate(
+						invalidEncapsulatedKey,
+						recipientPrivateKeyPair
+					)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it(`should fail with a mismatched curve type for ${curveString}`,
-         async () => {
-           const mismatchedCurveType =
-               curveType === ellipticCurves.CurveType.P256 ?
-               ellipticCurves.CurveType.P521 :
-               ellipticCurves.CurveType.P256;
+			it(`should fail with a mismatched curve type for ${curveString}`, async () => {
+				const mismatchedCurveType =
+					curveType === ellipticCurves.CurveType.P256
+						? ellipticCurves.CurveType.P521
+						: ellipticCurves.CurveType.P256;
 
-           const kem = NistCurvesHpkeKem.fromCurve(mismatchedCurveType);
+				const kem = NistCurvesHpkeKem.fromCurve(mismatchedCurveType);
 
-           const recipientPrivateKeyPair = await fromBytes({
-             privateKey: testInfo.recipientPrivateKey,
-             publicKey: testInfo.recipientPublicKey,
-             curveType,
-           });
+				const recipientPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.recipientPrivateKey,
+					publicKey: testInfo.recipientPublicKey,
+					curveType,
+				});
 
-           await expectAsync(
-               kem.decapsulate(
-                   testInfo.encapsulatedKey, recipientPrivateKeyPair))
-               .toBeRejectedWithError(InvalidArgumentsException);
-         });
+				await expectAsync(
+					kem.decapsulate(
+						testInfo.encapsulatedKey,
+						recipientPrivateKeyPair
+					)
+				).toBeRejectedWithError(InvalidArgumentsException);
+			});
 
-      it(`should not decapsulate the correct sharedSecret with a mismatched recipientPrivateKeyPair for ${
-             curveString}`,
-         async () => {
-           const kem = NistCurvesHpkeKem.fromCurve(curveType);
+			it(`should not decapsulate the correct sharedSecret with a mismatched recipientPrivateKeyPair for ${curveString}`, async () => {
+				const kem = NistCurvesHpkeKem.fromCurve(curveType);
 
-           // use senderPrivateKeyPair as the recipientPrivateKeyPair"
-           const senderPrivateKeyPair = await fromBytes({
-             privateKey: testInfo.senderPrivateKey,
-             publicKey: testInfo.senderPublicKey,
-             curveType,
-           });
+				// use senderPrivateKeyPair as the recipientPrivateKeyPair"
+				const senderPrivateKeyPair = await fromBytes({
+					privateKey: testInfo.senderPrivateKey,
+					publicKey: testInfo.senderPublicKey,
+					curveType,
+				});
 
-           const result: Uint8Array = await kem.decapsulate(
-               testInfo.encapsulatedKey, senderPrivateKeyPair);
+				const result: Uint8Array = await kem.decapsulate(
+					testInfo.encapsulatedKey,
+					senderPrivateKeyPair
+				);
 
-           expect(result).not.toEqual(testInfo.sharedSecret);
-         });
-    });
-  }
+				expect(result).not.toEqual(testInfo.sharedSecret);
+			});
+		});
+	}
 });

--- a/javascript/hybrid/internal/hpke/testing/hpke_test_utils_test.ts
+++ b/javascript/hybrid/internal/hpke/testing/hpke_test_utils_test.ts
@@ -4,79 +4,93 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as hpkeUtil from '../hpke_util';
+import * as hpkeUtil from "../hpke_util";
 
-import * as hpkeTestUtils from './hpke_test_utils';
+import * as hpkeTestUtils from "./hpke_test_utils";
 
 /** example `HpkeTestVector[]` with made up values for testing purposes` */
-const testVectors:
-    hpkeTestUtils.HpkeTestVector[] = hpkeTestUtils.parseTestVectors([{
-  'mode': 0,
-  'kem_id': 16,
-  'kdf_id': 1,
-  'aead_id': 1,
-  'info': '0001',
-  'ikmR': '0002',
-  'ikmE': '0003',
-  'skRm': '0004',
-  'skEm': '0005',
-  'pkRm': '0006',
-  'pkEm': '0007',
-  'enc': '0008',
-  'shared_secret': '0009',
-  'key_schedule_context': '0010',
-  'secret': '0011',
-  'key': '0012',
-  'base_nonce': '0013',
-  'exporter_secret': '0014',
-  'encryptions': [
-    {'aad': '0015', 'ciphertext': '0016', 'nonce': '0017', 'plaintext': '0018'}
-  ],
-  'exports': [{'exporter_context': '', 'L': 0, 'exported_value': ''}]
-}]);
+const testVectors: hpkeTestUtils.HpkeTestVector[] =
+	hpkeTestUtils.parseTestVectors([
+		{
+			mode: 0,
+			kem_id: 16,
+			kdf_id: 1,
+			aead_id: 1,
+			info: "0001",
+			ikmR: "0002",
+			ikmE: "0003",
+			skRm: "0004",
+			skEm: "0005",
+			pkRm: "0006",
+			pkEm: "0007",
+			enc: "0008",
+			shared_secret: "0009",
+			key_schedule_context: "0010",
+			secret: "0011",
+			key: "0012",
+			base_nonce: "0013",
+			exporter_secret: "0014",
+			encryptions: [
+				{
+					aad: "0015",
+					ciphertext: "0016",
+					nonce: "0017",
+					plaintext: "0018",
+				},
+			],
+			exports: [{ exporter_context: "", L: 0, exported_value: "" }],
+		},
+	]);
 
-describe('hpkeTestUtils', () => {
-  describe('HpkeTestVector', () => {
-    it('should be well formed', async () => {
-      const testVector: hpkeTestUtils.HpkeTestVector = testVectors[0];
-      expect(testVector.mode).toEqual(hpkeUtil.BASE_MODE);
-      expect(testVector.kemId).toEqual(hpkeUtil.P256_HKDF_SHA256_KEM_ID);
-      expect(testVector.kdfId).toEqual(hpkeUtil.HKDF_SHA256_KDF_ID);
-      expect(testVector.aeadId).toEqual(hpkeUtil.AES_128_GCM_AEAD_ID);
-      expect(testVector.info).toEqual(new Uint8Array([0, 0x0001]));
-      expect(testVector.recipientPrivateKey).toEqual(new Uint8Array([
-        0, 0x0004
-      ]));
-      expect(testVector.senderPrivateKey).toEqual(new Uint8Array([0, 0x0005]));
-      expect(testVector.recipientPublicKey).toEqual(new Uint8Array([
-        0, 0x0006
-      ]));
-      expect(testVector.senderPublicKey).toEqual(new Uint8Array([0, 0x0007]));
-      expect(testVector.encapsulatedKey).toEqual(new Uint8Array([0, 0x0008]));
-      expect(testVector.sharedSecret).toEqual(new Uint8Array([0, 0x0009]));
-      expect(testVector.keyScheduleContext).toEqual(new Uint8Array([
-        0, 0x0010
-      ]));
-      expect(testVector.secret).toEqual(new Uint8Array([0, 0x0011]));
-      expect(testVector.key).toEqual(new Uint8Array([0, 0x0012]));
-      expect(testVector.baseNonce).toEqual(new Uint8Array([0, 0x0013]));
-    });
+describe("hpkeTestUtils", () => {
+	describe("HpkeTestVector", () => {
+		it("should be well formed", async () => {
+			const testVector: hpkeTestUtils.HpkeTestVector = testVectors[0];
+			expect(testVector.mode).toEqual(hpkeUtil.BASE_MODE);
+			expect(testVector.kemId).toEqual(hpkeUtil.P256_HKDF_SHA256_KEM_ID);
+			expect(testVector.kdfId).toEqual(hpkeUtil.HKDF_SHA256_KDF_ID);
+			expect(testVector.aeadId).toEqual(hpkeUtil.AES_128_GCM_AEAD_ID);
+			expect(testVector.info).toEqual(new Uint8Array([0, 0x0001]));
+			expect(testVector.recipientPrivateKey).toEqual(
+				new Uint8Array([0, 0x0004])
+			);
+			expect(testVector.senderPrivateKey).toEqual(
+				new Uint8Array([0, 0x0005])
+			);
+			expect(testVector.recipientPublicKey).toEqual(
+				new Uint8Array([0, 0x0006])
+			);
+			expect(testVector.senderPublicKey).toEqual(
+				new Uint8Array([0, 0x0007])
+			);
+			expect(testVector.encapsulatedKey).toEqual(
+				new Uint8Array([0, 0x0008])
+			);
+			expect(testVector.sharedSecret).toEqual(
+				new Uint8Array([0, 0x0009])
+			);
+			expect(testVector.keyScheduleContext).toEqual(
+				new Uint8Array([0, 0x0010])
+			);
+			expect(testVector.secret).toEqual(new Uint8Array([0, 0x0011]));
+			expect(testVector.key).toEqual(new Uint8Array([0, 0x0012]));
+			expect(testVector.baseNonce).toEqual(new Uint8Array([0, 0x0013]));
+		});
 
-    it('encryption should be well formed', async () => {
-      const testVector: hpkeTestUtils.HpkeTestVector = testVectors[0];
-      expect(testVector.encryptions[0].associatedData).toEqual(new Uint8Array([
-        0, 0x0015
-      ]));
-      expect(testVector.encryptions[0].ciphertext).toEqual(new Uint8Array([
-        0, 0x0016
-      ]));
-      expect(testVector.encryptions[0].nonce).toEqual(new Uint8Array([
-        0, 0x0017
-      ]));
-      expect(testVector.encryptions[0].plaintext).toEqual(new Uint8Array([
-        0, 0x0018
-      ]));
-    });
-  });
-
+		it("encryption should be well formed", async () => {
+			const testVector: hpkeTestUtils.HpkeTestVector = testVectors[0];
+			expect(testVector.encryptions[0].associatedData).toEqual(
+				new Uint8Array([0, 0x0015])
+			);
+			expect(testVector.encryptions[0].ciphertext).toEqual(
+				new Uint8Array([0, 0x0016])
+			);
+			expect(testVector.encryptions[0].nonce).toEqual(
+				new Uint8Array([0, 0x0017])
+			);
+			expect(testVector.encryptions[0].plaintext).toEqual(
+				new Uint8Array([0, 0x0018])
+			);
+		});
+	});
 });

--- a/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.ts
+++ b/javascript/hybrid/registry_ecies_aead_hkdf_dem_helper_test.ts
@@ -4,160 +4,184 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
 
-import {RegistryEciesAeadHkdfDemHelper} from './registry_ecies_aead_hkdf_dem_helper';
+import { RegistryEciesAeadHkdfDemHelper } from "./registry_ecies_aead_hkdf_dem_helper";
 
-describe('registry ecies aead hkdf dem helper test', function() {
-  beforeEach(function() {
-    AeadConfig.register();
-  });
+describe("registry ecies aead hkdf dem helper test", () => {
+	beforeEach(() => {
+		AeadConfig.register();
+	});
 
-  afterEach(function() {
-    Registry.reset();
-  });
+	afterEach(() => {
+		Registry.reset();
+	});
 
-  //////////////////////////////////////////////////////////////////////////////
-  // Tests for constructor
-  //////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////
+	// Tests for constructor
+	//////////////////////////////////////////////////////////////////////////////
 
-  it('constructor, unsupported key type', function() {
-    const template = AeadKeyTemplates.aes128CtrHmacSha256().setTypeUrl(
-        'some_unsupported_type_url');
+	it("constructor, unsupported key type", () => {
+		const template = AeadKeyTemplates.aes128CtrHmacSha256().setTypeUrl(
+			"some_unsupported_type_url"
+		);
 
-    try {
-      new RegistryEciesAeadHkdfDemHelper(template);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedTypeUrl(template.getTypeUrl()));
-    }
-  });
+		try {
+			new RegistryEciesAeadHkdfDemHelper(template);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedTypeUrl(template.getTypeUrl())
+			);
+		}
+	});
 
-  it('constructor, invalid key formats', function() {
-    // Some valid AES-GCM and AES-CTR-HMAC key templates.
-    const templates =
-        [AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes128Gcm()];
-    const invalidKeyFormats = [new Uint8Array(0), new Uint8Array([0, 1, 2])];
+	it("constructor, invalid key formats", () => {
+		// Some valid AES-GCM and AES-CTR-HMAC key templates.
+		const templates = [
+			AeadKeyTemplates.aes128CtrHmacSha256(),
+			AeadKeyTemplates.aes128Gcm(),
+		];
+		const invalidKeyFormats = [
+			new Uint8Array(0),
+			new Uint8Array([0, 1, 2]),
+		];
 
-    // Test that if the value is changed to invalid key format than the DEM
-    // helper throws an exception.
-    for (const template of templates) {
-      for (const invalidKeyFormat of invalidKeyFormats) {
-        template.setValue(invalidKeyFormat);
+		// Test that if the value is changed to invalid key format than the DEM
+		// helper throws an exception.
+		for (const template of templates) {
+			for (const invalidKeyFormat of invalidKeyFormats) {
+				template.setValue(invalidKeyFormat);
 
-        try {
-          new RegistryEciesAeadHkdfDemHelper(template);
-          fail('An exception should be thrown.');
-        } catch (e: any) {
-          expect(e.toString())
-              .toBe(ExceptionText.invalidKeyFormat(template.getTypeUrl()));
-        }
-      }
-    }
-  });
+				try {
+					new RegistryEciesAeadHkdfDemHelper(template);
+					fail("An exception should be thrown.");
+				} catch (e: any) {
+					expect(e.toString()).toBe(
+						ExceptionText.invalidKeyFormat(template.getTypeUrl())
+					);
+				}
+			}
+		}
+	});
 
-  it('constructor, aes128 ctr hmac sha256 key template', function() {
-    const template = AeadKeyTemplates.aes128CtrHmacSha256();
-    const helper = new RegistryEciesAeadHkdfDemHelper(template);
+	it("constructor, aes128 ctr hmac sha256 key template", () => {
+		const template = AeadKeyTemplates.aes128CtrHmacSha256();
+		const helper = new RegistryEciesAeadHkdfDemHelper(template);
 
-    // Expected size is a sum of AES CTR key length and HMAC key length.
-    const expectedSize = 16 + 32;
-    expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
-  });
+		// Expected size is a sum of AES CTR key length and HMAC key length.
+		const expectedSize = 16 + 32;
+		expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
+	});
 
-  it('constructor, aes256 ctr hmac sha256 key template', function() {
-    const template = AeadKeyTemplates.aes256CtrHmacSha256();
-    const helper = new RegistryEciesAeadHkdfDemHelper(template);
+	it("constructor, aes256 ctr hmac sha256 key template", () => {
+		const template = AeadKeyTemplates.aes256CtrHmacSha256();
+		const helper = new RegistryEciesAeadHkdfDemHelper(template);
 
-    // Expected size is a sum of AES CTR key length and HMAC key length.
-    const expectedSize = 32 + 32;
-    expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
-  });
+		// Expected size is a sum of AES CTR key length and HMAC key length.
+		const expectedSize = 32 + 32;
+		expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
+	});
 
-  it('constructor, aes128 gcm', function() {
-    const template = AeadKeyTemplates.aes128Gcm();
-    const helper = new RegistryEciesAeadHkdfDemHelper(template);
+	it("constructor, aes128 gcm", () => {
+		const template = AeadKeyTemplates.aes128Gcm();
+		const helper = new RegistryEciesAeadHkdfDemHelper(template);
 
-    // Expected size is equal to the size of key.
-    const expectedSize = 16;
-    expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
-  });
+		// Expected size is equal to the size of key.
+		const expectedSize = 16;
+		expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
+	});
 
-  it('constructor, aes256 gcm', function() {
-    const template = AeadKeyTemplates.aes256Gcm();
-    const helper = new RegistryEciesAeadHkdfDemHelper(template);
+	it("constructor, aes256 gcm", () => {
+		const template = AeadKeyTemplates.aes256Gcm();
+		const helper = new RegistryEciesAeadHkdfDemHelper(template);
 
-    // Expected size is equal to the size of key.
-    const expectedSize = 32;
-    expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
-  });
+		// Expected size is equal to the size of key.
+		const expectedSize = 32;
+		expect(helper.getDemKeySizeInBytes()).toBe(expectedSize);
+	});
 
-  //////////////////////////////////////////////////////////////////////////////
-  // Tests for getAead method
-  //////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////
+	// Tests for getAead method
+	//////////////////////////////////////////////////////////////////////////////
 
-  it('get aead, invalid key length', async function() {
-    const template = AeadKeyTemplates.aes128CtrHmacSha256();
-    // Expected size is a sum of AES CTR key length and HMAC key length.
-    const expectedKeyLength = 16 + 32;
-    const helper = new RegistryEciesAeadHkdfDemHelper(template);
-    const keyLength = 2;
+	it("get aead, invalid key length", async () => {
+		const template = AeadKeyTemplates.aes128CtrHmacSha256();
+		// Expected size is a sum of AES CTR key length and HMAC key length.
+		const expectedKeyLength = 16 + 32;
+		const helper = new RegistryEciesAeadHkdfDemHelper(template);
+		const keyLength = 2;
 
-    try {
-      await helper.getAead(new Uint8Array(keyLength));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.invalidKeyLength(expectedKeyLength, keyLength));
-    }
-  });
+		try {
+			await helper.getAead(new Uint8Array(keyLength));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidKeyLength(expectedKeyLength, keyLength)
+			);
+		}
+	});
 
-  it('get aead, different templates', async function() {
-    const templates = [
-      AeadKeyTemplates.aes128CtrHmacSha256(), AeadKeyTemplates.aes128Gcm(),
-      AeadKeyTemplates.aes256CtrHmacSha256(), AeadKeyTemplates.aes256Gcm()
-    ];
+	it("get aead, different templates", async () => {
+		const templates = [
+			AeadKeyTemplates.aes128CtrHmacSha256(),
+			AeadKeyTemplates.aes128Gcm(),
+			AeadKeyTemplates.aes256CtrHmacSha256(),
+			AeadKeyTemplates.aes256Gcm(),
+		];
 
-    for (const template of templates) {
-      const helper = new RegistryEciesAeadHkdfDemHelper(template);
-      // Compute some demKey of size corresponding to the template.
-      // The result of getDemKeySizeInBytes is the expected one for the given
-      // templates as it was tested for these templates in previous tests.
-      const demKey = Random.randBytes(helper.getDemKeySizeInBytes());
+		for (const template of templates) {
+			const helper = new RegistryEciesAeadHkdfDemHelper(template);
+			// Compute some demKey of size corresponding to the template.
+			// The result of getDemKeySizeInBytes is the expected one for the given
+			// templates as it was tested for these templates in previous tests.
+			const demKey = Random.randBytes(helper.getDemKeySizeInBytes());
 
-      // Get Aead from helper.
-      const aead = await helper.getAead(demKey);
-      expect(aead != null).toBe(true);
+			// Get Aead from helper.
+			const aead = await helper.getAead(demKey);
+			expect(aead != null).toBe(true);
 
-      // Test the Aead instance.
-      const plaintext = Random.randBytes(10);
-      const aad = Random.randBytes(10);
-      const ciphertext = await aead.encrypt(plaintext, aad);
-      const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
+			// Test the Aead instance.
+			const plaintext = Random.randBytes(10);
+			const aad = Random.randBytes(10);
+			const ciphertext = await aead.encrypt(plaintext, aad);
+			const decryptedCiphertext = await aead.decrypt(ciphertext, aad);
 
-      expect(decryptedCiphertext).toEqual(plaintext);
-    }
-  });
+			expect(decryptedCiphertext).toEqual(plaintext);
+		}
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static unsupportedTypeUrl(typeUrl: string): string {
-    return 'SecurityException: Key type URL ' + typeUrl + ' is not supported.';
-  }
+	static unsupportedTypeUrl(typeUrl: string): string {
+		return (
+			"SecurityException: Key type URL " + typeUrl + " is not supported."
+		);
+	}
 
-  static invalidKeyFormat(keyType: string): string {
-    return 'SecurityException: Could not parse the given Uint8Array as ' +
-        'a serialized proto of ' + keyType + '.';
-  }
+	static invalidKeyFormat(keyType: string): string {
+		return (
+			"SecurityException: Could not parse the given Uint8Array as " +
+			"a serialized proto of " +
+			keyType +
+			"."
+		);
+	}
 
-  static invalidKeyLength(expectedKeyLength: number, actualKeyLength: number):
-      string {
-    return 'SecurityException: Key is not of the correct length, expected length: ' +
-        expectedKeyLength + ', but got key of length: ' + actualKeyLength + '.';
-  }
+	static invalidKeyLength(
+		expectedKeyLength: number,
+		actualKeyLength: number
+	): string {
+		return (
+			"SecurityException: Key is not of the correct length, expected length: " +
+			expectedKeyLength +
+			", but got key of length: " +
+			actualKeyLength +
+			"."
+		);
+	}
 }

--- a/javascript/internal/binary_keyset_reader_test.ts
+++ b/javascript/internal/binary_keyset_reader_test.ts
@@ -4,71 +4,82 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Random from '../subtle/random';
-import {assertMessageEquals} from '../testing/internal/test_utils';
+import * as Random from "../subtle/random";
+import { assertMessageEquals } from "../testing/internal/test_utils";
 
-import {BinaryKeysetReader} from './binary_keyset_reader';
-import {PbKeyData, PbKeyset, PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from './proto';
+import { BinaryKeysetReader } from "./binary_keyset_reader";
+import {
+	PbKeyData,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "./proto";
 
-describe('binary keyset reader test', function() {
-  it('read, invalid serialized keyset proto', function() {
-    for (let i = 0; i < 2; i++) {
-      // The Uint8Array is not a serialized keyset.
-      const reader = BinaryKeysetReader.withUint8Array(new Uint8Array(i));
+describe("binary keyset reader test", () => {
+	it("read, invalid serialized keyset proto", () => {
+		for (let i = 0; i < 2; i++) {
+			// The Uint8Array is not a serialized keyset.
+			const reader = BinaryKeysetReader.withUint8Array(new Uint8Array(i));
 
-      try {
-        reader.read();
-        fail('An exception should be thrown.');
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerialization());
-      }
-    }
-  });
+			try {
+				reader.read();
+				fail("An exception should be thrown.");
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.invalidSerialization());
+			}
+		}
+	});
 
-  it('read', function() {
-    // Create keyset proto and serialize it.
-    const keyset = new PbKeyset();
-    // The for cycle starts from 1 as setting any proto value to 0 sets it to
-    // null and after serialization and deserialization null is changed to
-    // undefined and the assertion at the end fails (unless you compare the
-    // keyset and newly created keyset value by value).
-    for (let i = 1; i < 20; i++) {
-      let outputPrefix;
-      switch (i % 3) {
-        case 0:
-          outputPrefix = PbOutputPrefixType.TINK;
-          break;
-        case 1:
-          outputPrefix = PbOutputPrefixType.RAW;
-          break;
-        default:
-          outputPrefix = PbOutputPrefixType.LEGACY;
-      }
-      keyset.addKey(createDummyKeysetKey(
-          /* keyId = */ i, outputPrefix, /* enabled = */ i % 4 < 3));
-    }
-    keyset.setPrimaryKeyId(1);
+	it("read", () => {
+		// Create keyset proto and serialize it.
+		const keyset = new PbKeyset();
+		// The for cycle starts from 1 as setting any proto value to 0 sets it to
+		// null and after serialization and deserialization null is changed to
+		// undefined and the assertion at the end fails (unless you compare the
+		// keyset and newly created keyset value by value).
+		for (let i = 1; i < 20; i++) {
+			let outputPrefix;
+			switch (i % 3) {
+				case 0:
+					outputPrefix = PbOutputPrefixType.TINK;
+					break;
+				case 1:
+					outputPrefix = PbOutputPrefixType.RAW;
+					break;
+				default:
+					outputPrefix = PbOutputPrefixType.LEGACY;
+			}
+			keyset.addKey(
+				createDummyKeysetKey(
+					/* keyId = */ i,
+					outputPrefix,
+					/* enabled = */ i % 4 < 3
+				)
+			);
+		}
+		keyset.setPrimaryKeyId(1);
 
-    const serializedKeyset = keyset.serializeBinary();
+		const serializedKeyset = keyset.serializeBinary();
 
-    // Read the keyset proto serialization.
-    const reader = BinaryKeysetReader.withUint8Array(serializedKeyset);
-    const keysetFromReader = reader.read();
+		// Read the keyset proto serialization.
+		const reader = BinaryKeysetReader.withUint8Array(serializedKeyset);
+		const keysetFromReader = reader.read();
 
-    // Test that it returns the same object as was created.
-    assertMessageEquals(keysetFromReader, keyset);
-  });
+		// Test that it returns the same object as was created.
+		assertMessageEquals(keysetFromReader, keyset);
+	});
 
-  it('read encrypted, not implemented yet', function() {
-    const reader = BinaryKeysetReader.withUint8Array(new Uint8Array(10));
+	it("read encrypted, not implemented yet", () => {
+		const reader = BinaryKeysetReader.withUint8Array(new Uint8Array(10));
 
-    try {
-      reader.readEncrypted();
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notImplemented());
-    }
-  });
+		try {
+			reader.readEncrypted();
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.notImplemented());
+		}
+	});
 });
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,39 +91,43 @@ describe('binary keyset reader test', function() {
  * @final
  */
 class ExceptionText {
-  static notImplemented(): string {
-    return 'SecurityException: Not implemented yet.';
-  }
+	static notImplemented(): string {
+		return "SecurityException: Not implemented yet.";
+	}
 
-  static nullKeyset(): string {
-    return 'SecurityException: Serialized keyset has to be non-null.';
-  }
+	static nullKeyset(): string {
+		return "SecurityException: Serialized keyset has to be non-null.";
+	}
 
-  static invalidSerialization(): string {
-    return 'SecurityException: Could not parse the given serialized proto as ' +
-        'a keyset proto.';
-  }
+	static invalidSerialization(): string {
+		return (
+			"SecurityException: Could not parse the given serialized proto as " +
+			"a keyset proto."
+		);
+	}
 }
 
 /** Function for creating keys for testing purposes. */
 function createDummyKeysetKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  // Set some key data.
-  key.setKeyData(new PbKeyData());
-  key.getKeyData()?.setTypeUrl('SOME_KEY_TYPE_URL_' + keyId.toString());
-  key.getKeyData()?.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
-  key.getKeyData()?.setValue(Random.randBytes(10));
+	// Set some key data.
+	key.setKeyData(new PbKeyData());
+	key.getKeyData()?.setTypeUrl("SOME_KEY_TYPE_URL_" + keyId.toString());
+	key.getKeyData()?.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
+	key.getKeyData()?.setValue(Random.randBytes(10));
 
-  return key;
+	return key;
 }

--- a/javascript/internal/binary_keyset_writer_test.ts
+++ b/javascript/internal/binary_keyset_writer_test.ts
@@ -4,24 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {assertMessageEquals, createKeyset} from '../testing/internal/test_utils';
+import {
+	assertMessageEquals,
+	createKeyset,
+} from "../testing/internal/test_utils";
 
-import {BinaryKeysetReader} from './binary_keyset_reader';
-import {BinaryKeysetWriter} from './binary_keyset_writer';
+import { BinaryKeysetReader } from "./binary_keyset_reader";
+import { BinaryKeysetWriter } from "./binary_keyset_writer";
 
-describe('binary keyset writer test', function() {
-  it('get serialized key set', function() {
-    const dummyKeyset = createKeyset();
+describe("binary keyset writer test", () => {
+	it("get serialized key set", () => {
+		const dummyKeyset = createKeyset();
 
-    // Write the keyset.
-    const writer = new BinaryKeysetWriter();
-    const serializedKeyset = writer.encodeBinary(dummyKeyset);
+		// Write the keyset.
+		const writer = new BinaryKeysetWriter();
+		const serializedKeyset = writer.encodeBinary(dummyKeyset);
 
-    // Read the keyset proto serialization.
-    const reader = BinaryKeysetReader.withUint8Array(serializedKeyset);
-    const keysetFromReader = reader.read();
+		// Read the keyset proto serialization.
+		const reader = BinaryKeysetReader.withUint8Array(serializedKeyset);
+		const keysetFromReader = reader.read();
 
-    // Test that it returns the same object as was created.
-    assertMessageEquals(keysetFromReader, dummyKeyset);
-  });
+		// Test that it returns the same object as was created.
+		assertMessageEquals(keysetFromReader, dummyKeyset);
+	});
 });

--- a/javascript/internal/cleartext_keyset_handle_test.ts
+++ b/javascript/internal/cleartext_keyset_handle_test.ts
@@ -4,26 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {createKeyset} from '../testing/internal/test_utils';
+import { createKeyset } from "../testing/internal/test_utils";
 
-import {CleartextKeysetHandle} from './cleartext_keyset_handle';
-import {KeysetHandle} from './keyset_handle';
+import { CleartextKeysetHandle } from "./cleartext_keyset_handle";
+import { KeysetHandle } from "./keyset_handle";
 
-describe('cleartext keyset handle test', function() {
-  it('deserialize from binary', function() {
-    const keyset1 = createKeyset();
-    const keysetHandle =
-        CleartextKeysetHandle.deserializeFromBinary(keyset1.serializeBinary());
-    const keyset2 = keysetHandle.getKeyset();
-    expect(keyset2.getPrimaryKeyId()).toBe(keyset1.getPrimaryKeyId());
-    expect(keyset2.getKeyList()).toEqual(keyset2.getKeyList());
-  });
+describe("cleartext keyset handle test", () => {
+	it("deserialize from binary", () => {
+		const keyset1 = createKeyset();
+		const keysetHandle = CleartextKeysetHandle.deserializeFromBinary(
+			keyset1.serializeBinary()
+		);
+		const keyset2 = keysetHandle.getKeyset();
+		expect(keyset2.getPrimaryKeyId()).toBe(keyset1.getPrimaryKeyId());
+		expect(keyset2.getKeyList()).toEqual(keyset2.getKeyList());
+	});
 
-  it('serialize to binary', function() {
-    const keyset = createKeyset();
-    const keysetHandle = new KeysetHandle(keyset);
+	it("serialize to binary", () => {
+		const keyset = createKeyset();
+		const keysetHandle = new KeysetHandle(keyset);
 
-    const keysetBinary = CleartextKeysetHandle.serializeToBinary(keysetHandle);
-    expect(keyset.serializeBinary()).toEqual(keysetBinary);
-  });
+		const keysetBinary =
+			CleartextKeysetHandle.serializeToBinary(keysetHandle);
+		expect(keyset.serializeBinary()).toEqual(keysetBinary);
+	});
 });

--- a/javascript/internal/crypto_format_test.ts
+++ b/javascript/internal/crypto_format_test.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {CryptoFormat} from './crypto_format';
-import {PbKeysetKey as PbKeysetKey, PbOutputPrefixType} from './proto';
+import {CryptoFormat} from "./crypto_format";
+import {PbKeysetKey as PbKeysetKey, PbOutputPrefixType} from "./proto";
 
-describe('crypto format test', function() {
-  it('constants', async function() {
+describe("crypto format test", () => {
+  it("constants", async () => {
     expect(CryptoFormat.RAW_PREFIX_SIZE).toBe(0);
     expect(CryptoFormat.NON_RAW_PREFIX_SIZE).toBe(5);
     expect(CryptoFormat.LEGACY_PREFIX_SIZE).toBe(5);
@@ -18,7 +18,7 @@ describe('crypto format test', function() {
     expect(CryptoFormat.TINK_START_BYTE).toBe(0x01);
   });
 
-  it('get output prefix unknown prefix type', async function() {
+  it("get output prefix unknown prefix type", async () => {
     let key = new PbKeysetKey()
                   .setOutputPrefixType(PbOutputPrefixType.UNKNOWN_PREFIX)
                   .setKeyId(2864434397);
@@ -27,13 +27,13 @@ describe('crypto format test', function() {
       CryptoFormat.getOutputPrefix(key);
     } catch (e: any) {
       expect(e.toString())
-          .toBe('SecurityException: Unsupported key prefix type.');
+          .toBe("SecurityException: Unsupported key prefix type.");
       return;
     }
-    fail('An exception should be thrown.');
+    fail("An exception should be thrown.");
   });
 
-  it('get output prefix invalid key id', async function() {
+  it("get output prefix invalid key id", async () => {
     // Key id has to be an unsigned 32-bit integer.
     const invalidKeyIds = [0.2, -10, 2**32];
     let key = new PbKeysetKey().setOutputPrefixType(PbOutputPrefixType.TINK);
@@ -46,14 +46,14 @@ describe('crypto format test', function() {
       } catch (e: any) {
         expect(e.toString())
             .toBe(
-                'InvalidArgumentsException: Number has to be unsigned 32-bit integer.');
+                "InvalidArgumentsException: Number has to be unsigned 32-bit integer.");
         continue;
       }
-      fail('An exception should be thrown for i: ' + i + '.');
+      fail("An exception should be thrown for i: " + i + ".");
     }
   });
 
-  it('get output prefix tink', async function() {
+  it("get output prefix tink", async () => {
     const key = new PbKeysetKey()
                     .setOutputPrefixType(PbOutputPrefixType.TINK)
                     .setKeyId(2864434397);
@@ -64,7 +64,7 @@ describe('crypto format test', function() {
     expect(actualResult).toEqual(expectedResult);
   });
 
-  it('get output prefix legacy', async function() {
+  it("get output prefix legacy", async () => {
     const key = new PbKeysetKey()
                     .setOutputPrefixType(PbOutputPrefixType.LEGACY)
                     .setKeyId(16909060);
@@ -75,7 +75,7 @@ describe('crypto format test', function() {
     expect(actualResult).toEqual(expectedResult);
   });
 
-  it('get output prefix raw', async function() {
+  it("get output prefix raw", async () => {
     const key = new PbKeysetKey()
                     .setOutputPrefixType(PbOutputPrefixType.RAW)
                     .setKeyId(370491921);

--- a/javascript/internal/keyset_handle_test.ts
+++ b/javascript/internal/keyset_handle_test.ts
@@ -4,623 +4,757 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Aead} from '../aead';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {SecurityException} from '../exception/security_exception';
-import {HybridDecrypt, HybridEncrypt} from '../hybrid';
-import * as HybridConfig from '../hybrid/hybrid_config';
-import {HybridKeyTemplates} from '../hybrid/hybrid_key_templates';
-import {Mac} from '../mac';
-import * as Bytes from '../subtle/bytes';
-import * as Random from '../subtle/random';
-import {assertExists, assertMessageEquals, createKeyset} from '../testing/internal/test_utils';
-
-import {BinaryKeysetReader} from './binary_keyset_reader';
-import {BinaryKeysetWriter} from './binary_keyset_writer';
-import {CleartextKeysetHandle} from './cleartext_keyset_handle';
-import {KeyFactory, KeyManager} from './key_manager';
-import {generateNew, KeysetHandle, read, readNoSecret} from './keyset_handle';
-import {PbKeyData, PbKeyMaterialType, PbKeyset, PbKeysetKey, PbKeyStatusType, PbMessage, PbOutputPrefixType} from './proto';
-import * as Registry from './registry';
-import {Constructor} from './util';
-
-describe('KeysetHandle', () => {
-  beforeEach(() => {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-
-    HybridConfig.register();
-  });
-
-  afterEach(() => {
-    Registry.reset();
-
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
-
-  describe('constructor', () => {
-    it('throws with empty list of keys', async () => {
-      const keyset = new PbKeyset().setKeyList([]);
-      expect(() => new KeysetHandle(keyset))
-          .toThrowError(
-              SecurityException,
-              'Keyset should be non null and must contain at least one key.');
-    });
-
-    it('does not throw for valid keyset protos', async () => {
-      const keyset = createKeyset();
-      expect(() => new KeysetHandle(keyset)).not.toThrow();
-    });
-  });
-
-  describe('getKeyset', () => {
-    it('returns the underlying keyset proto', async () => {
-      const keyset = createKeyset();
-      const keysetHandle = new KeysetHandle(keyset);
-
-      const result = keysetHandle.getKeyset();
-      expect(result).toEqual(keyset);
-    });
-  });
-
-  describe('read', () => {
-    it('is not yet implemented', async () => {
-      const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-      const keysetHandle = await generateNew(keyTemplate);
-      const serializedKeyset =
-          CleartextKeysetHandle.serializeToBinary(keysetHandle);
-      const keysetReader = new BinaryKeysetReader(serializedKeyset);
-      const aead = await keysetHandle.getPrimitive<Aead>(Aead);
-
-      await expectAsync(read(keysetReader, aead))
-          .toBeRejectedWithError(
-              SecurityException, 'KeysetHandle -- read: Not implemented yet.');
-    });
-  });
-
-  describe('generateNew', () => {
-    it('generates new keyset handles given a key template', async () => {
-      const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
-      const keysetHandle = await generateNew(keyTemplate);
-      const keyset = keysetHandle.getKeyset();
-      expect(1).toBe(keyset.getKeyList().length);
-
-      const key = keyset.getKeyList()[0];
-      expect(keyset.getPrimaryKeyId()).toBe(key.getKeyId());
-      expect(keyTemplate.getOutputPrefixType()).toBe(key.getOutputPrefixType());
-      expect(PbKeyStatusType.ENABLED).toBe(key.getStatus());
-
-      const keyData = assertExists(key.getKeyData());
-      expect(keyTemplate.getTypeUrl()).toBe(keyData.getTypeUrl());
-
-      const aead = await keysetHandle.getPrimitive(Aead);
-      const plaintext = Random.randBytes(20);
-      const ciphertext = await aead.encrypt(plaintext);
-      expect(await aead.decrypt(ciphertext)).toEqual(plaintext);
-    });
-  });
-
-  describe('write', () => {
-    it('is not yet implemented', async () => {
-      const keyset = createKeysetAndInitializeRegistry(Aead);
-      const keysetHandle = new KeysetHandle(keyset);
-      const keysetWriter = new BinaryKeysetWriter();
-      const aead = await keysetHandle.getPrimitive<Aead>(Aead);
-
-      await expectAsync(keysetHandle.write(keysetWriter, aead))
-          .toBeRejectedWithError(
-              SecurityException, 'KeysetHandle -- write: Not implemented yet.');
-    });
-  });
-
-  describe('getPrimitive', () => {
-    it('aead', async () => {
-      const keyset = createKeysetAndInitializeRegistry(Aead);
-      const keysetHandle = new KeysetHandle(keyset);
-
-      const aead = await keysetHandle.getPrimitive<Aead>(Aead);
-
-      // Test the aead primitive returned by getPrimitive method.
-      const plaintext = new Uint8Array([1, 2, 3, 4, 5, 6]);
-      const ciphertext = await aead.encrypt(plaintext);
-      const decryptedText = await aead.decrypt(ciphertext);
-
-      expect(decryptedText).toEqual(plaintext);
-    });
-
-    it('hybrid encrypt', async () => {
-      const keyset = createKeysetAndInitializeRegistry(HybridEncrypt);
-      const keysetHandle = new KeysetHandle(keyset);
-
-      // Test the HybridEncrypt primitive returned by getPrimitive method.
-      const hybridEncrypt =
-          await keysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await hybridEncrypt.encrypt(plaintext);
-
-      // DummyHybridEncrypt just appends a ciphertext suffix to the plaintext.
-      // Since the primary key id is 1, the ciphertext prefix should also be 1.
-      expect(ciphertext)
-          .toEqual(Bytes.concat(
-              new Uint8Array([
-                0, 0, 0, 0, 1
-              ]) /* prefix which is 1-byte version + 4-byte primary key id*/,
-              plaintext,
-              new Uint8Array([1]) /* suffix which is 1-byte primary key id */));
-    });
-
-    it('hybrid decrypt', async () => {
-      const decryptKeysetHandle =
-          new KeysetHandle(createKeysetAndInitializeRegistry(HybridDecrypt));
-      const hybridDecrypt =
-          await decryptKeysetHandle.getPrimitive<HybridDecrypt>(HybridDecrypt);
-
-      const encryptKeysetHandle =
-          new KeysetHandle(createKeysetAndInitializeRegistry(HybridEncrypt));
-      const hybridEncrypt =
-          await encryptKeysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
-
-      const plaintext = Random.randBytes(10);
-      const ciphertext = await hybridEncrypt.encrypt(plaintext);
-      const decrypted = await hybridDecrypt.decrypt(ciphertext);
-
-      expect(decrypted).toEqual(plaintext);
-    });
-
-    it('aead, custom key manager', async () => {
-      const keyset = new PbKeyset();
-
-      // Add a new key with a new key type associated to custom key manager
-      // to the keyset.
-      const keyTypeUrl = 'new_custom_aead_key_type';
-      const keyId = 0xFFFFFFFF;
-      const key =
-          createKey({keyId, outputPrefix: PbOutputPrefixType.TINK, keyTypeUrl});
-      keyset.addKey(key);
-      keyset.setPrimaryKeyId(keyId);
-      const keysetHandle = new KeysetHandle(keyset);
-
-      // Create a custom key manager.
-      const customKeyManager = new DummyKeyManager(
-          keyTypeUrl, new DummyAead(Random.randBytes(10)), Aead);
-
-      // Encrypt with the primitive returned by customKeyManager.
-      const aead =
-          await keysetHandle.getPrimitive<Aead>(Aead, customKeyManager);
-      const plaintext = Random.randBytes(20);
-      const ciphertext = await aead.encrypt(plaintext);
-
-      // Register another key manager with the custom key type.
-      const managerInRegistry = new DummyKeyManager(
-          keyTypeUrl, new DummyAead(Random.randBytes(10)), Aead);
-      Registry.registerKeyManager(managerInRegistry);
-
-      // Check that the primitive returned by getPrimitive cannot decrypt the
-      // ciphertext. This is because managerInRegistry is different from
-      // customKeyManager.
-      const aeadFromRegistry = await keysetHandle.getPrimitive<Aead>(Aead);
-
-      await expectAsync(aeadFromRegistry.decrypt(ciphertext))
-          .toBeRejectedWithError(
-              SecurityException, 'Decryption failed for the given ciphertext.');
-
-      // Check that the primitive returned by getPrimitive with customKeyManager
-      // decrypts correctly.
-      const aeadFromCustomKeyManager =
-          await keysetHandle.getPrimitive<Aead>(Aead, customKeyManager);
-      const decryptedText = await aeadFromCustomKeyManager.decrypt(ciphertext);
-      expect(decryptedText).toEqual(plaintext);
-    });
-
-    it('hybrid encrypt, custom key manager', async () => {
-      const keyset = new PbKeyset();
-
-      // Add a new key with a new key type associated to custom key manager
-      // to the keyset.
-      const keyTypeUrl = 'new_custom_hybrid_encrypt_key_type';
-      const keyId = 0xFFFFFFFF;
-      const key =
-          createKey({keyId, outputPrefix: PbOutputPrefixType.TINK, keyTypeUrl});
-      keyset.addKey(key);
-      keyset.setPrimaryKeyId(keyId);
-      const keysetHandle = new KeysetHandle(keyset);
-
-      // Create a custom key manager.
-      const customKeyManager = new DummyKeyManager(
-          keyTypeUrl, new DummyHybridEncrypt(Random.randBytes(10)),
-          HybridEncrypt);
-
-      // Encrypt with the primitive returned by customKeyManager.
-      const customHybridEncrypt =
-          await keysetHandle.getPrimitive<HybridEncrypt>(
-              HybridEncrypt, customKeyManager);
-      const plaintext = Random.randBytes(20);
-      const ciphertext = await customHybridEncrypt.encrypt(plaintext);
-
-      // Register another key manager with the custom key type.
-      const managerInRegistry = new DummyKeyManager(
-          keyTypeUrl, new DummyHybridEncrypt(Random.randBytes(10)),
-          HybridEncrypt);
-      Registry.registerKeyManager(managerInRegistry);
-
-      // Check that the primitive returned by getPrimitive is not the same as
-      // customHybridEncrypt. This is because managerInRegistry is different
-      // from customKeyManager.
-      const hybridFromRegistry =
-          await keysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
-      const ciphertext2 = await hybridFromRegistry.encrypt(plaintext);
-      expect(ciphertext2).not.toEqual(ciphertext);
-
-      // Check that the primitive returned by getPrimitive with customKeyManager
-      // is the same as customHybridEncrypt.
-      const hybridEncryptFromCustomKeyManager =
-          await keysetHandle.getPrimitive<HybridEncrypt>(
-              HybridEncrypt, customKeyManager);
-      const ciphertext3 =
-          await hybridEncryptFromCustomKeyManager.encrypt(plaintext);
-      expect(ciphertext3).toEqual(ciphertext);
-    });
-
-    it('hybrid decrypt, custom key manager', async () => {
-      // Both private and public keys have the same key id.
-      const keyId = 0xFFFFFFFF;
-
-      // Create a public keyset.
-
-      const publicKeyset = new PbKeyset();
-      // Add a new key with a new key type associated to custom key manager
-      // to the keyset.
-      const publicKeyTypeUrl = 'new_custom_hybrid_encrypt_key_type';
-      const publicKey = createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.TINK,
-        keyTypeUrl: publicKeyTypeUrl
-      });
-      publicKeyset.addKey(publicKey);
-      publicKeyset.setPrimaryKeyId(keyId);
-      const publicKeysetHandle = new KeysetHandle(publicKeyset);
-
-      // Create a corresponding private keyset.
-
-      const privateKeyset = new PbKeyset();
-      // Add a new key with a new key type associated to custom key manager
-      // to the keyset.
-      const privateKeyTypeUrl = 'new_custom_hybrid_decrypt_key_type';
-      const privateKey = createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.TINK,
-        keyTypeUrl: privateKeyTypeUrl
-      });
-      privateKeyset.addKey(privateKey);
-      privateKeyset.setPrimaryKeyId(keyId);
-      const privateKeysetHandle = new KeysetHandle(privateKeyset);
-
-      // DummyHybridEncrypt (and DummyHybridDecrypt) just appends (and removes)
-      // a suffix to the plaintext. Create a random suffix that allows to
-      // determine which HybridDecrypt object is valid.
-      const ciphertextSuffix = Random.randBytes(10);
-
-      // Register a public key manager that uses the legit ciphertext suffix.
-      const publicKeyManagerInRegistry = new DummyKeyManager(
-          publicKeyTypeUrl, new DummyHybridEncrypt(ciphertextSuffix),
-          HybridEncrypt);
-      Registry.registerKeyManager(publicKeyManagerInRegistry);
-
-      // Encrypt with the primitive returned by getPrimitive.
-      const hybridEncrypt =
-          await publicKeysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
-      const plaintext = Random.randBytes(20);
-      const ciphertext = await hybridEncrypt.encrypt(plaintext);
-
-      // Register a private key manager that uses a random ciphertext suffix.
-      const keyManagerWithRandomSuffix = new DummyKeyManager(
-          privateKeyTypeUrl, new DummyHybridDecrypt(Random.randBytes(10)),
-          HybridDecrypt);
-      Registry.registerKeyManager(keyManagerWithRandomSuffix);
-
-      // Check that the primitive returned by getPrimitive cannot decrypt. This
-      // is because the ciphertext suffix is different.
-      const hybridDecryptFromRegistry =
-          await privateKeysetHandle.getPrimitive<HybridDecrypt>(HybridDecrypt);
-      await expectAsync(hybridDecryptFromRegistry.decrypt(ciphertext))
-          .toBeRejectedWithError(
-              SecurityException, 'Decryption failed for the given ciphertext.');
-
-      // Create a custom private key manager with the correct ciphertext suffix.
-      const customHybridDecryptKeyManager = new DummyKeyManager(
-          privateKeyTypeUrl, new DummyHybridDecrypt(ciphertextSuffix),
-          HybridDecrypt);
-
-      // Check that the primitive returned by getPrimitive with
-      // customHybridDecryptKeyManager can decrypt.
-      const customHybridDecrypt =
-          await privateKeysetHandle.getPrimitive<HybridDecrypt>(
-              HybridDecrypt, customHybridDecryptKeyManager);
-      const decrypted = await customHybridDecrypt.decrypt(ciphertext);
-      expect(decrypted).toEqual(plaintext);
-    });
-
-    it('keyset contains key corresponding to different primitive', async () => {
-      const keyset = createKeysetAndInitializeRegistry(Aead);
-
-      // Add new key with new key type url to the keyset and register a key
-      // manager providing Mac primitives with this key.
-      const macKeyTypeUrl = 'mac_key_type_1';
-      const macKeyId = 0xFFFFFFFF;
-      const macKey = createKey({
-        keyId: macKeyId,
-        outputPrefix: PbOutputPrefixType.TINK,
-        keyTypeUrl: macKeyTypeUrl
-      });
-      keyset.addKey(macKey);
-      const primitive = new DummyMac(new Uint8Array([0xFF]));
-      Registry.registerKeyManager(
-          new DummyKeyManager(macKeyTypeUrl, primitive, Mac));
-
-      const keysetHandle = new KeysetHandle(keyset);
-
-      await expectAsync(keysetHandle.getPrimitive<Aead>(Aead))
-          .toBeRejectedWithError(
-              SecurityException,
-              'Requested primitive type which is not supported by ' +
-                  'this key manager.');
-    });
-  });
-
-  describe('getPrimitiveSet', () => {
-    it('primary key is the enabled key with given id', async () => {
-      const keyId = 1;
-      const primaryUrl = 'key_type_url_for_primary_key';
-      const disabledUrl = 'key_type_url_for_disabled_key';
-
-      const keyset = new PbKeyset();
-      keyset.addKey(createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.TINK,
-        keyTypeUrl: disabledUrl,
-        enabled: false
-      }));
-      keyset.addKey(createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.LEGACY,
-        keyTypeUrl: disabledUrl,
-        enabled: false
-      }));
-      keyset.addKey(createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.RAW,
-        keyTypeUrl: disabledUrl,
-        enabled: false
-      }));
-      keyset.addKey(createKey({
-        keyId,
-        outputPrefix: PbOutputPrefixType.TINK,
-        keyTypeUrl: primaryUrl,
-        enabled: true
-      }));
-      keyset.setPrimaryKeyId(keyId);
-
-      const keysetHandle = new KeysetHandle(keyset);
-
-      const primitive = new DummyAead(new Uint8Array(Random.randBytes(10)));
-      Registry.registerKeyManager(
-          new DummyKeyManager(primaryUrl, primitive, Aead));
-      Registry.registerKeyManager(new DummyKeyManager(
-          disabledUrl, new DummyAead(new Uint8Array(Random.randBytes(10))),
-          Aead));
-
-      const primitiveSet = await keysetHandle.getPrimitiveSet(Aead);
-      const primary = assertExists(primitiveSet.getPrimary());
-      expect(primary.getPrimitive()).toBe(primitive);
-    });
-
-    it('disabled keys should be ignored', async () => {
-      const enabledRawKeysCount = 10;
-      const enabledUrl = 'enabled_key_type_url';
-      const disabledUrl = 'disabled_key_type_url';
-
-      // Create keyset with both enabled and disabled RAW keys.
-      const keyset = new PbKeyset();
-      // Add RAW keys with different ids from [1, ENABLED_RAW_KEYS_COUNT].
-      for (let i = 0; i < enabledRawKeysCount; i++) {
-        keyset.addKey(createKey({
-          keyId: 1 + i,
-          outputPrefix: PbOutputPrefixType.RAW,
-          keyTypeUrl: enabledUrl,
-          enabled: true
-        }));
-        keyset.addKey(createKey({
-          keyId: 1 + i,
-          outputPrefix: PbOutputPrefixType.RAW,
-          keyTypeUrl: disabledUrl,
-          enabled: false
-        }));
-      }
-      keyset.setPrimaryKeyId(1);
-      const keysetHandle = new KeysetHandle(keyset);
-
-      // Register KeyManager (the key manager for enabled keys should be
-      // enough).
-      const primitive = new DummyAead(new Uint8Array(Random.randBytes(10)));
-      Registry.registerKeyManager(
-          new DummyKeyManager(enabledUrl, primitive, Aead));
-
-      // Get primitives and get all raw primitives.
-      const primitiveSet = await keysetHandle.getPrimitiveSet(Aead);
-      const rawPrimitives = primitiveSet.getRawPrimitives();
-
-      // Should return all enabled RAW primitives and nothing else (disabled
-      // primitives should not be added into primitive set).
-      expect(rawPrimitives.length).toBe(enabledRawKeysCount);
-
-      // Test that it returns the correct RAW primitives by using getPrimitive.
-      for (let i = 0; i < enabledRawKeysCount; ++i) {
-        expect(rawPrimitives[i].getPrimitive()).toBe(primitive);
-      }
-    });
-
-    it('with custom key manager', async () => {
-      // Create keyset handle.
-      const keyTypeUrl = 'some_key_type_url';
-      const keyId = 1;
-      const key =
-          createKey({keyId, outputPrefix: PbOutputPrefixType.TINK, keyTypeUrl});
-
-      const keyset = new PbKeyset();
-      keyset.addKey(key);
-      keyset.setPrimaryKeyId(keyId);
-
-      const keysetHandle = new KeysetHandle(keyset);
-
-      // Register key manager for the given keyType.
-      const primitive = new DummyAead(new Uint8Array(Random.randBytes(10)));
-      Registry.registerKeyManager(
-          new DummyKeyManager(keyTypeUrl, primitive, Aead));
-
-      // Use getPrimitives with custom key manager for the keyType.
-      const customPrimitive =
-          new DummyAead(new Uint8Array(Random.randBytes(10)));
-      const customKeyManager =
-          new DummyKeyManager(keyTypeUrl, customPrimitive, Aead);
-      const primitiveSet =
-          await keysetHandle.getPrimitiveSet(Aead, customKeyManager);
-
-      // Primary should be the entry corresponding to the keyTypeUrl and thus
-      // getPrimitive should return customPrimitive.
-      const primary = assertExists(primitiveSet.getPrimary());
-      expect(primary.getPrimitive()).toBe(customPrimitive);
-    });
-  });
-
-  describe('readNoSecret', () => {
-    it('throws for keysets containing secret key material', () => {
-      const secretKeyMaterialTypes = [
-        PbKeyMaterialType.SYMMETRIC, PbKeyMaterialType.ASYMMETRIC_PRIVATE,
-        PbKeyMaterialType.UNKNOWN_KEYMATERIAL
-      ];
-      for (const secretKeyMaterialType of secretKeyMaterialTypes) {
-        // Create a public keyset.
-        const keyset = new PbKeyset();
-        for (let i = 0; i < 3; i++) {
-          const key = createKey({
-            keyId: i + 1,
-            outputPrefix: PbOutputPrefixType.TINK,
-            keyTypeUrl: 'someType',
-            enabled: (i % 4) < 2,
-            keyMaterialType: PbKeyMaterialType.ASYMMETRIC_PUBLIC,
-          });
-          keyset.addKey(key);
-        }
-        keyset.setPrimaryKeyId(1);
-        const key = createKey({
-          keyId: 0xFFFFFFFF,
-          outputPrefix: PbOutputPrefixType.RAW,
-          keyTypeUrl: 'someType',
-          enabled: true,
-          keyMaterialType: secretKeyMaterialType,
-        });
-        keyset.addKey(key);
-        const reader =
-            BinaryKeysetReader.withUint8Array(keyset.serializeBinary());
-        expect(() => readNoSecret(reader))
-            .toThrowError(
-                SecurityException, 'Keyset contains secret key material.');
-      }
-    });
-
-    it('returns non-secret keysets', () => {
-      // Create a public keyset.
-      const keyset = new PbKeyset();
-      for (let i = 0; i < 3; i++) {
-        const key = createKey({
-          keyId: i + 1,
-          outputPrefix: PbOutputPrefixType.TINK,
-          keyTypeUrl: 'someType',
-          enabled: (i % 4) < 2,
-          keyMaterialType: PbKeyMaterialType.ASYMMETRIC_PUBLIC,
-        });
-        keyset.addKey(key);
-      }
-      keyset.setPrimaryKeyId(1);
-
-      const reader =
-          BinaryKeysetReader.withUint8Array(keyset.serializeBinary());
-      const keysetHandle = readNoSecret(reader);
-
-      assertMessageEquals(keysetHandle.getKeyset(), keyset);
-    });
-  });
-
-  describe('getPublicKeysetHandle', () => {
-    it('can get a public keyset from a private keyset', async () => {
-      const privateHandle = await generateNew(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      expect(() => privateHandle.getPublicKeysetHandle())
-          .not.toThrowError(
-              SecurityException, 'The keyset contains a non-private key');
-    });
-
-    it('can not get a public keyset from another public keyset', async () => {
-      const privateHandle = await generateNew(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      const publicHandle = privateHandle.getPublicKeysetHandle();
-      expect(() => publicHandle.getPublicKeysetHandle())
-          .toThrowError(
-              SecurityException, 'The keyset contains a non-private key');
-    });
-  });
-
-  describe('writeNoSecret', () => {
-    it('throws if the keyset contains secret keys', async () => {
-      const privateHandle = await generateNew(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      expect(() => privateHandle.writeNoSecret(new BinaryKeysetWriter()))
-          .toThrowError(SecurityException);
-    });
-
-    it('writes bytes if the keyset contains no secret keys', async () => {
-      const privateHandle = await generateNew(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      const publicHandle = privateHandle.getPublicKeysetHandle();
-      expect(() => publicHandle.writeNoSecret(new BinaryKeysetWriter()))
-          .not.toThrow();
-    });
-
-    it('can import the keyset using readNoSecret', async () => {
-      const privateHandle = await generateNew(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      const publicHandle = privateHandle.getPublicKeysetHandle();
-      const keysetBytes = publicHandle.writeNoSecret(new BinaryKeysetWriter());
-
-      const importedHandle = readNoSecret(new BinaryKeysetReader(keysetBytes));
-      assertMessageEquals(publicHandle.getKeyset(), importedHandle.getKeyset());
-    });
-  });
+import { Aead } from "../aead";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import { SecurityException } from "../exception/security_exception";
+import { HybridDecrypt, HybridEncrypt } from "../hybrid";
+import * as HybridConfig from "../hybrid/hybrid_config";
+import { HybridKeyTemplates } from "../hybrid/hybrid_key_templates";
+import { Mac } from "../mac";
+import * as Bytes from "../subtle/bytes";
+import * as Random from "../subtle/random";
+import {
+	assertExists,
+	assertMessageEquals,
+	createKeyset,
+} from "../testing/internal/test_utils";
+
+import { BinaryKeysetReader } from "./binary_keyset_reader";
+import { BinaryKeysetWriter } from "./binary_keyset_writer";
+import { CleartextKeysetHandle } from "./cleartext_keyset_handle";
+import { KeyFactory, KeyManager } from "./key_manager";
+import { generateNew, KeysetHandle, read, readNoSecret } from "./keyset_handle";
+import {
+	PbKeyData,
+	PbKeyMaterialType,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbMessage,
+	PbOutputPrefixType,
+} from "./proto";
+import * as Registry from "./registry";
+import { Constructor } from "./util";
+
+describe("KeysetHandle", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+
+		HybridConfig.register();
+	});
+
+	afterEach(() => {
+		Registry.reset();
+
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
+
+	describe("constructor", () => {
+		it("throws with empty list of keys", async () => {
+			const keyset = new PbKeyset().setKeyList([]);
+			expect(() => new KeysetHandle(keyset)).toThrowError(
+				SecurityException,
+				"Keyset should be non null and must contain at least one key."
+			);
+		});
+
+		it("does not throw for valid keyset protos", async () => {
+			const keyset = createKeyset();
+			expect(() => new KeysetHandle(keyset)).not.toThrow();
+		});
+	});
+
+	describe("getKeyset", () => {
+		it("returns the underlying keyset proto", async () => {
+			const keyset = createKeyset();
+			const keysetHandle = new KeysetHandle(keyset);
+
+			const result = keysetHandle.getKeyset();
+			expect(result).toEqual(keyset);
+		});
+	});
+
+	describe("read", () => {
+		it("is not yet implemented", async () => {
+			const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+			const keysetHandle = await generateNew(keyTemplate);
+			const serializedKeyset =
+				CleartextKeysetHandle.serializeToBinary(keysetHandle);
+			const keysetReader = new BinaryKeysetReader(serializedKeyset);
+			const aead = await keysetHandle.getPrimitive<Aead>(Aead);
+
+			await expectAsync(read(keysetReader, aead)).toBeRejectedWithError(
+				SecurityException,
+				"KeysetHandle -- read: Not implemented yet."
+			);
+		});
+	});
+
+	describe("generateNew", () => {
+		it("generates new keyset handles given a key template", async () => {
+			const keyTemplate = AeadKeyTemplates.aes128CtrHmacSha256();
+			const keysetHandle = await generateNew(keyTemplate);
+			const keyset = keysetHandle.getKeyset();
+			expect(1).toBe(keyset.getKeyList().length);
+
+			const key = keyset.getKeyList()[0];
+			expect(keyset.getPrimaryKeyId()).toBe(key.getKeyId());
+			expect(keyTemplate.getOutputPrefixType()).toBe(
+				key.getOutputPrefixType()
+			);
+			expect(PbKeyStatusType.ENABLED).toBe(key.getStatus());
+
+			const keyData = assertExists(key.getKeyData());
+			expect(keyTemplate.getTypeUrl()).toBe(keyData.getTypeUrl());
+
+			const aead = await keysetHandle.getPrimitive(Aead);
+			const plaintext = Random.randBytes(20);
+			const ciphertext = await aead.encrypt(plaintext);
+			expect(await aead.decrypt(ciphertext)).toEqual(plaintext);
+		});
+	});
+
+	describe("write", () => {
+		it("is not yet implemented", async () => {
+			const keyset = createKeysetAndInitializeRegistry(Aead);
+			const keysetHandle = new KeysetHandle(keyset);
+			const keysetWriter = new BinaryKeysetWriter();
+			const aead = await keysetHandle.getPrimitive<Aead>(Aead);
+
+			await expectAsync(
+				keysetHandle.write(keysetWriter, aead)
+			).toBeRejectedWithError(
+				SecurityException,
+				"KeysetHandle -- write: Not implemented yet."
+			);
+		});
+	});
+
+	describe("getPrimitive", () => {
+		it("aead", async () => {
+			const keyset = createKeysetAndInitializeRegistry(Aead);
+			const keysetHandle = new KeysetHandle(keyset);
+
+			const aead = await keysetHandle.getPrimitive<Aead>(Aead);
+
+			// Test the aead primitive returned by getPrimitive method.
+			const plaintext = new Uint8Array([1, 2, 3, 4, 5, 6]);
+			const ciphertext = await aead.encrypt(plaintext);
+			const decryptedText = await aead.decrypt(ciphertext);
+
+			expect(decryptedText).toEqual(plaintext);
+		});
+
+		it("hybrid encrypt", async () => {
+			const keyset = createKeysetAndInitializeRegistry(HybridEncrypt);
+			const keysetHandle = new KeysetHandle(keyset);
+
+			// Test the HybridEncrypt primitive returned by getPrimitive method.
+			const hybridEncrypt =
+				await keysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await hybridEncrypt.encrypt(plaintext);
+
+			// DummyHybridEncrypt just appends a ciphertext suffix to the plaintext.
+			// Since the primary key id is 1, the ciphertext prefix should also be 1.
+			expect(ciphertext).toEqual(
+				Bytes.concat(
+					new Uint8Array([
+						0, 0, 0, 0, 1,
+					]) /* prefix which is 1-byte version + 4-byte primary key id*/,
+					plaintext,
+					new Uint8Array([
+						1,
+					]) /* suffix which is 1-byte primary key id */
+				)
+			);
+		});
+
+		it("hybrid decrypt", async () => {
+			const decryptKeysetHandle = new KeysetHandle(
+				createKeysetAndInitializeRegistry(HybridDecrypt)
+			);
+			const hybridDecrypt =
+				await decryptKeysetHandle.getPrimitive<HybridDecrypt>(
+					HybridDecrypt
+				);
+
+			const encryptKeysetHandle = new KeysetHandle(
+				createKeysetAndInitializeRegistry(HybridEncrypt)
+			);
+			const hybridEncrypt =
+				await encryptKeysetHandle.getPrimitive<HybridEncrypt>(
+					HybridEncrypt
+				);
+
+			const plaintext = Random.randBytes(10);
+			const ciphertext = await hybridEncrypt.encrypt(plaintext);
+			const decrypted = await hybridDecrypt.decrypt(ciphertext);
+
+			expect(decrypted).toEqual(plaintext);
+		});
+
+		it("aead, custom key manager", async () => {
+			const keyset = new PbKeyset();
+
+			// Add a new key with a new key type associated to custom key manager
+			// to the keyset.
+			const keyTypeUrl = "new_custom_aead_key_type";
+			const keyId = 0xffffffff;
+			const key = createKey({
+				keyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl,
+			});
+			keyset.addKey(key);
+			keyset.setPrimaryKeyId(keyId);
+			const keysetHandle = new KeysetHandle(keyset);
+
+			// Create a custom key manager.
+			const customKeyManager = new DummyKeyManager(
+				keyTypeUrl,
+				new DummyAead(Random.randBytes(10)),
+				Aead
+			);
+
+			// Encrypt with the primitive returned by customKeyManager.
+			const aead = await keysetHandle.getPrimitive<Aead>(
+				Aead,
+				customKeyManager
+			);
+			const plaintext = Random.randBytes(20);
+			const ciphertext = await aead.encrypt(plaintext);
+
+			// Register another key manager with the custom key type.
+			const managerInRegistry = new DummyKeyManager(
+				keyTypeUrl,
+				new DummyAead(Random.randBytes(10)),
+				Aead
+			);
+			Registry.registerKeyManager(managerInRegistry);
+
+			// Check that the primitive returned by getPrimitive cannot decrypt the
+			// ciphertext. This is because managerInRegistry is different from
+			// customKeyManager.
+			const aeadFromRegistry = await keysetHandle.getPrimitive<Aead>(
+				Aead
+			);
+
+			await expectAsync(
+				aeadFromRegistry.decrypt(ciphertext)
+			).toBeRejectedWithError(
+				SecurityException,
+				"Decryption failed for the given ciphertext."
+			);
+
+			// Check that the primitive returned by getPrimitive with customKeyManager
+			// decrypts correctly.
+			const aeadFromCustomKeyManager =
+				await keysetHandle.getPrimitive<Aead>(Aead, customKeyManager);
+			const decryptedText = await aeadFromCustomKeyManager.decrypt(
+				ciphertext
+			);
+			expect(decryptedText).toEqual(plaintext);
+		});
+
+		it("hybrid encrypt, custom key manager", async () => {
+			const keyset = new PbKeyset();
+
+			// Add a new key with a new key type associated to custom key manager
+			// to the keyset.
+			const keyTypeUrl = "new_custom_hybrid_encrypt_key_type";
+			const keyId = 0xffffffff;
+			const key = createKey({
+				keyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl,
+			});
+			keyset.addKey(key);
+			keyset.setPrimaryKeyId(keyId);
+			const keysetHandle = new KeysetHandle(keyset);
+
+			// Create a custom key manager.
+			const customKeyManager = new DummyKeyManager(
+				keyTypeUrl,
+				new DummyHybridEncrypt(Random.randBytes(10)),
+				HybridEncrypt
+			);
+
+			// Encrypt with the primitive returned by customKeyManager.
+			const customHybridEncrypt =
+				await keysetHandle.getPrimitive<HybridEncrypt>(
+					HybridEncrypt,
+					customKeyManager
+				);
+			const plaintext = Random.randBytes(20);
+			const ciphertext = await customHybridEncrypt.encrypt(plaintext);
+
+			// Register another key manager with the custom key type.
+			const managerInRegistry = new DummyKeyManager(
+				keyTypeUrl,
+				new DummyHybridEncrypt(Random.randBytes(10)),
+				HybridEncrypt
+			);
+			Registry.registerKeyManager(managerInRegistry);
+
+			// Check that the primitive returned by getPrimitive is not the same as
+			// customHybridEncrypt. This is because managerInRegistry is different
+			// from customKeyManager.
+			const hybridFromRegistry =
+				await keysetHandle.getPrimitive<HybridEncrypt>(HybridEncrypt);
+			const ciphertext2 = await hybridFromRegistry.encrypt(plaintext);
+			expect(ciphertext2).not.toEqual(ciphertext);
+
+			// Check that the primitive returned by getPrimitive with customKeyManager
+			// is the same as customHybridEncrypt.
+			const hybridEncryptFromCustomKeyManager =
+				await keysetHandle.getPrimitive<HybridEncrypt>(
+					HybridEncrypt,
+					customKeyManager
+				);
+			const ciphertext3 = await hybridEncryptFromCustomKeyManager.encrypt(
+				plaintext
+			);
+			expect(ciphertext3).toEqual(ciphertext);
+		});
+
+		it("hybrid decrypt, custom key manager", async () => {
+			// Both private and public keys have the same key id.
+			const keyId = 0xffffffff;
+
+			// Create a public keyset.
+
+			const publicKeyset = new PbKeyset();
+			// Add a new key with a new key type associated to custom key manager
+			// to the keyset.
+			const publicKeyTypeUrl = "new_custom_hybrid_encrypt_key_type";
+			const publicKey = createKey({
+				keyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl: publicKeyTypeUrl,
+			});
+			publicKeyset.addKey(publicKey);
+			publicKeyset.setPrimaryKeyId(keyId);
+			const publicKeysetHandle = new KeysetHandle(publicKeyset);
+
+			// Create a corresponding private keyset.
+
+			const privateKeyset = new PbKeyset();
+			// Add a new key with a new key type associated to custom key manager
+			// to the keyset.
+			const privateKeyTypeUrl = "new_custom_hybrid_decrypt_key_type";
+			const privateKey = createKey({
+				keyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl: privateKeyTypeUrl,
+			});
+			privateKeyset.addKey(privateKey);
+			privateKeyset.setPrimaryKeyId(keyId);
+			const privateKeysetHandle = new KeysetHandle(privateKeyset);
+
+			// DummyHybridEncrypt (and DummyHybridDecrypt) just appends (and removes)
+			// a suffix to the plaintext. Create a random suffix that allows to
+			// determine which HybridDecrypt object is valid.
+			const ciphertextSuffix = Random.randBytes(10);
+
+			// Register a public key manager that uses the legit ciphertext suffix.
+			const publicKeyManagerInRegistry = new DummyKeyManager(
+				publicKeyTypeUrl,
+				new DummyHybridEncrypt(ciphertextSuffix),
+				HybridEncrypt
+			);
+			Registry.registerKeyManager(publicKeyManagerInRegistry);
+
+			// Encrypt with the primitive returned by getPrimitive.
+			const hybridEncrypt =
+				await publicKeysetHandle.getPrimitive<HybridEncrypt>(
+					HybridEncrypt
+				);
+			const plaintext = Random.randBytes(20);
+			const ciphertext = await hybridEncrypt.encrypt(plaintext);
+
+			// Register a private key manager that uses a random ciphertext suffix.
+			const keyManagerWithRandomSuffix = new DummyKeyManager(
+				privateKeyTypeUrl,
+				new DummyHybridDecrypt(Random.randBytes(10)),
+				HybridDecrypt
+			);
+			Registry.registerKeyManager(keyManagerWithRandomSuffix);
+
+			// Check that the primitive returned by getPrimitive cannot decrypt. This
+			// is because the ciphertext suffix is different.
+			const hybridDecryptFromRegistry =
+				await privateKeysetHandle.getPrimitive<HybridDecrypt>(
+					HybridDecrypt
+				);
+			await expectAsync(
+				hybridDecryptFromRegistry.decrypt(ciphertext)
+			).toBeRejectedWithError(
+				SecurityException,
+				"Decryption failed for the given ciphertext."
+			);
+
+			// Create a custom private key manager with the correct ciphertext suffix.
+			const customHybridDecryptKeyManager = new DummyKeyManager(
+				privateKeyTypeUrl,
+				new DummyHybridDecrypt(ciphertextSuffix),
+				HybridDecrypt
+			);
+
+			// Check that the primitive returned by getPrimitive with
+			// customHybridDecryptKeyManager can decrypt.
+			const customHybridDecrypt =
+				await privateKeysetHandle.getPrimitive<HybridDecrypt>(
+					HybridDecrypt,
+					customHybridDecryptKeyManager
+				);
+			const decrypted = await customHybridDecrypt.decrypt(ciphertext);
+			expect(decrypted).toEqual(plaintext);
+		});
+
+		it("keyset contains key corresponding to different primitive", async () => {
+			const keyset = createKeysetAndInitializeRegistry(Aead);
+
+			// Add new key with new key type url to the keyset and register a key
+			// manager providing Mac primitives with this key.
+			const macKeyTypeUrl = "mac_key_type_1";
+			const macKeyId = 0xffffffff;
+			const macKey = createKey({
+				keyId: macKeyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl: macKeyTypeUrl,
+			});
+			keyset.addKey(macKey);
+			const primitive = new DummyMac(new Uint8Array([0xff]));
+			Registry.registerKeyManager(
+				new DummyKeyManager(macKeyTypeUrl, primitive, Mac)
+			);
+
+			const keysetHandle = new KeysetHandle(keyset);
+
+			await expectAsync(
+				keysetHandle.getPrimitive<Aead>(Aead)
+			).toBeRejectedWithError(
+				SecurityException,
+				"Requested primitive type which is not supported by " +
+					"this key manager."
+			);
+		});
+	});
+
+	describe("getPrimitiveSet", () => {
+		it("primary key is the enabled key with given id", async () => {
+			const keyId = 1;
+			const primaryUrl = "key_type_url_for_primary_key";
+			const disabledUrl = "key_type_url_for_disabled_key";
+
+			const keyset = new PbKeyset();
+			keyset.addKey(
+				createKey({
+					keyId,
+					outputPrefix: PbOutputPrefixType.TINK,
+					keyTypeUrl: disabledUrl,
+					enabled: false,
+				})
+			);
+			keyset.addKey(
+				createKey({
+					keyId,
+					outputPrefix: PbOutputPrefixType.LEGACY,
+					keyTypeUrl: disabledUrl,
+					enabled: false,
+				})
+			);
+			keyset.addKey(
+				createKey({
+					keyId,
+					outputPrefix: PbOutputPrefixType.RAW,
+					keyTypeUrl: disabledUrl,
+					enabled: false,
+				})
+			);
+			keyset.addKey(
+				createKey({
+					keyId,
+					outputPrefix: PbOutputPrefixType.TINK,
+					keyTypeUrl: primaryUrl,
+					enabled: true,
+				})
+			);
+			keyset.setPrimaryKeyId(keyId);
+
+			const keysetHandle = new KeysetHandle(keyset);
+
+			const primitive = new DummyAead(
+				new Uint8Array(Random.randBytes(10))
+			);
+			Registry.registerKeyManager(
+				new DummyKeyManager(primaryUrl, primitive, Aead)
+			);
+			Registry.registerKeyManager(
+				new DummyKeyManager(
+					disabledUrl,
+					new DummyAead(new Uint8Array(Random.randBytes(10))),
+					Aead
+				)
+			);
+
+			const primitiveSet = await keysetHandle.getPrimitiveSet(Aead);
+			const primary = assertExists(primitiveSet.getPrimary());
+			expect(primary.getPrimitive()).toBe(primitive);
+		});
+
+		it("disabled keys should be ignored", async () => {
+			const enabledRawKeysCount = 10;
+			const enabledUrl = "enabled_key_type_url";
+			const disabledUrl = "disabled_key_type_url";
+
+			// Create keyset with both enabled and disabled RAW keys.
+			const keyset = new PbKeyset();
+			// Add RAW keys with different ids from [1, ENABLED_RAW_KEYS_COUNT].
+			for (let i = 0; i < enabledRawKeysCount; i++) {
+				keyset.addKey(
+					createKey({
+						keyId: 1 + i,
+						outputPrefix: PbOutputPrefixType.RAW,
+						keyTypeUrl: enabledUrl,
+						enabled: true,
+					})
+				);
+				keyset.addKey(
+					createKey({
+						keyId: 1 + i,
+						outputPrefix: PbOutputPrefixType.RAW,
+						keyTypeUrl: disabledUrl,
+						enabled: false,
+					})
+				);
+			}
+			keyset.setPrimaryKeyId(1);
+			const keysetHandle = new KeysetHandle(keyset);
+
+			// Register KeyManager (the key manager for enabled keys should be
+			// enough).
+			const primitive = new DummyAead(
+				new Uint8Array(Random.randBytes(10))
+			);
+			Registry.registerKeyManager(
+				new DummyKeyManager(enabledUrl, primitive, Aead)
+			);
+
+			// Get primitives and get all raw primitives.
+			const primitiveSet = await keysetHandle.getPrimitiveSet(Aead);
+			const rawPrimitives = primitiveSet.getRawPrimitives();
+
+			// Should return all enabled RAW primitives and nothing else (disabled
+			// primitives should not be added into primitive set).
+			expect(rawPrimitives.length).toBe(enabledRawKeysCount);
+
+			// Test that it returns the correct RAW primitives by using getPrimitive.
+			for (let i = 0; i < enabledRawKeysCount; ++i) {
+				expect(rawPrimitives[i].getPrimitive()).toBe(primitive);
+			}
+		});
+
+		it("with custom key manager", async () => {
+			// Create keyset handle.
+			const keyTypeUrl = "some_key_type_url";
+			const keyId = 1;
+			const key = createKey({
+				keyId,
+				outputPrefix: PbOutputPrefixType.TINK,
+				keyTypeUrl,
+			});
+
+			const keyset = new PbKeyset();
+			keyset.addKey(key);
+			keyset.setPrimaryKeyId(keyId);
+
+			const keysetHandle = new KeysetHandle(keyset);
+
+			// Register key manager for the given keyType.
+			const primitive = new DummyAead(
+				new Uint8Array(Random.randBytes(10))
+			);
+			Registry.registerKeyManager(
+				new DummyKeyManager(keyTypeUrl, primitive, Aead)
+			);
+
+			// Use getPrimitives with custom key manager for the keyType.
+			const customPrimitive = new DummyAead(
+				new Uint8Array(Random.randBytes(10))
+			);
+			const customKeyManager = new DummyKeyManager(
+				keyTypeUrl,
+				customPrimitive,
+				Aead
+			);
+			const primitiveSet = await keysetHandle.getPrimitiveSet(
+				Aead,
+				customKeyManager
+			);
+
+			// Primary should be the entry corresponding to the keyTypeUrl and thus
+			// getPrimitive should return customPrimitive.
+			const primary = assertExists(primitiveSet.getPrimary());
+			expect(primary.getPrimitive()).toBe(customPrimitive);
+		});
+	});
+
+	describe("readNoSecret", () => {
+		it("throws for keysets containing secret key material", () => {
+			const secretKeyMaterialTypes = [
+				PbKeyMaterialType.SYMMETRIC,
+				PbKeyMaterialType.ASYMMETRIC_PRIVATE,
+				PbKeyMaterialType.UNKNOWN_KEYMATERIAL,
+			];
+			for (const secretKeyMaterialType of secretKeyMaterialTypes) {
+				// Create a public keyset.
+				const keyset = new PbKeyset();
+				for (let i = 0; i < 3; i++) {
+					const key = createKey({
+						keyId: i + 1,
+						outputPrefix: PbOutputPrefixType.TINK,
+						keyTypeUrl: "someType",
+						enabled: i % 4 < 2,
+						keyMaterialType: PbKeyMaterialType.ASYMMETRIC_PUBLIC,
+					});
+					keyset.addKey(key);
+				}
+				keyset.setPrimaryKeyId(1);
+				const key = createKey({
+					keyId: 0xffffffff,
+					outputPrefix: PbOutputPrefixType.RAW,
+					keyTypeUrl: "someType",
+					enabled: true,
+					keyMaterialType: secretKeyMaterialType,
+				});
+				keyset.addKey(key);
+				const reader = BinaryKeysetReader.withUint8Array(
+					keyset.serializeBinary()
+				);
+				expect(() => readNoSecret(reader)).toThrowError(
+					SecurityException,
+					"Keyset contains secret key material."
+				);
+			}
+		});
+
+		it("returns non-secret keysets", () => {
+			// Create a public keyset.
+			const keyset = new PbKeyset();
+			for (let i = 0; i < 3; i++) {
+				const key = createKey({
+					keyId: i + 1,
+					outputPrefix: PbOutputPrefixType.TINK,
+					keyTypeUrl: "someType",
+					enabled: i % 4 < 2,
+					keyMaterialType: PbKeyMaterialType.ASYMMETRIC_PUBLIC,
+				});
+				keyset.addKey(key);
+			}
+			keyset.setPrimaryKeyId(1);
+
+			const reader = BinaryKeysetReader.withUint8Array(
+				keyset.serializeBinary()
+			);
+			const keysetHandle = readNoSecret(reader);
+
+			assertMessageEquals(keysetHandle.getKeyset(), keyset);
+		});
+	});
+
+	describe("getPublicKeysetHandle", () => {
+		it("can get a public keyset from a private keyset", async () => {
+			const privateHandle = await generateNew(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			expect(() =>
+				privateHandle.getPublicKeysetHandle()
+			).not.toThrowError(
+				SecurityException,
+				"The keyset contains a non-private key"
+			);
+		});
+
+		it("can not get a public keyset from another public keyset", async () => {
+			const privateHandle = await generateNew(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			const publicHandle = privateHandle.getPublicKeysetHandle();
+			expect(() => publicHandle.getPublicKeysetHandle()).toThrowError(
+				SecurityException,
+				"The keyset contains a non-private key"
+			);
+		});
+	});
+
+	describe("writeNoSecret", () => {
+		it("throws if the keyset contains secret keys", async () => {
+			const privateHandle = await generateNew(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			expect(() =>
+				privateHandle.writeNoSecret(new BinaryKeysetWriter())
+			).toThrowError(SecurityException);
+		});
+
+		it("writes bytes if the keyset contains no secret keys", async () => {
+			const privateHandle = await generateNew(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			const publicHandle = privateHandle.getPublicKeysetHandle();
+			expect(() =>
+				publicHandle.writeNoSecret(new BinaryKeysetWriter())
+			).not.toThrow();
+		});
+
+		it("can import the keyset using readNoSecret", async () => {
+			const privateHandle = await generateNew(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			const publicHandle = privateHandle.getPublicKeysetHandle();
+			const keysetBytes = publicHandle.writeNoSecret(
+				new BinaryKeysetWriter()
+			);
+
+			const importedHandle = readNoSecret(
+				new BinaryKeysetReader(keysetBytes)
+			);
+			assertMessageEquals(
+				publicHandle.getKeyset(),
+				importedHandle.getKeyset()
+			);
+		});
+	});
 });
 
 /** Function for creating keys for testing purposes. */
 function createKey({
-  keyId,
-  outputPrefix,
-  keyTypeUrl,
-  enabled = true,
-  keyMaterialType = PbKeyMaterialType.SYMMETRIC
+	keyId,
+	outputPrefix,
+	keyTypeUrl,
+	enabled = true,
+	keyMaterialType = PbKeyMaterialType.SYMMETRIC,
 }: {
-  keyId: number,
-  outputPrefix: PbOutputPrefixType,
-  keyTypeUrl: string,
-  enabled?: boolean,
-  keyMaterialType?: PbKeyMaterialType,
+	keyId: number;
+	outputPrefix: PbOutputPrefixType;
+	keyTypeUrl: string;
+	enabled?: boolean;
+	keyMaterialType?: PbKeyMaterialType;
 }): PbKeysetKey {
-  return new PbKeysetKey()
-      .setStatus(enabled ? PbKeyStatusType.ENABLED : PbKeyStatusType.DISABLED)
-      .setOutputPrefixType(outputPrefix)
-      .setKeyId(keyId)
-      .setKeyData(new PbKeyData()
-                      .setTypeUrl(keyTypeUrl)
-                      .setValue(new Uint8Array([1]))
-                      .setKeyMaterialType(keyMaterialType));
+	return new PbKeysetKey()
+		.setStatus(enabled ? PbKeyStatusType.ENABLED : PbKeyStatusType.DISABLED)
+		.setOutputPrefixType(outputPrefix)
+		.setKeyId(keyId)
+		.setKeyData(
+			new PbKeyData()
+				.setTypeUrl(keyTypeUrl)
+				.setValue(new Uint8Array([1]))
+				.setKeyMaterialType(keyMaterialType)
+		);
 }
 
 /**
@@ -631,163 +765,185 @@ function createKey({
  * keyType added to the Keyset.
  */
 function createKeysetAndInitializeRegistry(
-    primitiveType: Constructor<unknown>, numberOfKeys = 15): PbKeyset {
-  const numberOfKeyTypes = 5;
-  const keyTypePrefix = 'key_type_';
+	primitiveType: Constructor<unknown>,
+	numberOfKeys = 15
+): PbKeyset {
+	const numberOfKeyTypes = 5;
+	const keyTypePrefix = "key_type_";
 
-  for (let i = 0; i < numberOfKeyTypes; i++) {
-    const typeUrl = keyTypePrefix + i.toString();
-    let primitive;
-    switch (primitiveType) {
-      case HybridDecrypt:
-        primitive = new DummyHybridDecrypt(new Uint8Array([i]));
-        break;
-      case HybridEncrypt:
-        primitive = new DummyHybridEncrypt(new Uint8Array([i]));
-        break;
-      default:
-        primitive = new DummyAead(new Uint8Array([i]));
-        break;
-    }
-    Registry.registerKeyManager(
-        new DummyKeyManager(typeUrl, primitive, primitiveType));
-  }
+	for (let i = 0; i < numberOfKeyTypes; i++) {
+		const typeUrl = keyTypePrefix + i.toString();
+		let primitive;
+		switch (primitiveType) {
+			case HybridDecrypt:
+				primitive = new DummyHybridDecrypt(new Uint8Array([i]));
+				break;
+			case HybridEncrypt:
+				primitive = new DummyHybridEncrypt(new Uint8Array([i]));
+				break;
+			default:
+				primitive = new DummyAead(new Uint8Array([i]));
+				break;
+		}
+		Registry.registerKeyManager(
+			new DummyKeyManager(typeUrl, primitive, primitiveType)
+		);
+	}
 
-  const keyset = new PbKeyset();
+	const keyset = new PbKeyset();
 
-  for (let i = 1; i < numberOfKeys; i++) {
-    const keyTypeUrl = keyTypePrefix + (i % numberOfKeyTypes).toString();
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    // There are no primitives added to PrimitiveSet for disabled keys, thus
-    // they are quite rarely added into the Keyset.
-    keyset.addKey(
-        createKey({keyId: i, outputPrefix, keyTypeUrl, enabled: i % 7 < 6}));
-  }
+	for (let i = 1; i < numberOfKeys; i++) {
+		const keyTypeUrl = keyTypePrefix + (i % numberOfKeyTypes).toString();
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		// There are no primitives added to PrimitiveSet for disabled keys, thus
+		// they are quite rarely added into the Keyset.
+		keyset.addKey(
+			createKey({
+				keyId: i,
+				outputPrefix,
+				keyTypeUrl,
+				enabled: i % 7 < 6,
+			})
+		);
+	}
 
-  keyset.setPrimaryKeyId(1);
-  return keyset;
+	keyset.setPrimaryKeyId(1);
+	return keyset;
 }
 
 class DummyAead extends Aead {
-  constructor(private readonly ciphertextSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly ciphertextSuffix: Uint8Array) {
+		super();
+	}
 
-  // Encrypt method just append the primitive identifier to plaintext.
-  async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array) {
-    const result =
-        new Uint8Array(plaintext.length + this.ciphertextSuffix.length);
-    result.set(plaintext, 0);
-    result.set(this.ciphertextSuffix, plaintext.length);
-    return result;
-  }
+	// Encrypt method just append the primitive identifier to plaintext.
+	async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array) {
+		const result = new Uint8Array(
+			plaintext.length + this.ciphertextSuffix.length
+		);
+		result.set(plaintext, 0);
+		result.set(this.ciphertextSuffix, plaintext.length);
+		return result;
+	}
 
-  // Decrypt method throws an exception whenever ciphertext does not end with
-  // ciphertext suffix, otherwise it returns the first part (without
-  // ciphertext suffix).
-  async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array) {
-    const plaintext = ciphertext.subarray(
-        0, ciphertext.length - this.ciphertextSuffix.length);
-    const ciphertextSuffix = ciphertext.subarray(
-        ciphertext.length - this.ciphertextSuffix.length, ciphertext.length);
+	// Decrypt method throws an exception whenever ciphertext does not end with
+	// ciphertext suffix, otherwise it returns the first part (without
+	// ciphertext suffix).
+	async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array) {
+		const plaintext = ciphertext.subarray(
+			0,
+			ciphertext.length - this.ciphertextSuffix.length
+		);
+		const ciphertextSuffix = ciphertext.subarray(
+			ciphertext.length - this.ciphertextSuffix.length,
+			ciphertext.length
+		);
 
-    if ([...ciphertextSuffix].toString() !==
-        [...this.ciphertextSuffix].toString()) {
-      throw new SecurityException('Ciphertext decryption failed.');
-    }
+		if (
+			[...ciphertextSuffix].toString() !==
+			[...this.ciphertextSuffix].toString()
+		) {
+			throw new SecurityException("Ciphertext decryption failed.");
+		}
 
-    return plaintext;
-  }
+		return plaintext;
+	}
 }
 
 class DummyMac extends Mac {
-  constructor(private readonly tag: Uint8Array) {
-    super();
-  }
+	constructor(private readonly tag: Uint8Array) {
+		super();
+	}
 
-  /**
-   * Just appends the tag to the data.
-   */
-  async computeMac(data: Uint8Array) {
-    return this.tag;
-  }
+	/**
+	 * Just appends the tag to the data.
+	 */
+	async computeMac(data: Uint8Array) {
+		return this.tag;
+	}
 
-  /**
-   * Returns whether data ends with tag.
-   */
-  async verifyMac(tag: Uint8Array, data: Uint8Array) {
-    return [...tag].toString() === [...this.tag].toString();
-  }
+	/**
+	 * Returns whether data ends with tag.
+	 */
+	async verifyMac(tag: Uint8Array, data: Uint8Array) {
+		return [...tag].toString() === [...this.tag].toString();
+	}
 }
 
 class DummyHybridEncrypt extends HybridEncrypt {
-  constructor(private readonly ciphertextSuffix: Uint8Array) {
-    super();
-  }
-  // Async is used here just because real primitives returns Promise.
-  async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array) {
-    return Bytes.concat(plaintext, this.ciphertextSuffix);
-  }
+	constructor(private readonly ciphertextSuffix: Uint8Array) {
+		super();
+	}
+	// Async is used here just because real primitives returns Promise.
+	async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array) {
+		return Bytes.concat(plaintext, this.ciphertextSuffix);
+	}
 }
 
 class DummyHybridDecrypt extends HybridDecrypt {
-  constructor(private readonly ciphertextSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly ciphertextSuffix: Uint8Array) {
+		super();
+	}
 
-  async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array) {
-    const cipherLen = ciphertext.length;
-    const suffixLen = this.ciphertextSuffix.length;
-    const plaintext = ciphertext.subarray(0, cipherLen - suffixLen);
-    const suffix = ciphertext.subarray(cipherLen - suffixLen, cipherLen);
-    if (!Bytes.isEqual(this.ciphertextSuffix, suffix)) {
-      throw new SecurityException('Ciphertext decryption failed.');
-    }
-    return plaintext;
-  }
+	async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array) {
+		const cipherLen = ciphertext.length;
+		const suffixLen = this.ciphertextSuffix.length;
+		const plaintext = ciphertext.subarray(0, cipherLen - suffixLen);
+		const suffix = ciphertext.subarray(cipherLen - suffixLen, cipherLen);
+		if (!Bytes.isEqual(this.ciphertextSuffix, suffix)) {
+			throw new SecurityException("Ciphertext decryption failed.");
+		}
+		return plaintext;
+	}
 }
 
 class DummyKeyManager<T> implements KeyManager<T> {
-  constructor(
-      private readonly keyType: string, private readonly primitive: T,
-      private readonly primitiveType: Constructor<T>) {}
+	constructor(
+		private readonly keyType: string,
+		private readonly primitive: T,
+		private readonly primitiveType: Constructor<T>
+	) {}
 
-  async getPrimitive(primitiveType: Constructor<T>, key: PbKeyData|PbMessage) {
-    if (primitiveType !== this.getPrimitiveType()) {
-      throw new SecurityException(
-          'Requested primitive type which is not ' +
-          'supported by this key manager.');
-    }
-    return this.primitive;
-  }
+	async getPrimitive(
+		primitiveType: Constructor<T>,
+		key: PbKeyData | PbMessage
+	) {
+		if (primitiveType !== this.getPrimitiveType()) {
+			throw new SecurityException(
+				"Requested primitive type which is not " +
+					"supported by this key manager."
+			);
+		}
+		return this.primitive;
+	}
 
-  doesSupport(keyType: string) {
-    return keyType === this.getKeyType();
-  }
+	doesSupport(keyType: string) {
+		return keyType === this.getKeyType();
+	}
 
-  getKeyType() {
-    return this.keyType;
-  }
+	getKeyType() {
+		return this.keyType;
+	}
 
-  getPrimitiveType() {
-    return this.primitiveType;
-  }
+	getPrimitiveType() {
+		return this.primitiveType;
+	}
 
-  getVersion(): number {
-    throw new SecurityException('Not implemented, function is not needed.');
-  }
+	getVersion(): number {
+		throw new SecurityException("Not implemented, function is not needed.");
+	}
 
-  getKeyFactory(): KeyFactory {
-    throw new SecurityException('Not implemented, function is not needed.');
-  }
+	getKeyFactory(): KeyFactory {
+		throw new SecurityException("Not implemented, function is not needed.");
+	}
 }

--- a/javascript/internal/primitive_set_test.ts
+++ b/javascript/internal/primitive_set_test.ts
@@ -4,286 +4,309 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Aead} from '../aead';
-import {SecurityException} from '../exception/security_exception';
+import { Aead } from "../aead";
+import { SecurityException } from "../exception/security_exception";
 
-import {CryptoFormat} from './crypto_format';
-import * as PrimitiveSet from './primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from './proto';
+import { CryptoFormat } from "./crypto_format";
+import * as PrimitiveSet from "./primitive_set";
+import { PbKeysetKey, PbKeyStatusType, PbOutputPrefixType } from "./proto";
 
-describe('primitive set test', function() {
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for addPrimitive method
-  it('add primitive unknown crypto format', function() {
-    const primitive = new DummyAead1();
-    const key =
-        createKey().setOutputPrefixType(PbOutputPrefixType.UNKNOWN_PREFIX);
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+describe("primitive set test", () => {
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for addPrimitive method
+	it("add primitive unknown crypto format", () => {
+		const primitive = new DummyAead1();
+		const key = createKey().setOutputPrefixType(
+			PbOutputPrefixType.UNKNOWN_PREFIX
+		);
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
 
-    try {
-      primitiveSet.addPrimitive(primitive, key);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownPrefixType());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
-  it('add primitive multiple times should work', function() {
-    const key = createKey();
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+		try {
+			primitiveSet.addPrimitive(primitive, key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownPrefixType());
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
+	it("add primitive multiple times should work", () => {
+		const key = createKey();
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
 
-    for (let i = 0; i < 4; i++) {
-      let primitive;
-      if (i % 2 === 0) {
-        primitive = new DummyAead1();
-      } else {
-        primitive = new DummyAead2();
-      }
-      const result = primitiveSet.addPrimitive(primitive, key);
+		for (let i = 0; i < 4; i++) {
+			let primitive;
+			if (i % 2 === 0) {
+				primitive = new DummyAead1();
+			} else {
+				primitive = new DummyAead2();
+			}
+			const result = primitiveSet.addPrimitive(primitive, key);
 
-      expect(result.getPrimitive()).toEqual(primitive);
-      expect(result.getKeyStatus()).toBe(key.getStatus());
-      expect(result.getOutputPrefixType()).toBe(key.getOutputPrefixType());
-      expect(result.getIdentifier()).toEqual(CryptoFormat.getOutputPrefix(key));
-    }
-  });
+			expect(result.getPrimitive()).toEqual(primitive);
+			expect(result.getKeyStatus()).toBe(key.getStatus());
+			expect(result.getOutputPrefixType()).toBe(
+				key.getOutputPrefixType()
+			);
+			expect(result.getIdentifier()).toEqual(
+				CryptoFormat.getOutputPrefix(key)
+			);
+		}
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getPrimitives method
-  it('get primitives which were not added', function() {
-    // Fill in the structure with some primitives.
-    const numberOfAddedPrimitives = 12;
-    const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getPrimitives method
+	it("get primitives which were not added", () => {
+		// Fill in the structure with some primitives.
+		const numberOfAddedPrimitives = 12;
+		const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
 
-    const key = createKey(/* opt_keyId = */ numberOfAddedPrimitives + 1);
-    const identifier = CryptoFormat.getOutputPrefix(key);
-    const result = primitiveSet.getPrimitives(identifier);
+		const key = createKey(/* opt_keyId = */ numberOfAddedPrimitives + 1);
+		const identifier = CryptoFormat.getOutputPrefix(key);
+		const result = primitiveSet.getPrimitives(identifier);
 
-    expect(result).toEqual([]);
-  });
+		expect(result).toEqual([]);
+	});
 
-  it('get primitives different identifiers', function() {
-    // Fill in the structure with some primitives.
-    const n = 100;
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+	it("get primitives different identifiers", () => {
+		// Fill in the structure with some primitives.
+		const n = 100;
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
 
-    const added = [];
-    for (let id = 0; id < n; id++) {
-      const legacyKeyType = ((id % 2) < 1);
-      const enabledKey = ((id % 4) < 2);
-      const key = createKey(id, legacyKeyType, enabledKey);
+		const added = [];
+		for (let id = 0; id < n; id++) {
+			const legacyKeyType = id % 2 < 1;
+			const enabledKey = id % 4 < 2;
+			const key = createKey(id, legacyKeyType, enabledKey);
 
-      let primitive;
-      if  ((id % 8) < 4) {
-        primitive = new DummyAead1();
-      } else {
-        primitive = new DummyAead2();
-      }
+			let primitive;
+			if (id % 8 < 4) {
+				primitive = new DummyAead1();
+			} else {
+				primitive = new DummyAead2();
+			}
 
-      const res = primitiveSet.addPrimitive(primitive, key);
-      added.push({key, entry: res});
-    }
+			const res = primitiveSet.addPrimitive(primitive, key);
+			added.push({ key, entry: res });
+		}
 
-    // Test that getPrimitives return correct value for them.
-    const addedLength = added.length;
-    for (let i = 0; i < addedLength; i++) {
-      const identifier = CryptoFormat.getOutputPrefix(added[i].key);
-      // Should return a set containing only one primitive as each added
-      // primitive has different identifier.
-      const expectedResult = [added[i].entry];
-      const result = primitiveSet.getPrimitives(identifier);
+		// Test that getPrimitives return correct value for them.
+		const addedLength = added.length;
+		for (let i = 0; i < addedLength; i++) {
+			const identifier = CryptoFormat.getOutputPrefix(added[i].key);
+			// Should return a set containing only one primitive as each added
+			// primitive has different identifier.
+			const expectedResult = [added[i].entry];
+			const result = primitiveSet.getPrimitives(identifier);
 
-      expect(result).toEqual(expectedResult);
-    }
-  });
+			expect(result).toEqual(expectedResult);
+		}
+	});
 
-  it('get primitives same identifiers', function() {
-    // Fill in the structure with some primitives.
-    const numberOfAddedPrimitives = 50;
-    const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
+	it("get primitives same identifiers", () => {
+		// Fill in the structure with some primitives.
+		const numberOfAddedPrimitives = 50;
+		const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
 
-    // Add a group of primitives with same identifier.
-    const n = 12;
-    const keyId = 0xABCDEF98;
-    const legacyKeyType = false;
+		// Add a group of primitives with same identifier.
+		const n = 12;
+		const keyId = 0xabcdef98;
+		const legacyKeyType = false;
 
-    const expectedResult = [];
-    for (let i = 0; i < n; i++) {
-      const enabledKey = ((i % 2) < 1);
-      const key = createKey(keyId, legacyKeyType, enabledKey);
+		const expectedResult = [];
+		for (let i = 0; i < n; i++) {
+			const enabledKey = i % 2 < 1;
+			const key = createKey(keyId, legacyKeyType, enabledKey);
 
-      let primitive;
-      if  ((i % 4) < 2) {
-        primitive = new DummyAead1();
-      } else {
-        primitive = new DummyAead2();
-      }
+			let primitive;
+			if (i % 4 < 2) {
+				primitive = new DummyAead1();
+			} else {
+				primitive = new DummyAead2();
+			}
 
-      const res = primitiveSet.addPrimitive(primitive, key);
-      expectedResult.push(res);
-    }
+			const res = primitiveSet.addPrimitive(primitive, key);
+			expectedResult.push(res);
+		}
 
-    const identifier =
-        CryptoFormat.getOutputPrefix(createKey(keyId, legacyKeyType));
-    const result = primitiveSet.getPrimitives(identifier);
+		const identifier = CryptoFormat.getOutputPrefix(
+			createKey(keyId, legacyKeyType)
+		);
+		const result = primitiveSet.getPrimitives(identifier);
 
-    expect(result).toEqual(expectedResult);
-  });
+		expect(result).toEqual(expectedResult);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getRawPrimitives method
-  it('get raw primitives', function() {
-    const numberOfAddedPrimitives = 20;
-    const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getRawPrimitives method
+	it("get raw primitives", () => {
+		const numberOfAddedPrimitives = 20;
+		const primitiveSet = initPrimitiveSet(numberOfAddedPrimitives);
 
-    // No RAW primitives were added.
-    const expectedResult: Array<PrimitiveSet.Entry<Aead>> = [];
-    let result = primitiveSet.getRawPrimitives();
-    expect(result).toEqual(expectedResult);
+		// No RAW primitives were added.
+		const expectedResult: Array<PrimitiveSet.Entry<Aead>> = [];
+		let result = primitiveSet.getRawPrimitives();
+		expect(result).toEqual(expectedResult);
 
-    // Add RAW primitives and check the result again after each adding.
-    const key = createKey().setOutputPrefixType(PbOutputPrefixType.RAW);
+		// Add RAW primitives and check the result again after each adding.
+		const key = createKey().setOutputPrefixType(PbOutputPrefixType.RAW);
 
-    let addResult = primitiveSet.addPrimitive(new DummyAead1(), key);
-    expectedResult.push(addResult);
-    result = primitiveSet.getRawPrimitives();
-    expect(result).toEqual(expectedResult);
+		let addResult = primitiveSet.addPrimitive(new DummyAead1(), key);
+		expectedResult.push(addResult);
+		result = primitiveSet.getRawPrimitives();
+		expect(result).toEqual(expectedResult);
 
-    key.setStatus(PbKeyStatusType.DISABLED);
-    addResult = primitiveSet.addPrimitive(new DummyAead2(), key);
-    expectedResult.push(addResult);
-    result = primitiveSet.getRawPrimitives();
-    expect(result).toEqual(expectedResult);
-  });
+		key.setStatus(PbKeyStatusType.DISABLED);
+		addResult = primitiveSet.addPrimitive(new DummyAead2(), key);
+		expectedResult.push(addResult);
+		result = primitiveSet.getRawPrimitives();
+		expect(result).toEqual(expectedResult);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for setPrimary and getPrimary methods
-  it('set primary to nonholded entry', function() {
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
-    const entry = new PrimitiveSet.Entry(
-        new DummyAead1(), new Uint8Array(10), PbKeyStatusType.ENABLED,
-        PbOutputPrefixType.TINK);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for setPrimary and getPrimary methods
+	it("set primary to nonholded entry", () => {
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+		const entry = new PrimitiveSet.Entry(
+			new DummyAead1(),
+			new Uint8Array(10),
+			PbKeyStatusType.ENABLED,
+			PbOutputPrefixType.TINK
+		);
 
-    try {
-      primitiveSet.setPrimary(entry);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.setPrimaryToMissingEntry());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			primitiveSet.setPrimary(entry);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.setPrimaryToMissingEntry());
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('set primary to entry with disabled key status', function() {
-    const key = createKey(/* opt_keyId = */ 0x12345678,
-        /* opt_legacy = */ false, /* opt_enabled = */ false);
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+	it("set primary to entry with disabled key status", () => {
+		const key = createKey(
+			/* opt_keyId = */ 0x12345678,
+			/* opt_legacy = */ false,
+			/* opt_enabled = */ false
+		);
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
 
-    const primary = primitiveSet.addPrimitive(new DummyAead1(), key);
+		const primary = primitiveSet.addPrimitive(new DummyAead1(), key);
 
-    try {
-      primitiveSet.setPrimary(primary);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.setPrimaryToDisabled());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			primitiveSet.setPrimary(primary);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.setPrimaryToDisabled());
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('set and get primary', function() {
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
-    expect(primitiveSet.getPrimary()).toBe(null);
+	it("set and get primary", () => {
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+		expect(primitiveSet.getPrimary()).toBe(null);
 
-    const key1 = createKey(/* opt_keyId = */ 0xBBBCCC);
+		const key1 = createKey(/* opt_keyId = */ 0xbbbccc);
 
-    const result = primitiveSet.addPrimitive(new DummyAead1(), key1);
-    // Check that primary remains unset, set it to newly added and verify that
-    // it was set.
-    expect(primitiveSet.getPrimary()).toBe(null);
-    primitiveSet.setPrimary(result);
-    expect(primitiveSet.getPrimary()).toEqual(result);
+		const result = primitiveSet.addPrimitive(new DummyAead1(), key1);
+		// Check that primary remains unset, set it to newly added and verify that
+		// it was set.
+		expect(primitiveSet.getPrimary()).toBe(null);
+		primitiveSet.setPrimary(result);
+		expect(primitiveSet.getPrimary()).toEqual(result);
 
-    const key2 = createKey(/* opt_keyId = */ 0xAAABBB);
-    // Add new primitive, check that it does not change primary.
-    const result2 = primitiveSet.addPrimitive(new DummyAead2(), key2);
-    expect(primitiveSet.getPrimary()).toEqual(result);
+		const key2 = createKey(/* opt_keyId = */ 0xaaabbb);
+		// Add new primitive, check that it does not change primary.
+		const result2 = primitiveSet.addPrimitive(new DummyAead2(), key2);
+		expect(primitiveSet.getPrimary()).toEqual(result);
 
-    // Change the primary and verify the change.
-    primitiveSet.setPrimary(result2);
-    expect(primitiveSet.getPrimary()).toEqual(result2);
-  });
+		// Change the primary and verify the change.
+		primitiveSet.setPrimary(result2);
+		expect(primitiveSet.getPrimary()).toEqual(result2);
+	});
 
-  it('set primary, raw primitives', function() {
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
-    for (let i = 0; i < 3; i++) {
-      const key = createKey(i).setOutputPrefixType(PbOutputPrefixType.RAW);
-      primitiveSet.addPrimitive(new DummyAead1(), key);
-    }
-    const primaryKey =
-        createKey(255).setOutputPrefixType(PbOutputPrefixType.RAW);
-    const primaryEntry =
-        primitiveSet.addPrimitive(new DummyAead1(), primaryKey);
-    primitiveSet.setPrimary(primaryEntry);
-  });
+	it("set primary, raw primitives", () => {
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+		for (let i = 0; i < 3; i++) {
+			const key = createKey(i).setOutputPrefixType(
+				PbOutputPrefixType.RAW
+			);
+			primitiveSet.addPrimitive(new DummyAead1(), key);
+		}
+		const primaryKey = createKey(255).setOutputPrefixType(
+			PbOutputPrefixType.RAW
+		);
+		const primaryEntry = primitiveSet.addPrimitive(
+			new DummyAead1(),
+			primaryKey
+		);
+		primitiveSet.setPrimary(primaryEntry);
+	});
 
-  it('get primary type', function() {
-    const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
-    expect(primitiveSet.getPrimitiveType()).toEqual(Aead);
-  });
+	it("get primary type", () => {
+		const primitiveSet = new PrimitiveSet.PrimitiveSet(Aead);
+		expect(primitiveSet.getPrimitiveType()).toEqual(Aead);
+	});
 });
 
 // Helper classes and functions used for testing purposes.
 
 class ExceptionText {
-  static unknownPrefixType(): string {
-    return 'SecurityException: Unsupported key prefix type.';
-  }
+	static unknownPrefixType(): string {
+		return "SecurityException: Unsupported key prefix type.";
+	}
 
-  static addingNullPrimitive(): string {
-    return 'SecurityException: Primitive has to be non null.';
-  }
+	static addingNullPrimitive(): string {
+		return "SecurityException: Primitive has to be non null.";
+	}
 
-  static addingNullKey(): string {
-    return 'SecurityException: Key has to be non null.';
-  }
+	static addingNullKey(): string {
+		return "SecurityException: Key has to be non null.";
+	}
 
-  static setPrimaryToNull(): string {
-    return 'SecurityException: Primary cannot be set to null.';
-  }
+	static setPrimaryToNull(): string {
+		return "SecurityException: Primary cannot be set to null.";
+	}
 
-  static setPrimaryToMissingEntry(): string {
-    return 'SecurityException: Primary cannot be set to an entry which is ' +
-        'not held by this primitive set.';
-  }
+	static setPrimaryToMissingEntry(): string {
+		return (
+			"SecurityException: Primary cannot be set to an entry which is " +
+			"not held by this primitive set."
+		);
+	}
 
-  static setPrimaryToDisabled(): string {
-    return 'SecurityException: Primary has to be enabled.';
-  }
+	static setPrimaryToDisabled(): string {
+		return "SecurityException: Primary has to be enabled.";
+	}
 }
 
 /** @final */
 class DummyAead1 extends Aead {
-  encrypt(plaintext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
-    throw new SecurityException(
-        'Not implemented, intentended just for testing.');
-  }
+	encrypt(plaintext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
+		throw new SecurityException(
+			"Not implemented, intentended just for testing."
+		);
+	}
 
-  decrypt(ciphertext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
-    throw new SecurityException(
-        'Not implemented, intentended just for testing.');
-  }
+	decrypt(ciphertext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
+		throw new SecurityException(
+			"Not implemented, intentended just for testing."
+		);
+	}
 }
 
 /** @final */
 class DummyAead2 extends Aead {
-  encrypt(plaintext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
-    throw new SecurityException(
-        'Not implemented, intentended just for testing.');
-  }
+	encrypt(plaintext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
+		throw new SecurityException(
+			"Not implemented, intentended just for testing."
+		);
+	}
 
-  decrypt(ciphertext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
-    throw new SecurityException(
-        'Not implemented, intentended just for testing.');
-  }
+	decrypt(ciphertext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
+		throw new SecurityException(
+			"Not implemented, intentended just for testing."
+		);
+	}
 }
 
 /**
@@ -295,56 +318,61 @@ class DummyAead2 extends Aead {
  *    and key types (legacy, tink).
  */
 function initPrimitiveSet(n: number): PrimitiveSet.PrimitiveSet<Aead> {
-  const primitiveSet = new PrimitiveSet.PrimitiveSet<Aead>(Aead);
+	const primitiveSet = new PrimitiveSet.PrimitiveSet<Aead>(Aead);
 
-  // Set primary.
-  const primaryKey = createKey(/* opt_id = */ 0, /* opt_legacy = */ false,
-      /* opt_enabled = */ true);
-  const primary = primitiveSet.addPrimitive(new DummyAead1(), primaryKey);
-  primitiveSet.setPrimary(primary);
+	// Set primary.
+	const primaryKey = createKey(
+		/* opt_id = */ 0,
+		/* opt_legacy = */ false,
+		/* opt_enabled = */ true
+	);
+	const primary = primitiveSet.addPrimitive(new DummyAead1(), primaryKey);
+	primitiveSet.setPrimary(primary);
 
-  // Add n-1 other keys to primitive set.
-  for (let id = 1; id < n; id++) {
-    const legacyKeyType = ((id % 2) < 1);
-    const enabledKey = ((id % 4) < 2);
-    const key = createKey(id, legacyKeyType, enabledKey);
+	// Add n-1 other keys to primitive set.
+	for (let id = 1; id < n; id++) {
+		const legacyKeyType = id % 2 < 1;
+		const enabledKey = id % 4 < 2;
+		const key = createKey(id, legacyKeyType, enabledKey);
 
-    let primitive;
-    if ((id % 8) < 4) {
-      primitive = new DummyAead1();
-    } else {
-      primitive = new DummyAead2();
-    }
+		let primitive;
+		if (id % 8 < 4) {
+			primitive = new DummyAead1();
+		} else {
+			primitive = new DummyAead2();
+		}
 
-    primitiveSet.addPrimitive(primitive, key);
-  }
+		primitiveSet.addPrimitive(primitive, key);
+	}
 
-  return primitiveSet;
+	return primitiveSet;
 }
 
 /**
  * Function for creating keys for testing purposes.
- * If doesn't set otherwise it generates a key with id 0x12345678, which is
+ * If doesn"t set otherwise it generates a key with id 0x12345678, which is
  * ENABLED and with prefix type TINK.
  */
 function createKey(
-    opt_keyId: number = 0x12345678, opt_legacy: boolean = false,
-    opt_enabled: boolean = true): PbKeysetKey {
-  const key = new PbKeysetKey();
+	opt_keyId: number = 0x12345678,
+	opt_legacy: boolean = false,
+	opt_enabled: boolean = true
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (opt_enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	if (opt_enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  if (opt_legacy) {
-    key.setOutputPrefixType(PbOutputPrefixType.LEGACY);
-  } else {
-    key.setOutputPrefixType(PbOutputPrefixType.TINK);
-  }
+	if (opt_legacy) {
+		key.setOutputPrefixType(PbOutputPrefixType.LEGACY);
+	} else {
+		key.setOutputPrefixType(PbOutputPrefixType.TINK);
+	}
 
-  key.setKeyId(opt_keyId);
+	key.setKeyId(opt_keyId);
 
-  return key;
+	return key;
 }

--- a/javascript/internal/proto_shims_test.ts
+++ b/javascript/internal/proto_shims_test.ts
@@ -4,22 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as random from '../subtle/random';
+import * as random from "../subtle/random";
 
-import {PbKeyData} from './proto';
-import {bytesAsU8, bytesLength} from './proto_shims';
+import { PbKeyData } from "./proto";
+import { bytesAsU8, bytesLength } from "./proto_shims";
 
-describe('proto shims test', () => {
-  it('transforms bytes to uint8array and returns byte length', () => {
-    const rawKey = random.randBytes(32);
+describe("proto shims test", () => {
+	it("transforms bytes to uint8array and returns byte length", () => {
+		const rawKey = random.randBytes(32);
 
-    const keyData =
-        new PbKeyData()
-            .setTypeUrl('key_type_url')
-            .setValue(rawKey)
-            .setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
+		const keyData = new PbKeyData()
+			.setTypeUrl("key_type_url")
+			.setValue(rawKey)
+			.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
 
-    expect(bytesAsU8(keyData.getValue())).toEqual(rawKey);
-    expect(bytesLength(keyData.getValue())).toEqual(32);
-  });
+		expect(bytesAsU8(keyData.getValue())).toEqual(rawKey);
+		expect(bytesLength(keyData.getValue())).toEqual(32);
+	});
 });

--- a/javascript/internal/proto_test.ts
+++ b/javascript/internal/proto_test.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbKeyset} from './proto';
+import { PbKeyset } from "./proto";
 
-describe('proto test', function() {
-  it('field', function() {
-    const keyset = new PbKeyset().setPrimaryKeyId(1);
-    expect(keyset.getPrimaryKeyId()).toBe(1);
-  });
+describe("proto test", () => {
+	it("field", () => {
+		const keyset = new PbKeyset().setPrimaryKeyId(1);
+		expect(keyset.getPrimaryKeyId()).toBe(1);
+	});
 });

--- a/javascript/internal/registry_test.ts
+++ b/javascript/internal/registry_test.ts
@@ -4,492 +4,581 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Aead} from '../aead';
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {AesCtrHmacAeadKeyManager} from '../aead/aes_ctr_hmac_aead_key_manager';
-import {SecurityException} from '../exception/security_exception';
-import * as HybridConfig from '../hybrid/hybrid_config';
-import {HybridKeyTemplates} from '../hybrid/hybrid_key_templates';
-import {Mac} from '../mac';
-import {EncryptThenAuthenticate} from '../subtle/encrypt_then_authenticate';
-import {assertExists, assertInstanceof} from '../testing/internal/test_utils';
+import { Aead } from "../aead";
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import { AesCtrHmacAeadKeyManager } from "../aead/aes_ctr_hmac_aead_key_manager";
+import { SecurityException } from "../exception/security_exception";
+import * as HybridConfig from "../hybrid/hybrid_config";
+import { HybridKeyTemplates } from "../hybrid/hybrid_key_templates";
+import { Mac } from "../mac";
+import { EncryptThenAuthenticate } from "../subtle/encrypt_then_authenticate";
+import { assertExists, assertInstanceof } from "../testing/internal/test_utils";
 
-import * as KeyManager from './key_manager';
-import * as PrimitiveSet from './primitive_set';
-import {PrimitiveWrapper} from './primitive_wrapper';
-import {PbAesCtrHmacAeadKey, PbAesCtrHmacAeadKeyFormat, PbAesCtrKey, PbAesCtrKeyFormat, PbAesCtrParams, PbEciesAeadHkdfPrivateKey, PbEciesAeadHkdfPublicKey, PbHashType, PbHmacKeyFormat, PbHmacParams, PbKeyData, PbKeyTemplate, PbMessage} from './proto';
-import {bytesAsU8, bytesLength} from './proto_shims';
-import * as Registry from './registry';
-import {Constructor} from './util';
+import * as KeyManager from "./key_manager";
+import * as PrimitiveSet from "./primitive_set";
+import { PrimitiveWrapper } from "./primitive_wrapper";
+import {
+	PbAesCtrHmacAeadKey,
+	PbAesCtrHmacAeadKeyFormat,
+	PbAesCtrKey,
+	PbAesCtrKeyFormat,
+	PbAesCtrParams,
+	PbEciesAeadHkdfPrivateKey,
+	PbEciesAeadHkdfPublicKey,
+	PbHashType,
+	PbHmacKeyFormat,
+	PbHmacParams,
+	PbKeyData,
+	PbKeyTemplate,
+	PbMessage,
+} from "./proto";
+import { bytesAsU8, bytesLength } from "./proto_shims";
+import * as Registry from "./registry";
+import { Constructor } from "./util";
 
 ////////////////////////////////////////////////////////////////////////////////
 // tests
 ////////////////////////////////////////////////////////////////////////////////
 
-describe('registry test', function() {
-  afterEach(function() {
-    Registry.reset();
-  });
+describe("registry test", () => {
+	afterEach(() => {
+		Registry.reset();
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for registerPrimitiveWrapper method
-  it('register primitive wrapper, overwriting with same class', function() {
-    Registry.registerPrimitiveWrapper(new DummyPrimitiveWrapper1(
-        new DummyPrimitive1Impl1(), DummyPrimitive1));
-    Registry.registerPrimitiveWrapper(new DummyPrimitiveWrapper1(
-        new DummyPrimitive1Impl2(), DummyPrimitive1));
-  });
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for registerPrimitiveWrapper method
+	it("register primitive wrapper, overwriting with same class", () => {
+		Registry.registerPrimitiveWrapper(
+			new DummyPrimitiveWrapper1(
+				new DummyPrimitive1Impl1(),
+				DummyPrimitive1
+			)
+		);
+		Registry.registerPrimitiveWrapper(
+			new DummyPrimitiveWrapper1(
+				new DummyPrimitive1Impl2(),
+				DummyPrimitive1
+			)
+		);
+	});
 
-  it('register primitive wrapper, overwriting with different class',
-     function() {
-       class DummyPrimitiveWrapper1Alternative implements
-           PrimitiveWrapper<DummyPrimitive1> {
-         wrap(): DummyPrimitive1 {
-           throw new Error();
-         }
+	it("register primitive wrapper, overwriting with different class", () => {
+		class DummyPrimitiveWrapper1Alternative
+			implements PrimitiveWrapper<DummyPrimitive1>
+		{
+			wrap(): DummyPrimitive1 {
+				throw new Error();
+			}
 
-         getPrimitiveType() {
-           return DummyPrimitive1;
-         }
-       }
-       Registry.registerPrimitiveWrapper(new DummyPrimitiveWrapper1(
-           new DummyPrimitive1Impl1(), DummyPrimitive1));
-       try {
-         Registry.registerPrimitiveWrapper(
-             new DummyPrimitiveWrapper1Alternative());
-         fail('An exception should be thrown.');
-       } catch (e: any) {
-         expect(e.toString())
-             .toBe(
-                 'SecurityException: primitive wrapper for type ' +
-                 DummyPrimitive1 +
-                 ' has already been registered and cannot be overwritten');
-       }
-     });
+			getPrimitiveType() {
+				return DummyPrimitive1;
+			}
+		}
+		Registry.registerPrimitiveWrapper(
+			new DummyPrimitiveWrapper1(
+				new DummyPrimitive1Impl1(),
+				DummyPrimitive1
+			)
+		);
+		try {
+			Registry.registerPrimitiveWrapper(
+				new DummyPrimitiveWrapper1Alternative()
+			);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: primitive wrapper for type " +
+					DummyPrimitive1 +
+					" has already been registered and cannot be overwritten"
+			);
+		}
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for wrap method
-  it('wrap, should work', function() {
-    const p1 = new DummyPrimitive1Impl1();
-    const p2 = new DummyPrimitive2Impl();
-    Registry.registerPrimitiveWrapper(
-        new DummyPrimitiveWrapper1(p1, DummyPrimitive1));
-    Registry.registerPrimitiveWrapper(
-        new DummyPrimitiveWrapper2(p2, DummyPrimitive2));
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for wrap method
+	it("wrap, should work", () => {
+		const p1 = new DummyPrimitive1Impl1();
+		const p2 = new DummyPrimitive2Impl();
+		Registry.registerPrimitiveWrapper(
+			new DummyPrimitiveWrapper1(p1, DummyPrimitive1)
+		);
+		Registry.registerPrimitiveWrapper(
+			new DummyPrimitiveWrapper2(p2, DummyPrimitive2)
+		);
 
-    expect(Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive1)))
-        .toBe(p1);
-    expect(Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive2)))
-        .toBe(p2);
-  });
+		expect(
+			Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive1))
+		).toBe(p1);
+		expect(
+			Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive2))
+		).toBe(p2);
+	});
 
-  it('wrap, not registered primitive type', function() {
-    expect(() => {
-      Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive1));
-    }).toThrowError('no primitive wrapper found for type ' + DummyPrimitive1);
-  });
+	it("wrap, not registered primitive type", () => {
+		expect(() => {
+			Registry.wrap(new PrimitiveSet.PrimitiveSet(DummyPrimitive1));
+		}).toThrowError(
+			"no primitive wrapper found for type " + DummyPrimitive1
+		);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for registerKeyManager  method
-  it('register key manager, overwriting attempt', function() {
-    const keyType = 'someKeyType';
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for registerKeyManager  method
+	it("register key manager, overwriting attempt", () => {
+		const keyType = "someKeyType";
 
-    try {
-      Registry.registerKeyManager(new DummyKeyManager1(keyType));
-      Registry.registerKeyManager(new DummyKeyManager2(keyType));
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.keyManagerOverwrittingAttempt(keyType));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Registry.registerKeyManager(new DummyKeyManager1(keyType));
+			Registry.registerKeyManager(new DummyKeyManager2(keyType));
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.keyManagerOverwrittingAttempt(keyType)
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  // Testing newKeyAllowed behavior -- should hold the most restrictive setting.
-  it('register key manager, more restrictive new key allowed',
-     async function() {
-       const keyType = 'someTypeUrl';
-       const keyManager1 = new DummyKeyManager1(keyType);
-       const keyTemplate = new PbKeyTemplate().setTypeUrl(keyType);
+	// Testing newKeyAllowed behavior -- should hold the most restrictive setting.
+	it("register key manager, more restrictive new key allowed", async () => {
+		const keyType = "someTypeUrl";
+		const keyManager1 = new DummyKeyManager1(keyType);
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(keyType);
 
-       // Register the key manager with new_key_allowed and test that it is
-       // possible to create a new key data.
-       Registry.registerKeyManager(keyManager1);
-       await Registry.newKeyData(keyTemplate);
+		// Register the key manager with new_key_allowed and test that it is
+		// possible to create a new key data.
+		Registry.registerKeyManager(keyManager1);
+		await Registry.newKeyData(keyTemplate);
 
-       // Restrict the key manager and test that new key data cannot be created.
-       Registry.registerKeyManager(keyManager1, false);
-       try {
-         await Registry.newKeyData(keyTemplate);
-       } catch (e: any) {
-         expect(e.toString()).toBe(ExceptionText.newKeyForbidden(keyType));
-         return;
-       }
-       fail('An exception should be thrown.');
-     });
+		// Restrict the key manager and test that new key data cannot be created.
+		Registry.registerKeyManager(keyManager1, false);
+		try {
+			await Registry.newKeyData(keyTemplate);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.newKeyForbidden(keyType));
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('register key manager, less restrictive new key allowed',
-     async function() {
-       const keyType = 'someTypeUrl';
-       const keyManager1 = new DummyKeyManager1(keyType);
-       const keyTemplate = new PbKeyTemplate().setTypeUrl(keyType);
+	it("register key manager, less restrictive new key allowed", async () => {
+		const keyType = "someTypeUrl";
+		const keyManager1 = new DummyKeyManager1(keyType);
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(keyType);
 
-       Registry.registerKeyManager(keyManager1, false);
+		Registry.registerKeyManager(keyManager1, false);
 
-       // Re-registering key manager with less restrictive setting should not be
-       // possible and the restriction has to be still true (i.e. new key data
-       // cannot be created).
-       try {
-         Registry.registerKeyManager(keyManager1);
-         fail('An exception should be thrown.');
-       } catch (e: any) {
-         expect(e.toString())
-             .toBe(ExceptionText.prohibitedChangeToLessRestricted(
-                 keyManager1.getKeyType()));
-       }
-       try {
-         await Registry.newKeyData(keyTemplate);
-       } catch (e: any) {
-         expect(e.toString()).toBe(ExceptionText.newKeyForbidden(keyType));
-         return;
-       }
-       fail('An exception should be thrown.');
-     });
+		// Re-registering key manager with less restrictive setting should not be
+		// possible and the restriction has to be still true (i.e. new key data
+		// cannot be created).
+		try {
+			Registry.registerKeyManager(keyManager1);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.prohibitedChangeToLessRestricted(
+					keyManager1.getKeyType()
+				)
+			);
+		}
+		try {
+			await Registry.newKeyData(keyTemplate);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.newKeyForbidden(keyType));
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getKeyManager method
-  it('get key manager, should work', function() {
-    const numberOfKeyManagers = 10;
-    const keyManagers1 = [];
-    const keyManagers2 = [];
-    for (let i = 0; i < numberOfKeyManagers; i++) {
-      keyManagers1.push(new DummyKeyManager1('someKeyType' + i.toString()));
-      keyManagers2.push(new DummyKeyManager2('otherKeyType' + i.toString()));
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getKeyManager method
+	it("get key manager, should work", () => {
+		const numberOfKeyManagers = 10;
+		const keyManagers1 = [];
+		const keyManagers2 = [];
+		for (let i = 0; i < numberOfKeyManagers; i++) {
+			keyManagers1.push(
+				new DummyKeyManager1("someKeyType" + i.toString())
+			);
+			keyManagers2.push(
+				new DummyKeyManager2("otherKeyType" + i.toString())
+			);
 
-      Registry.registerKeyManager(keyManagers1[i]);
-      Registry.registerKeyManager(keyManagers2[i]);
-    }
+			Registry.registerKeyManager(keyManagers1[i]);
+			Registry.registerKeyManager(keyManagers2[i]);
+		}
 
-    let result;
-    for (let i = 0; i < numberOfKeyManagers; i++) {
-      result = Registry.getKeyManager(keyManagers1[i].getKeyType());
-      expect(result).toEqual(keyManagers1[i]);
+		let result;
+		for (let i = 0; i < numberOfKeyManagers; i++) {
+			result = Registry.getKeyManager(keyManagers1[i].getKeyType());
+			expect(result).toEqual(keyManagers1[i]);
 
-      result = Registry.getKeyManager(keyManagers2[i].getKeyType());
-      expect(result).toEqual(keyManagers2[i]);
-    }
-  });
+			result = Registry.getKeyManager(keyManagers2[i].getKeyType());
+			expect(result).toEqual(keyManagers2[i]);
+		}
+	});
 
-  it('get key manager, not registered key type', function() {
-    const keyType = 'some_key_type';
+	it("get key manager, not registered key type", () => {
+		const keyType = "some_key_type";
 
-    try {
-      Registry.getKeyManager(keyType);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notRegisteredKeyType(keyType));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Registry.getKeyManager(keyType);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.notRegisteredKeyType(keyType)
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for newKeyData method
-  it('new key data, no manager for given key type', async function() {
-    const keyManager1 = new DummyKeyManager1('someKeyType');
-    const differentKeyType = 'otherKeyType';
-    const keyTemplate = new PbKeyTemplate().setTypeUrl(differentKeyType);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for newKeyData method
+	it("new key data, no manager for given key type", async () => {
+		const keyManager1 = new DummyKeyManager1("someKeyType");
+		const differentKeyType = "otherKeyType";
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(differentKeyType);
 
-    Registry.registerKeyManager(keyManager1);
-    try {
-      await Registry.newKeyData(keyTemplate);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.notRegisteredKeyType(differentKeyType));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		Registry.registerKeyManager(keyManager1);
+		try {
+			await Registry.newKeyData(keyTemplate);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.notRegisteredKeyType(differentKeyType)
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('new key data, new key disallowed', async function() {
-    const keyManager1 = new DummyKeyManager1('someKeyType');
-    const keyTemplate =
-        new PbKeyTemplate().setTypeUrl(keyManager1.getKeyType());
+	it("new key data, new key disallowed", async () => {
+		const keyManager1 = new DummyKeyManager1("someKeyType");
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(
+			keyManager1.getKeyType()
+		);
 
-    Registry.registerKeyManager(keyManager1, false);
-    try {
-      await Registry.newKeyData(keyTemplate);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.newKeyForbidden(keyManager1.getKeyType()));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		Registry.registerKeyManager(keyManager1, false);
+		try {
+			await Registry.newKeyData(keyTemplate);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.newKeyForbidden(keyManager1.getKeyType())
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('new key data, new key allowed', async function() {
-    const keyTypes: string[] = [];
-    for (let i = 0; i < 10; i++) {
-      keyTypes.push('someKeyType' + i.toString());
-    }
+	it("new key data, new key allowed", async () => {
+		const keyTypes: string[] = [];
+		for (let i = 0; i < 10; i++) {
+			keyTypes.push("someKeyType" + i.toString());
+		}
 
-    const keyTypesLength = keyTypes.length;
-    for (let i = 0; i < keyTypesLength; i++) {
-      Registry.registerKeyManager(new DummyKeyManager1(keyTypes[i]), true);
-    }
+		const keyTypesLength = keyTypes.length;
+		for (let i = 0; i < keyTypesLength; i++) {
+			Registry.registerKeyManager(
+				new DummyKeyManager1(keyTypes[i]),
+				true
+			);
+		}
 
-    for (let i = 0; i < keyTypesLength; i++) {
-      const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
-      const result = await Registry.newKeyData(keyTemplate);
-      expect(result.getTypeUrl()).toBe(keyTypes[i]);
-    }
-  });
+		for (let i = 0; i < keyTypesLength; i++) {
+			const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
+			const result = await Registry.newKeyData(keyTemplate);
+			expect(result.getTypeUrl()).toBe(keyTypes[i]);
+		}
+	});
 
-  it('new key data, new key is allowed automatically', async function() {
-    const keyTypes: string[] = [];
-    for (let i = 0; i < 10; i++) {
-      keyTypes.push('someKeyType' + i.toString());
-    }
+	it("new key data, new key is allowed automatically", async () => {
+		const keyTypes: string[] = [];
+		for (let i = 0; i < 10; i++) {
+			keyTypes.push("someKeyType" + i.toString());
+		}
 
-    const keyTypesLength = keyTypes.length;
-    for (let i = 0; i < keyTypesLength; i++) {
-      Registry.registerKeyManager(new DummyKeyManager1(keyTypes[i]));
-    }
+		const keyTypesLength = keyTypes.length;
+		for (let i = 0; i < keyTypesLength; i++) {
+			Registry.registerKeyManager(new DummyKeyManager1(keyTypes[i]));
+		}
 
-    for (let i = 0; i < keyTypesLength; i++) {
-      const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
-      const result = await Registry.newKeyData(keyTemplate);
-      expect(result.getTypeUrl()).toBe(keyTypes[i]);
-    }
-  });
+		for (let i = 0; i < keyTypesLength; i++) {
+			const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
+			const result = await Registry.newKeyData(keyTemplate);
+			expect(result.getTypeUrl()).toBe(keyTypes[i]);
+		}
+	});
 
-  it('new key data, with aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    Registry.registerKeyManager(manager);
-    const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
-    const keyData = await Registry.newKeyData(keyTemplate);
+	it("new key data, with aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		Registry.registerKeyManager(manager);
+		const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
+		const keyData = await Registry.newKeyData(keyTemplate);
 
-    // Checks that correct AES CTR HMAC AEAD key was returned.
-    const keyFormat =
-        PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyTemplate.getValue());
-    const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
-    // Check AES CTR key.
-    expect(keyFormat.getAesCtrKeyFormat()?.getKeySize())
-        .toBe(bytesLength(key.getAesCtrKey()?.getKeyValue()));
-    expect(keyFormat.getAesCtrKeyFormat()?.getParams())
-        .toEqual(key.getAesCtrKey()?.getParams());
-    // Check HMAC key.
-    expect(keyFormat.getHmacKeyFormat()?.getKeySize())
-        .toBe(bytesLength(key.getHmacKey()?.getKeyValue()));
-    expect(keyFormat.getHmacKeyFormat()?.getParams())
-        .toEqual(key.getHmacKey()?.getParams());
-  });
+		// Checks that correct AES CTR HMAC AEAD key was returned.
+		const keyFormat = PbAesCtrHmacAeadKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
+		// Check AES CTR key.
+		expect(keyFormat.getAesCtrKeyFormat()?.getKeySize()).toBe(
+			bytesLength(key.getAesCtrKey()?.getKeyValue())
+		);
+		expect(keyFormat.getAesCtrKeyFormat()?.getParams()).toEqual(
+			key.getAesCtrKey()?.getParams()
+		);
+		// Check HMAC key.
+		expect(keyFormat.getHmacKeyFormat()?.getKeySize()).toBe(
+			bytesLength(key.getHmacKey()?.getKeyValue())
+		);
+		expect(keyFormat.getHmacKeyFormat()?.getParams()).toEqual(
+			key.getHmacKey()?.getParams()
+		);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for newKey method
-  it('new key, no manager for given key type', async function() {
-    const notRegisteredKeyType = 'not_registered_key_type';
-    const keyTemplate = new PbKeyTemplate().setTypeUrl(notRegisteredKeyType);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for newKey method
+	it("new key, no manager for given key type", async () => {
+		const notRegisteredKeyType = "not_registered_key_type";
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(
+			notRegisteredKeyType
+		);
 
-    try {
-      await Registry.newKey(keyTemplate);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.notRegisteredKeyType(notRegisteredKeyType));
-    }
-  });
+		try {
+			await Registry.newKey(keyTemplate);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.notRegisteredKeyType(notRegisteredKeyType)
+			);
+		}
+	});
 
-  it('new key, new key disallowed', async function() {
-    const keyManager = new DummyKeyManagerForNewKeyTests('someKeyType');
-    const keyTemplate = new PbKeyTemplate().setTypeUrl(keyManager.getKeyType());
-    Registry.registerKeyManager(keyManager, /* opt_newKeyAllowed = */ false);
+	it("new key, new key disallowed", async () => {
+		const keyManager = new DummyKeyManagerForNewKeyTests("someKeyType");
+		const keyTemplate = new PbKeyTemplate().setTypeUrl(
+			keyManager.getKeyType()
+		);
+		Registry.registerKeyManager(
+			keyManager,
+			/* opt_newKeyAllowed = */ false
+		);
 
-    try {
-      await Registry.newKey(keyTemplate);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.newKeyForbidden(keyManager.getKeyType()));
-    }
-  });
+		try {
+			await Registry.newKey(keyTemplate);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.newKeyForbidden(keyManager.getKeyType())
+			);
+		}
+	});
 
-  it('new key, should work', async function() {
-    const keyTypes: string[] = [];
-    const newKeyMethodResult: Uint8Array[] = [];
-    const keyTypesLength = 10;
+	it("new key, should work", async () => {
+		const keyTypes: string[] = [];
+		const newKeyMethodResult: Uint8Array[] = [];
+		const keyTypesLength = 10;
 
-    // Add some keys to Registry.
-    for (let i = 0; i < keyTypesLength; i++) {
-      keyTypes.push('someKeyType' + i.toString());
-      newKeyMethodResult.push(new Uint8Array([i + 1]));
+		// Add some keys to Registry.
+		for (let i = 0; i < keyTypesLength; i++) {
+			keyTypes.push("someKeyType" + i.toString());
+			newKeyMethodResult.push(new Uint8Array([i + 1]));
 
-      Registry.registerKeyManager(
-          new DummyKeyManagerForNewKeyTests(keyTypes[i], newKeyMethodResult[i]),
-          /* newKeyAllowed = */ true);
-    }
+			Registry.registerKeyManager(
+				new DummyKeyManagerForNewKeyTests(
+					keyTypes[i],
+					newKeyMethodResult[i]
+				),
+				/* newKeyAllowed = */ true
+			);
+		}
 
-    // For every keyType verify that it calls new key method of the
-    // corresponding KeyManager (KeyFactory).
-    for (let i = 0; i < keyTypesLength; i++) {
-      const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
+		// For every keyType verify that it calls new key method of the
+		// corresponding KeyManager (KeyFactory).
+		for (let i = 0; i < keyTypesLength; i++) {
+			const keyTemplate = new PbKeyTemplate().setTypeUrl(keyTypes[i]);
 
-      const key =
-          assertInstanceof(await Registry.newKey(keyTemplate), PbAesCtrKey);
+			const key = assertInstanceof(
+				await Registry.newKey(keyTemplate),
+				PbAesCtrKey
+			);
 
-      // The new key method of DummyKeyFactory returns an AesCtrKey which
-      // KeyValue is set to corresponding value in newKeyMethodResult.
-      expect(bytesAsU8(key.getKeyValue())).toEqual(newKeyMethodResult[i]);
-    }
-  });
-  it('new key, with aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    Registry.registerKeyManager(manager);
-    const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
+			// The new key method of DummyKeyFactory returns an AesCtrKey which
+			// KeyValue is set to corresponding value in newKeyMethodResult.
+			expect(bytesAsU8(key.getKeyValue())).toEqual(newKeyMethodResult[i]);
+		}
+	});
+	it("new key, with aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		Registry.registerKeyManager(manager);
+		const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
 
-    const key = assertInstanceof(
-        await Registry.newKey(keyTemplate), PbAesCtrHmacAeadKey);
+		const key = assertInstanceof(
+			await Registry.newKey(keyTemplate),
+			PbAesCtrHmacAeadKey
+		);
 
-    // Checks that correct AES CTR HMAC AEAD key was returned.
-    const keyFormat =
-        PbAesCtrHmacAeadKeyFormat.deserializeBinary(keyTemplate.getValue());
-    // Check AES CTR key.
-    expect(keyFormat.getAesCtrKeyFormat()?.getKeySize())
-        .toBe(bytesLength(key.getAesCtrKey()?.getKeyValue()));
-    expect(keyFormat.getAesCtrKeyFormat()?.getParams())
-        .toEqual(key.getAesCtrKey()?.getParams());
-    // Check HMAC key.
-    expect(keyFormat.getHmacKeyFormat()?.getKeySize())
-        .toBe(bytesLength(key.getHmacKey()?.getKeyValue()));
-    expect(keyFormat.getHmacKeyFormat()?.getParams())
-        .toEqual(key.getHmacKey()?.getParams());
-  });
+		// Checks that correct AES CTR HMAC AEAD key was returned.
+		const keyFormat = PbAesCtrHmacAeadKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		// Check AES CTR key.
+		expect(keyFormat.getAesCtrKeyFormat()?.getKeySize()).toBe(
+			bytesLength(key.getAesCtrKey()?.getKeyValue())
+		);
+		expect(keyFormat.getAesCtrKeyFormat()?.getParams()).toEqual(
+			key.getAesCtrKey()?.getParams()
+		);
+		// Check HMAC key.
+		expect(keyFormat.getHmacKeyFormat()?.getKeySize()).toBe(
+			bytesLength(key.getHmacKey()?.getKeyValue())
+		);
+		expect(keyFormat.getHmacKeyFormat()?.getParams()).toEqual(
+			key.getHmacKey()?.getParams()
+		);
+	});
 
-  /////////////////////////////////////////////////////////////////////////////
-  // tests for getPrimitive method
-  it('get primitive, different key types', async function() {
-    const keyDataType = 'key_data_key_type_url';
-    const anotherType = 'another_key_type_url';
-    const keyData = new PbKeyData().setTypeUrl(keyDataType);
+	/////////////////////////////////////////////////////////////////////////////
+	// tests for getPrimitive method
+	it("get primitive, different key types", async () => {
+		const keyDataType = "key_data_key_type_url";
+		const anotherType = "another_key_type_url";
+		const keyData = new PbKeyData().setTypeUrl(keyDataType);
 
-    try {
-      await Registry.getPrimitive(Aead, keyData, anotherType);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.keyTypesAreNotMatching(keyDataType, anotherType));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			await Registry.getPrimitive(Aead, keyData, anotherType);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.keyTypesAreNotMatching(keyDataType, anotherType)
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('get primitive, without defining key type', async function() {
-    // Get primitive from key proto without key type.
-    try {
-      await Registry.getPrimitive(Aead, new PbHmacParams());
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.keyTypeNotDefined());
-    }
-  });
+	it("get primitive, without defining key type", async () => {
+		// Get primitive from key proto without key type.
+		try {
+			await Registry.getPrimitive(Aead, new PbHmacParams());
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.keyTypeNotDefined());
+		}
+	});
 
-  it('get primitive, missing key manager', async function() {
-    const keyDataType = 'key_data_key_type_url';
-    const keyData = new PbKeyData().setTypeUrl(keyDataType);
+	it("get primitive, missing key manager", async () => {
+		const keyDataType = "key_data_key_type_url";
+		const keyData = new PbKeyData().setTypeUrl(keyDataType);
 
-    try {
-      await Registry.getPrimitive(Aead, keyData);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.notRegisteredKeyType(keyDataType));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			await Registry.getPrimitive(Aead, keyData);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.notRegisteredKeyType(keyDataType)
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('get primitive, from aes ctr hmac aead key data', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    Registry.registerKeyManager(manager);
-    const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
-    const keyData = await Registry.newKeyData(keyTemplate);
+	it("get primitive, from aes ctr hmac aead key data", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		Registry.registerKeyManager(manager);
+		const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
+		const keyData = await Registry.newKeyData(keyTemplate);
 
-    const primitive =
-        await Registry.getPrimitive(manager.getPrimitiveType(), keyData);
-    expect(primitive instanceof EncryptThenAuthenticate).toBe(true);
-  });
+		const primitive = await Registry.getPrimitive(
+			manager.getPrimitiveType(),
+			keyData
+		);
+		expect(primitive instanceof EncryptThenAuthenticate).toBe(true);
+	});
 
-  it('get primitive, from aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    Registry.registerKeyManager(manager);
-    const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
-    const keyData = await Registry.newKeyData(keyTemplate);
-    const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
+	it("get primitive, from aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		Registry.registerKeyManager(manager);
+		const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
+		const keyData = await Registry.newKeyData(keyTemplate);
+		const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
 
-    const primitive = await Registry.getPrimitive(
-        manager.getPrimitiveType(), key, keyData.getTypeUrl());
-    expect(primitive instanceof EncryptThenAuthenticate).toBe(true);
-  });
+		const primitive = await Registry.getPrimitive(
+			manager.getPrimitiveType(),
+			key,
+			keyData.getTypeUrl()
+		);
+		expect(primitive instanceof EncryptThenAuthenticate).toBe(true);
+	});
 
-  it('get primitive, mac from aes ctr hmac aead key', async function() {
-    const manager = new AesCtrHmacAeadKeyManager();
-    Registry.registerKeyManager(manager);
-    const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
-    const keyData = await Registry.newKeyData(keyTemplate);
-    const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
+	it("get primitive, mac from aes ctr hmac aead key", async () => {
+		const manager = new AesCtrHmacAeadKeyManager();
+		Registry.registerKeyManager(manager);
+		const keyTemplate = createAesCtrHmacAeadTestKeyTemplate();
+		const keyData = await Registry.newKeyData(keyTemplate);
+		const key = PbAesCtrHmacAeadKey.deserializeBinary(keyData.getValue());
 
-    try {
-      await Registry.getPrimitive(Mac, key, keyData.getTypeUrl());
-    } catch (e: any) {
-      expect(e.toString().includes(ExceptionText.getPrimitiveBadPrimitive()))
-          .toBe(true);
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			await Registry.getPrimitive(Mac, key, keyData.getTypeUrl());
+		} catch (e: any) {
+			expect(
+				e.toString().includes(ExceptionText.getPrimitiveBadPrimitive())
+			).toBe(true);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  describe('get public key data', function() {
-    it('not private key factory', function() {
-      AeadConfig.register();
-      const notPrivateTypeUrl = AeadConfig.AES_GCM_TYPE_URL;
-      try {
-        Registry.getPublicKeyData(notPrivateTypeUrl, new Uint8Array(8));
-        fail('An exception should be thrown.');
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe(ExceptionText.notPrivateKeyFactory(notPrivateTypeUrl));
-      }
-    });
+	describe("get public key data", () => {
+		it("not private key factory", () => {
+			AeadConfig.register();
+			const notPrivateTypeUrl = AeadConfig.AES_GCM_TYPE_URL;
+			try {
+				Registry.getPublicKeyData(notPrivateTypeUrl, new Uint8Array(8));
+				fail("An exception should be thrown.");
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					ExceptionText.notPrivateKeyFactory(notPrivateTypeUrl)
+				);
+			}
+		});
 
-    it('invalid private key proto serialization', function() {
-      HybridConfig.register();
-      const typeUrl = HybridConfig.ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE;
-      try {
-        Registry.getPublicKeyData(typeUrl, new Uint8Array(10));
-        fail('An exception should be thrown.');
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.couldNotParse(typeUrl));
-      }
-    });
+		it("invalid private key proto serialization", () => {
+			HybridConfig.register();
+			const typeUrl = HybridConfig.ECIES_AEAD_HKDF_PRIVATE_KEY_TYPE;
+			try {
+				Registry.getPublicKeyData(typeUrl, new Uint8Array(10));
+				fail("An exception should be thrown.");
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.couldNotParse(typeUrl));
+			}
+		});
 
-    it('should work', async function() {
-      HybridConfig.register();
-      const privateKeyData = await Registry.newKeyData(
-          HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm());
-      const privateKey = PbEciesAeadHkdfPrivateKey.deserializeBinary(
-          privateKeyData.getValue());
+		it("should work", async () => {
+			HybridConfig.register();
+			const privateKeyData = await Registry.newKeyData(
+				HybridKeyTemplates.eciesP256HkdfHmacSha256Aes128Gcm()
+			);
+			const privateKey = PbEciesAeadHkdfPrivateKey.deserializeBinary(
+				privateKeyData.getValue()
+			);
 
-      const publicKeyData = Registry.getPublicKeyData(
-          privateKeyData.getTypeUrl(), bytesAsU8(privateKeyData.getValue()));
-      expect(HybridConfig.ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE)
-          .toBe(publicKeyData.getTypeUrl());
-      expect(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC)
-          .toBe(publicKeyData.getKeyMaterialType());
+			const publicKeyData = Registry.getPublicKeyData(
+				privateKeyData.getTypeUrl(),
+				bytesAsU8(privateKeyData.getValue())
+			);
+			expect(HybridConfig.ECIES_AEAD_HKDF_PUBLIC_KEY_TYPE).toBe(
+				publicKeyData.getTypeUrl()
+			);
+			expect(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC).toBe(
+				publicKeyData.getKeyMaterialType()
+			);
 
-      const expectedPublicKey = assertExists(privateKey.getPublicKey());
-      const publicKey =
-          PbEciesAeadHkdfPublicKey.deserializeBinary(publicKeyData.getValue());
-      expect(publicKey).toEqual(expectedPublicKey);
-    });
-  });
+			const expectedPublicKey = assertExists(privateKey.getPublicKey());
+			const publicKey = PbEciesAeadHkdfPublicKey.deserializeBinary(
+				publicKeyData.getValue()
+			);
+			expect(publicKey).toEqual(expectedPublicKey);
+		});
+	});
 });
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -501,293 +590,338 @@ describe('registry test', function() {
  * @final
  */
 class ExceptionText {
-  static notImplemented(): string {
-    return 'SecurityException: Not implemented yet.';
-  }
+	static notImplemented(): string {
+		return "SecurityException: Not implemented yet.";
+	}
 
-  static newKeyForbidden(keyType: string): string {
-    return 'SecurityException: New key operation is forbidden for key type: ' +
-        keyType + '.';
-  }
+	static newKeyForbidden(keyType: string): string {
+		return (
+			"SecurityException: New key operation is forbidden for key type: " +
+			keyType +
+			"."
+		);
+	}
 
-  static notRegisteredKeyType(keyType: string): string {
-    return 'SecurityException: Key manager for key type ' + keyType +
-        ' has not been registered.';
-  }
+	static notRegisteredKeyType(keyType: string): string {
+		return (
+			"SecurityException: Key manager for key type " +
+			keyType +
+			" has not been registered."
+		);
+	}
 
-  static nullKeyManager(): string {
-    return 'SecurityException: Key manager cannot be null.';
-  }
+	static nullKeyManager(): string {
+		return "SecurityException: Key manager cannot be null.";
+	}
 
-  static undefinedKeyType(): string {
-    return 'SecurityException: Key type has to be defined.';
-  }
+	static undefinedKeyType(): string {
+		return "SecurityException: Key type has to be defined.";
+	}
 
-  static keyManagerOverwrittingAttempt(keyType: string): string {
-    return 'SecurityException: Key manager for key type ' + keyType +
-        ' has already been registered and cannot be overwritten.';
-  }
+	static keyManagerOverwrittingAttempt(keyType: string): string {
+		return (
+			"SecurityException: Key manager for key type " +
+			keyType +
+			" has already been registered and cannot be overwritten."
+		);
+	}
 
-  static notSupportedKey(givenKeyType: string): string {
-    return 'SecurityException: The provided key manager does not support ' +
-        'key type ' + givenKeyType + '.';
-  }
+	static notSupportedKey(givenKeyType: string): string {
+		return (
+			"SecurityException: The provided key manager does not support " +
+			"key type " +
+			givenKeyType +
+			"."
+		);
+	}
 
-  static prohibitedChangeToLessRestricted(keyType: string): string {
-    return 'SecurityException: Key manager for key type ' + keyType +
-        ' has already been registered with forbidden new key operation.';
-  }
+	static prohibitedChangeToLessRestricted(keyType: string): string {
+		return (
+			"SecurityException: Key manager for key type " +
+			keyType +
+			" has already been registered with forbidden new key operation."
+		);
+	}
 
-  static keyTypesAreNotMatching(
-      keyTypeFromKeyData: string, keyTypeParam: string): string {
-    return 'SecurityException: Key type is ' + keyTypeParam +
-        ', but it is expected to be ' + keyTypeFromKeyData + ' or undefined.';
-  }
+	static keyTypesAreNotMatching(
+		keyTypeFromKeyData: string,
+		keyTypeParam: string
+	): string {
+		return (
+			"SecurityException: Key type is " +
+			keyTypeParam +
+			", but it is expected to be " +
+			keyTypeFromKeyData +
+			" or undefined."
+		);
+	}
 
-  static keyTypeNotDefined(): string {
-    return 'SecurityException: Key type has to be specified.';
-  }
+	static keyTypeNotDefined(): string {
+		return "SecurityException: Key type has to be specified.";
+	}
 
-  static nullKeysetHandle(): string {
-    return 'SecurityException: Keyset handle has to be non-null.';
-  }
+	static nullKeysetHandle(): string {
+		return "SecurityException: Keyset handle has to be non-null.";
+	}
 
-  static getPrimitiveBadPrimitive(): string {
-    return 'Requested primitive type which is not supported by this ' +
-        'key manager.';
-  }
+	static getPrimitiveBadPrimitive(): string {
+		return (
+			"Requested primitive type which is not supported by this " +
+			"key manager."
+		);
+	}
 
-  static notPrivateKeyFactory(typeUrl: string): string {
-    return 'SecurityException: Key manager for key type ' + typeUrl +
-        ' does not have a private key factory.';
-  }
+	static notPrivateKeyFactory(typeUrl: string): string {
+		return (
+			"SecurityException: Key manager for key type " +
+			typeUrl +
+			" does not have a private key factory."
+		);
+	}
 
-  static couldNotParse(typeUrl: string): string {
-    return 'SecurityException: Input cannot be parsed as ' + typeUrl +
-        ' key-proto.';
-  }
+	static couldNotParse(typeUrl: string): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			typeUrl +
+			" key-proto."
+		);
+	}
 }
 
 /** Creates AES CTR HMAC AEAD key format which can be used in tests */
 function createAesCtrHmacAeadTestKeyTemplate(): PbKeyTemplate {
-  const KEY_SIZE = 16;
-  const IV_SIZE = 12;
-  const TAG_SIZE = 16;
+	const KEY_SIZE = 16;
+	const IV_SIZE = 12;
+	const TAG_SIZE = 16;
 
-  const keyFormat = new PbAesCtrHmacAeadKeyFormat().setAesCtrKeyFormat(
-      new PbAesCtrKeyFormat());
-  keyFormat.getAesCtrKeyFormat()?.setKeySize(KEY_SIZE);
-  keyFormat.getAesCtrKeyFormat()?.setParams(new PbAesCtrParams());
-  keyFormat.getAesCtrKeyFormat()?.getParams()?.setIvSize(IV_SIZE);
+	const keyFormat = new PbAesCtrHmacAeadKeyFormat().setAesCtrKeyFormat(
+		new PbAesCtrKeyFormat()
+	);
+	keyFormat.getAesCtrKeyFormat()?.setKeySize(KEY_SIZE);
+	keyFormat.getAesCtrKeyFormat()?.setParams(new PbAesCtrParams());
+	keyFormat.getAesCtrKeyFormat()?.getParams()?.setIvSize(IV_SIZE);
 
-  // set HMAC key
-  keyFormat.setHmacKeyFormat(new PbHmacKeyFormat());
-  keyFormat.getHmacKeyFormat()?.setKeySize(KEY_SIZE);
-  keyFormat.getHmacKeyFormat()?.setParams(new PbHmacParams());
-  keyFormat.getHmacKeyFormat()?.getParams()?.setHash(PbHashType.SHA1);
-  keyFormat.getHmacKeyFormat()?.getParams()?.setTagSize(TAG_SIZE);
+	// set HMAC key
+	keyFormat.setHmacKeyFormat(new PbHmacKeyFormat());
+	keyFormat.getHmacKeyFormat()?.setKeySize(KEY_SIZE);
+	keyFormat.getHmacKeyFormat()?.setParams(new PbHmacParams());
+	keyFormat.getHmacKeyFormat()?.getParams()?.setHash(PbHashType.SHA1);
+	keyFormat.getHmacKeyFormat()?.getParams()?.setTagSize(TAG_SIZE);
 
-  let keyTemplate =
-      new PbKeyTemplate()
-          .setTypeUrl(
-              'type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey')
-          .setValue(keyFormat.serializeBinary());
-  return keyTemplate;
+	let keyTemplate = new PbKeyTemplate()
+		.setTypeUrl("type.googleapis.com/google.crypto.tink.AesCtrHmacAeadKey")
+		.setValue(keyFormat.serializeBinary());
+	return keyTemplate;
 }
 
 // Key factory and key manager classes used in tests
 
 /** @final */
 class DummyKeyFactory implements KeyManager.KeyFactory {
-  constructor(
-      private readonly keyType: string,
-      private readonly newKeyMethodResult = new Uint8Array(10)) {}
+	constructor(
+		private readonly keyType: string,
+		private readonly newKeyMethodResult = new Uint8Array(10)
+	) {}
 
-  /**
-   */
-  newKey(keyFormat: PbMessage|Uint8Array) {
-    const key = new PbAesCtrKey().setKeyValue(this.newKeyMethodResult);
-    return key;
-  }
+	/**
+	 */
+	newKey(keyFormat: PbMessage | Uint8Array) {
+		const key = new PbAesCtrKey().setKeyValue(this.newKeyMethodResult);
+		return key;
+	}
 
-  /**
-   */
-  newKeyData(serializedKeyFormat: Uint8Array) {
-    const keyData =
-        new PbKeyData()
-            .setTypeUrl(this.keyType)
-            .setValue(this.newKeyMethodResult)
-            .setKeyMaterialType(PbKeyData.KeyMaterialType.UNKNOWN_KEYMATERIAL);
+	/**
+	 */
+	newKeyData(serializedKeyFormat: Uint8Array) {
+		const keyData = new PbKeyData()
+			.setTypeUrl(this.keyType)
+			.setValue(this.newKeyMethodResult)
+			.setKeyMaterialType(PbKeyData.KeyMaterialType.UNKNOWN_KEYMATERIAL);
 
-    return keyData;
-  }
+		return keyData;
+	}
 }
 
 // Primitive abstract types for testing purposes.
 abstract class DummyPrimitive1 {
-  abstract operation1(): number;
+	abstract operation1(): number;
 }
 abstract class DummyPrimitive2 {
-  abstract operation2(): string;
+	abstract operation2(): string;
 }
 
 // Primitive implementations for testing purposes.
 class DummyPrimitive1Impl1 extends DummyPrimitive1 {
-  operation1() {
-    return 1;
-  }
+	operation1() {
+		return 1;
+	}
 }
 class DummyPrimitive1Impl2 extends DummyPrimitive1 {
-  operation1() {
-    return 2;
-  }
+	operation1() {
+		return 2;
+	}
 }
 class DummyPrimitive2Impl extends DummyPrimitive2 {
-  operation2() {
-    return 'dummy';
-  }
+	operation2() {
+		return "dummy";
+	}
 }
 
 const DEFAULT_PRIMITIVE_TYPE = Aead;
 
 /** @final */
 class DummyKeyManager1 implements KeyManager.KeyManager<DummyPrimitive1> {
-  private readonly KEY_FACTORY: KeyManager.KeyFactory;
+	private readonly KEY_FACTORY: KeyManager.KeyFactory;
 
-  constructor(
-      private readonly keyType: string,
-      private readonly primitive: DummyPrimitive1 = new DummyPrimitive1Impl1(),
-      private readonly primitiveType = DummyPrimitive1) {
-    this.KEY_FACTORY = new DummyKeyFactory(keyType);
-  }
+	constructor(
+		private readonly keyType: string,
+		private readonly primitive: DummyPrimitive1 = new DummyPrimitive1Impl1(),
+		private readonly primitiveType = DummyPrimitive1
+	) {
+		this.KEY_FACTORY = new DummyKeyFactory(keyType);
+	}
 
-  async getPrimitive(
-      primitiveType: Constructor<DummyKeyManager1>, key: PbKeyData|PbMessage) {
-    return this.primitive;
-  }
+	async getPrimitive(
+		primitiveType: Constructor<DummyKeyManager1>,
+		key: PbKeyData | PbMessage
+	) {
+		return this.primitive;
+	}
 
-  doesSupport(keyType: string) {
-    return keyType === this.getKeyType();
-  }
+	doesSupport(keyType: string) {
+		return keyType === this.getKeyType();
+	}
 
-  getKeyType() {
-    return this.keyType;
-  }
+	getKeyType() {
+		return this.keyType;
+	}
 
-  getPrimitiveType(): Constructor<DummyPrimitive1> {
-    return this.primitiveType;
-  }
+	getPrimitiveType(): Constructor<DummyPrimitive1> {
+		return this.primitiveType;
+	}
 
-  getVersion(): number {
-    throw new SecurityException('Not implemented, only for testing purposes.');
-  }
+	getVersion(): number {
+		throw new SecurityException(
+			"Not implemented, only for testing purposes."
+		);
+	}
 
-  getKeyFactory() {
-    return this.KEY_FACTORY;
-  }
+	getKeyFactory() {
+		return this.KEY_FACTORY;
+	}
 }
 
 /** @final */
 class DummyKeyManager2 implements KeyManager.KeyManager<DummyPrimitive2> {
-  private readonly KEY_FACTORY: KeyManager.KeyFactory;
+	private readonly KEY_FACTORY: KeyManager.KeyFactory;
 
-  constructor(
-      private readonly keyType: string,
-      private readonly primitive: DummyPrimitive2 = new DummyPrimitive2Impl(),
-      private readonly primitiveType = DummyPrimitive2) {
-    this.KEY_FACTORY = new DummyKeyFactory(keyType);
-  }
+	constructor(
+		private readonly keyType: string,
+		private readonly primitive: DummyPrimitive2 = new DummyPrimitive2Impl(),
+		private readonly primitiveType = DummyPrimitive2
+	) {
+		this.KEY_FACTORY = new DummyKeyFactory(keyType);
+	}
 
-  async getPrimitive(
-      primitiveType: Constructor<DummyKeyManager2>, key: PbKeyData|PbMessage) {
-    return this.primitive;
-  }
+	async getPrimitive(
+		primitiveType: Constructor<DummyKeyManager2>,
+		key: PbKeyData | PbMessage
+	) {
+		return this.primitive;
+	}
 
-  doesSupport(keyType: string) {
-    return keyType === this.getKeyType();
-  }
+	doesSupport(keyType: string) {
+		return keyType === this.getKeyType();
+	}
 
-  getKeyType() {
-    return this.keyType;
-  }
+	getKeyType() {
+		return this.keyType;
+	}
 
-  getPrimitiveType() {
-    return this.primitiveType;
-  }
+	getPrimitiveType() {
+		return this.primitiveType;
+	}
 
-  getVersion(): number {
-    throw new SecurityException('Not implemented, only for testing purposes.');
-  }
+	getVersion(): number {
+		throw new SecurityException(
+			"Not implemented, only for testing purposes."
+		);
+	}
 
-  getKeyFactory() {
-    return this.KEY_FACTORY;
-  }
+	getKeyFactory() {
+		return this.KEY_FACTORY;
+	}
 }
 
 /** @final */
 class DummyKeyManagerForNewKeyTests implements KeyManager.KeyManager<string> {
-  private readonly KEY_FACTORY: KeyManager.KeyFactory;
+	private readonly KEY_FACTORY: KeyManager.KeyFactory;
 
-  constructor(
-      private readonly keyType: string, opt_newKeyMethodResult?: Uint8Array) {
-    this.KEY_FACTORY = new DummyKeyFactory(keyType, opt_newKeyMethodResult);
-  }
+	constructor(
+		private readonly keyType: string,
+		opt_newKeyMethodResult?: Uint8Array
+	) {
+		this.KEY_FACTORY = new DummyKeyFactory(keyType, opt_newKeyMethodResult);
+	}
 
-  async getPrimitive(
-      primitiveType: Constructor<DummyKeyManagerForNewKeyTests>,
-      key: PbKeyData|PbMessage): Promise<string> {
-    throw new SecurityException('Not implemented, function is not needed.');
-  }
+	async getPrimitive(
+		primitiveType: Constructor<DummyKeyManagerForNewKeyTests>,
+		key: PbKeyData | PbMessage
+	): Promise<string> {
+		throw new SecurityException("Not implemented, function is not needed.");
+	}
 
-  doesSupport(keyType: string) {
-    return keyType === this.getKeyType();
-  }
+	doesSupport(keyType: string) {
+		return keyType === this.getKeyType();
+	}
 
-  getKeyType() {
-    return this.keyType;
-  }
+	getKeyType() {
+		return this.keyType;
+	}
 
-  getPrimitiveType(): never {
-    throw new SecurityException('Not implemented, function is not needed.');
-  }
+	getPrimitiveType(): never {
+		throw new SecurityException("Not implemented, function is not needed.");
+	}
 
-  getVersion(): never {
-    throw new SecurityException('Not implemented, function is not needed.');
-  }
+	getVersion(): never {
+		throw new SecurityException("Not implemented, function is not needed.");
+	}
 
-  getKeyFactory() {
-    return this.KEY_FACTORY;
-  }
+	getKeyFactory() {
+		return this.KEY_FACTORY;
+	}
 }
 
 // PrimitiveWrapper classes for testing purposes
 
 /** @final */
 class DummyPrimitiveWrapper1 implements PrimitiveWrapper<DummyPrimitive1> {
-  constructor(
-      private readonly primitive: DummyPrimitive1,
-      private readonly primitiveType: Constructor<DummyPrimitive1>) {}
+	constructor(
+		private readonly primitive: DummyPrimitive1,
+		private readonly primitiveType: Constructor<DummyPrimitive1>
+	) {}
 
-  wrap(primitiveSet: PrimitiveSet.PrimitiveSet<DummyPrimitive1>) {
-    return this.primitive;
-  }
+	wrap(primitiveSet: PrimitiveSet.PrimitiveSet<DummyPrimitive1>) {
+		return this.primitive;
+	}
 
-  getPrimitiveType() {
-    return this.primitiveType;
-  }
+	getPrimitiveType() {
+		return this.primitiveType;
+	}
 }
 
 /** @final */
 class DummyPrimitiveWrapper2 implements PrimitiveWrapper<DummyPrimitive2> {
-  constructor(
-      private readonly primitive: DummyPrimitive2,
-      private readonly primitiveType: Constructor<DummyPrimitive2>) {}
+	constructor(
+		private readonly primitive: DummyPrimitive2,
+		private readonly primitiveType: Constructor<DummyPrimitive2>
+	) {}
 
-  wrap(primitiveSet: PrimitiveSet.PrimitiveSet<DummyPrimitive2>) {
-    return this.primitive;
-  }
+	wrap(primitiveSet: PrimitiveSet.PrimitiveSet<DummyPrimitive2>) {
+		return this.primitive;
+	}
 
-  getPrimitiveType() {
-    return this.primitiveType;
-  }
+	getPrimitiveType() {
+		return this.primitiveType;
+	}
 }

--- a/javascript/internal/util_test.ts
+++ b/javascript/internal/util_test.ts
@@ -4,226 +4,266 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as EllipticCurves from '../subtle/elliptic_curves';
+import * as EllipticCurves from "../subtle/elliptic_curves";
 
-import {PbEllipticCurveType, PbHashType, PbKeyData, PbKeyset, PbKeysetKey, PbKeyStatusType, PbOutputPrefixType, PbPointFormat} from './proto';
-import * as Util from './util';
+import {
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyData,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+	PbPointFormat,
+} from "./proto";
+import * as Util from "./util";
 
 ////////////////////////////////////////////////////////////////////////////////
 // tests
 ////////////////////////////////////////////////////////////////////////////////
 
-describe('util test', function() {
-  // tests for validateKey method
-  it('validate key missing key data', async function() {
-    const key = createKey().setKeyData(null);
+describe("util test", () => {
+	// tests for validateKey method
+	it("validate key missing key data", async () => {
+		const key = createKey().setKeyData(null);
 
-    try {
-      Util.validateKey(key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.InvalidKeyMissingKeyData(key.getKeyId()));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKey(key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeyMissingKeyData(key.getKeyId())
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate key unknown prefix', async function() {
-    const key =
-        createKey().setOutputPrefixType(PbOutputPrefixType.UNKNOWN_PREFIX);
+	it("validate key unknown prefix", async () => {
+		const key = createKey().setOutputPrefixType(
+			PbOutputPrefixType.UNKNOWN_PREFIX
+		);
 
-    try {
-      Util.validateKey(key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.InvalidKeyUnknownPrefix(key.getKeyId()));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKey(key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeyUnknownPrefix(key.getKeyId())
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate key unknown status', async function() {
-    const key = createKey().setStatus(PbKeyStatusType.UNKNOWN_STATUS);
+	it("validate key unknown status", async () => {
+		const key = createKey().setStatus(PbKeyStatusType.UNKNOWN_STATUS);
 
-    try {
-      Util.validateKey(key);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKey(key);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeyUnknownStatus(key.getKeyId())
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate key valid keys', async function() {
-    Util.validateKey(createKey());
-    Util.validateKey(
-        createKey(/* opt_keyId = */ 0xAABBCCDD, /* opt_enabled = */ true));
-    Util.validateKey(
-        createKey(/* opt_keyId = */ 0xABCDABCD, /* opt_enabled = */ false));
-  });
+	it("validate key valid keys", async () => {
+		Util.validateKey(createKey());
+		Util.validateKey(
+			createKey(/* opt_keyId = */ 0xaabbccdd, /* opt_enabled = */ true)
+		);
+		Util.validateKey(
+			createKey(/* opt_keyId = */ 0xabcdabcd, /* opt_enabled = */ false)
+		);
+	});
 
-  // tests for validateKeyset method
-  it('validate keyset without keys', async function() {
-    const keyset = new PbKeyset();
+	// tests for validateKeyset method
+	it("validate keyset without keys", async () => {
+		const keyset = new PbKeyset();
 
-    try {
-      Util.validateKeyset(keyset);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.InvalidKeysetMissingKeys());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKeyset(keyset);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.InvalidKeysetMissingKeys());
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate keyset disabled primary', async function() {
-    const keyset = createKeyset();
-    keyset.addKey(
-        createKey(/* opt_id = */ 0xFFFFFFFF, /* opt_enabled = */ false));
-    keyset.setPrimaryKeyId(0xFFFFFFFF);
+	it("validate keyset disabled primary", async () => {
+		const keyset = createKeyset();
+		keyset.addKey(
+			createKey(/* opt_id = */ 0xffffffff, /* opt_enabled = */ false)
+		);
+		keyset.setPrimaryKeyId(0xffffffff);
 
-    try {
-      Util.validateKeyset(keyset);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.InvalidKeysetDisabledPrimary());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKeyset(keyset);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeysetDisabledPrimary()
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate keyset multiple primaries', async function() {
-    const keyset = createKeyset();
-    const key =
-        createKey(/* opt_id = */ 0xFFFFFFFF, /* opt_enabled = */ true);
-    keyset.addKey(key);
-    keyset.addKey(key);
-    keyset.setPrimaryKeyId(0xFFFFFFFF);
+	it("validate keyset multiple primaries", async () => {
+		const keyset = createKeyset();
+		const key = createKey(
+			/* opt_id = */ 0xffffffff,
+			/* opt_enabled = */ true
+		);
+		keyset.addKey(key);
+		keyset.addKey(key);
+		keyset.setPrimaryKeyId(0xffffffff);
 
-    try {
-      Util.validateKeyset(keyset);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.InvalidKeysetMultiplePrimaries());
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKeyset(keyset);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeysetMultiplePrimaries()
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate keyset with invalid key', async function() {
-    const keyset = createKeyset();
-    const key =
-        createKey(4294967295, true).setStatus(PbKeyStatusType.UNKNOWN_STATUS);
-    keyset.addKey(key);
+	it("validate keyset with invalid key", async () => {
+		const keyset = createKeyset();
+		const key = createKey(4294967295, true).setStatus(
+			PbKeyStatusType.UNKNOWN_STATUS
+		);
+		keyset.addKey(key);
 
-    try {
-      Util.validateKeyset(keyset);
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.InvalidKeyUnknownStatus(key.getKeyId()));
-      return;
-    }
-    fail('An exception should be thrown.');
-  });
+		try {
+			Util.validateKeyset(keyset);
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.InvalidKeyUnknownStatus(key.getKeyId())
+			);
+			return;
+		}
+		fail("An exception should be thrown.");
+	});
 
-  it('validate keyset with valid keyset', async function() {
-    const keyset = createKeyset();
+	it("validate keyset with valid keyset", async () => {
+		const keyset = createKeyset();
 
-    Util.validateKeyset(keyset);
-  });
+		Util.validateKeyset(keyset);
+	});
 
-  // tests for protoToSubtle methods
-  it('curve type proto to subtle', function() {
-    expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P256))
-        .toBe(EllipticCurves.CurveType.P256);
-    expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P384))
-        .toBe(EllipticCurves.CurveType.P384);
-    expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P521))
-        .toBe(EllipticCurves.CurveType.P521);
-  });
+	// tests for protoToSubtle methods
+	it("curve type proto to subtle", () => {
+		expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P256)).toBe(
+			EllipticCurves.CurveType.P256
+		);
+		expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P384)).toBe(
+			EllipticCurves.CurveType.P384
+		);
+		expect(Util.curveTypeProtoToSubtle(PbEllipticCurveType.NIST_P521)).toBe(
+			EllipticCurves.CurveType.P521
+		);
+	});
 
-  it('point format proto to subtle', function() {
-    expect(Util.pointFormatProtoToSubtle(PbPointFormat.UNCOMPRESSED))
-        .toBe(EllipticCurves.PointFormatType.UNCOMPRESSED);
-    expect(Util.pointFormatProtoToSubtle(PbPointFormat.COMPRESSED))
-        .toBe(EllipticCurves.PointFormatType.COMPRESSED);
-    expect(Util.pointFormatProtoToSubtle(
-               PbPointFormat.DO_NOT_USE_CRUNCHY_UNCOMPRESSED))
-        .toBe(EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED);
-  });
+	it("point format proto to subtle", () => {
+		expect(Util.pointFormatProtoToSubtle(PbPointFormat.UNCOMPRESSED)).toBe(
+			EllipticCurves.PointFormatType.UNCOMPRESSED
+		);
+		expect(Util.pointFormatProtoToSubtle(PbPointFormat.COMPRESSED)).toBe(
+			EllipticCurves.PointFormatType.COMPRESSED
+		);
+		expect(
+			Util.pointFormatProtoToSubtle(
+				PbPointFormat.DO_NOT_USE_CRUNCHY_UNCOMPRESSED
+			)
+		).toBe(EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED);
+	});
 
-  it('hash type proto to string', function() {
-    expect(Util.hashTypeProtoToString(PbHashType.SHA1)).toBe('SHA-1');
-    expect(Util.hashTypeProtoToString(PbHashType.SHA256)).toBe('SHA-256');
-    expect(Util.hashTypeProtoToString(PbHashType.SHA512)).toBe('SHA-512');
-  });
+	it("hash type proto to string", () => {
+		expect(Util.hashTypeProtoToString(PbHashType.SHA1)).toBe("SHA-1");
+		expect(Util.hashTypeProtoToString(PbHashType.SHA256)).toBe("SHA-256");
+		expect(Util.hashTypeProtoToString(PbHashType.SHA512)).toBe("SHA-512");
+	});
 });
-
 
 /**
  * Class which holds texts for each type of exception.
  * @final
  */
 class ExceptionText {
-  // Exceptions for invalid keys.
-  static InvalidKeyMissingKeyData(keyId: number): string {
-    return 'SecurityException: Key data are missing for key ' + keyId + '.';
-  }
-  static InvalidKeyUnknownPrefix(keyId: number): string {
-    return 'SecurityException: Key ' + keyId +
-        ' has unknown output prefix type.';
-  }
-  static InvalidKeyUnknownStatus(keyId: number): string {
-    return 'SecurityException: Key ' + keyId + ' has unknown status.';
-  }
+	// Exceptions for invalid keys.
+	static InvalidKeyMissingKeyData(keyId: number): string {
+		return "SecurityException: Key data are missing for key " + keyId + ".";
+	}
+	static InvalidKeyUnknownPrefix(keyId: number): string {
+		return (
+			"SecurityException: Key " +
+			keyId +
+			" has unknown output prefix type."
+		);
+	}
+	static InvalidKeyUnknownStatus(keyId: number): string {
+		return "SecurityException: Key " + keyId + " has unknown status.";
+	}
 
-  // Exceptions for invalid keysets.
-  static InvalidKeysetMissingKeys(): string {
-    return 'SecurityException: Keyset should be non null and ' +
-        'must contain at least one key.';
-  }
-  static InvalidKeysetDisabledPrimary(): string {
-    return 'SecurityException: Primary key has to be in the keyset and ' +
-        'has to be enabled.';
-  }
-  static InvalidKeysetMultiplePrimaries(): string {
-    return 'SecurityException: Primary key has to be unique.';
-  }
+	// Exceptions for invalid keysets.
+	static InvalidKeysetMissingKeys(): string {
+		return (
+			"SecurityException: Keyset should be non null and " +
+			"must contain at least one key."
+		);
+	}
+	static InvalidKeysetDisabledPrimary(): string {
+		return (
+			"SecurityException: Primary key has to be in the keyset and " +
+			"has to be enabled."
+		);
+	}
+	static InvalidKeysetMultiplePrimaries(): string {
+		return "SecurityException: Primary key has to be unique.";
+	}
 }
 
 /** Returns a valid PbKeysetKey. */
 function createKey(
-    opt_id: number = 0x12345678, opt_enabled: boolean = true,
-    opt_publicKey: boolean = false): PbKeysetKey {
-  const keyData =
-      new PbKeyData().setTypeUrl('someTypeUrl').setValue(new Uint8Array(10));
-  if (opt_publicKey) {
-    keyData.setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
-  } else {
-    keyData.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
-  }
+	opt_id: number = 0x12345678,
+	opt_enabled: boolean = true,
+	opt_publicKey: boolean = false
+): PbKeysetKey {
+	const keyData = new PbKeyData()
+		.setTypeUrl("someTypeUrl")
+		.setValue(new Uint8Array(10));
+	if (opt_publicKey) {
+		keyData.setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
+	} else {
+		keyData.setKeyMaterialType(PbKeyData.KeyMaterialType.SYMMETRIC);
+	}
 
-  const key = new PbKeysetKey().setKeyData(keyData);
-  if (opt_enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
-  key.setKeyId(opt_id);
-  key.setOutputPrefixType(PbOutputPrefixType.TINK);
+	const key = new PbKeysetKey().setKeyData(keyData);
+	if (opt_enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
+	key.setKeyId(opt_id);
+	key.setOutputPrefixType(PbOutputPrefixType.TINK);
 
-  return key;
+	return key;
 }
 
 /** Returns a valid PbKeyset which primary has id equal to 1. */
 function createKeyset(): PbKeyset {
-  const numberOfKeys = 20;
+	const numberOfKeys = 20;
 
-  const keyset = new PbKeyset();
-  for (let i = 0; i < numberOfKeys; i++) {
-    // Key id is never set to 0 as primaryKeyId = 0 if it is unset.
-    const key = createKey(i + 1, /* opt_enabled = */ (i % 2) < 1, (i % 4) < 2);
-    keyset.addKey(key);
-  }
+	const keyset = new PbKeyset();
+	for (let i = 0; i < numberOfKeys; i++) {
+		// Key id is never set to 0 as primaryKeyId = 0 if it is unset.
+		const key = createKey(i + 1, /* opt_enabled = */ i % 2 < 1, i % 4 < 2);
+		keyset.addKey(key);
+	}
 
-  keyset.setPrimaryKeyId(1);
-  return keyset;
+	keyset.setPrimaryKeyId(1);
+	return keyset;
 }

--- a/javascript/signature/ecdsa_private_key_manager_test.ts
+++ b/javascript/signature/ecdsa_private_key_manager_test.ts
@@ -4,504 +4,611 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbEcdsaKeyFormat, PbEcdsaParams, PbEcdsaPrivateKey, PbEcdsaPublicKey, PbEcdsaSignatureEncoding, PbEllipticCurveType, PbHashType, PbKeyData} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
-import {assertExists, assertInstanceof} from '../testing/internal/test_utils';
+import {
+	PbEcdsaKeyFormat,
+	PbEcdsaParams,
+	PbEcdsaPrivateKey,
+	PbEcdsaPublicKey,
+	PbEcdsaSignatureEncoding,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyData,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
+import { assertExists, assertInstanceof } from "../testing/internal/test_utils";
 
-import {EcdsaPrivateKeyManager} from './ecdsa_private_key_manager';
-import {EcdsaPublicKeyManager} from './ecdsa_public_key_manager';
-import {PublicKeySign} from './internal/public_key_sign';
-import {PublicKeyVerify} from './internal/public_key_verify';
+import { EcdsaPrivateKeyManager } from "./ecdsa_private_key_manager";
+import { EcdsaPublicKeyManager } from "./ecdsa_public_key_manager";
+import { PublicKeySign } from "./internal/public_key_sign";
+import { PublicKeyVerify } from "./internal/public_key_verify";
 
 const PRIVATE_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EcdsaPrivateKey';
+	"type.googleapis.com/google.crypto.tink.EcdsaPrivateKey";
 const PRIVATE_KEY_MATERIAL_TYPE = PbKeyData.KeyMaterialType.ASYMMETRIC_PRIVATE;
 const VERSION = 0;
 const PRIVATE_KEY_MANAGER_PRIMITIVE = PublicKeySign;
 
-const PUBLIC_KEY_TYPE = 'type.googleapis.com/google.crypto.tink.EcdsaPublicKey';
+const PUBLIC_KEY_TYPE = "type.googleapis.com/google.crypto.tink.EcdsaPublicKey";
 const PUBLIC_KEY_MATERIAL_TYPE = PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC;
 const PUBLIC_KEY_MANAGER_PRIMITIVE = PublicKeyVerify;
 
-describe('ecdsa private key manager test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecdsa private key manager test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new key, invalid serialized key format', async function() {
-    const invalidSerializedKeyFormat = new Uint8Array(0);
-    const manager = new EcdsaPrivateKeyManager();
+	it("new key, invalid serialized key format", async () => {
+		const invalidSerializedKeyFormat = new Uint8Array(0);
+		const manager = new EcdsaPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(invalidSerializedKeyFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidSerializedKeyFormat()
+			);
+		}
+	});
 
-  it('new key, unsupported key format proto', async function() {
-    const unsupportedKeyFormatProto = new PbEcdsaParams();
-    const manager = new EcdsaPrivateKeyManager();
+	it("new key, unsupported key format proto", async () => {
+		const unsupportedKeyFormatProto = new PbEcdsaParams();
+		const manager = new EcdsaPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyFormat());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(unsupportedKeyFormatProto);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyFormat());
+		}
+	});
 
-  it('new key, invalid format, missing params', async function() {
-    const invalidFormat = new PbEcdsaKeyFormat();
-    const manager = new EcdsaPrivateKeyManager();
+	it("new key, invalid format, missing params", async () => {
+		const invalidFormat = new PbEcdsaKeyFormat();
+		const manager = new EcdsaPrivateKeyManager();
 
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidKeyFormatMissingParams());
-    }
-  });
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.invalidKeyFormatMissingParams()
+			);
+		}
+	});
 
-  it('new key, invalid format, invalid params', async function() {
-    const manager = new EcdsaPrivateKeyManager();
+	it("new key, invalid format, invalid params", async () => {
+		const manager = new EcdsaPrivateKeyManager();
 
-    // Unknown encoding.
-    const invalidFormat = createKeyFormat();
-    invalidFormat.getParams()?.setEncoding(
-        PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownEncoding());
-    }
-    invalidFormat.getParams()?.setEncoding(PbEcdsaSignatureEncoding.DER);
+		// Unknown encoding.
+		const invalidFormat = createKeyFormat();
+		invalidFormat
+			.getParams()
+			?.setEncoding(PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownEncoding());
+		}
+		invalidFormat.getParams()?.setEncoding(PbEcdsaSignatureEncoding.DER);
 
-    // Unknown hash.
-    invalidFormat.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHash());
-    }
-    invalidFormat.getParams()?.setHashType(PbHashType.SHA256);
+		// Unknown hash.
+		invalidFormat.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHash());
+		}
+		invalidFormat.getParams()?.setHashType(PbHashType.SHA256);
 
-    // Unknown curve.
-    invalidFormat.getParams()?.setCurve(PbEllipticCurveType.UNKNOWN_CURVE);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownCurve());
-    }
+		// Unknown curve.
+		invalidFormat.getParams()?.setCurve(PbEllipticCurveType.UNKNOWN_CURVE);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownCurve());
+		}
 
-    // Bad hash + curve combinations.
-    invalidFormat.getParams()?.setCurve(PbEllipticCurveType.NIST_P384);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256');
-    }
-    invalidFormat.getParams()?.setCurve(PbEllipticCurveType.NIST_P521);
-    try {
-      await manager.getKeyFactory().newKey(invalidFormat);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256');
-    }
-  });
+		// Bad hash + curve combinations.
+		invalidFormat.getParams()?.setCurve(PbEllipticCurveType.NIST_P384);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256"
+			);
+		}
+		invalidFormat.getParams()?.setCurve(PbEllipticCurveType.NIST_P521);
+		try {
+			await manager.getKeyFactory().newKey(invalidFormat);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256"
+			);
+		}
+	});
 
-  it('new key, via key format', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const manager = new EcdsaPrivateKeyManager();
-    for (const keyFormat of keyFormats) {
-      const key = await manager.getKeyFactory().newKey(keyFormat);
+	it("new key, via key format", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const manager = new EcdsaPrivateKeyManager();
+		for (const keyFormat of keyFormats) {
+			const key = await manager.getKeyFactory().newKey(keyFormat);
 
-      expect(key.getPublicKey()?.getParams()).toEqual(keyFormat.getParams());
-      // The keys are tested more in tests for getPrimitive method below, where
-      // the primitive based on the created key is tested.
-    }
-  });
+			expect(key.getPublicKey()?.getParams()).toEqual(
+				keyFormat.getParams()
+			);
+			// The keys are tested more in tests for getPrimitive method below, where
+			// the primitive based on the created key is tested.
+		}
+	});
 
-  it('new key data, invalid serialized key format', async function() {
-    const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
-    const manager = new EcdsaPrivateKeyManager();
+	it("new key data, invalid serialized key format", async () => {
+		const serializedKeyFormats = [new Uint8Array(1), new Uint8Array(0)];
+		const manager = new EcdsaPrivateKeyManager();
 
-    const serializedKeyFormatsLength = serializedKeyFormats.length;
-    for (let i = 0; i < serializedKeyFormatsLength; i++) {
-      try {
-        await manager.getKeyFactory().newKeyData(serializedKeyFormats[i]);
-        fail(
-            'An exception should be thrown for the string: ' +
-            serializedKeyFormats[i]);
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKeyFormat());
-        continue;
-      }
-    }
-  });
+		const serializedKeyFormatsLength = serializedKeyFormats.length;
+		for (let i = 0; i < serializedKeyFormatsLength; i++) {
+			try {
+				await manager
+					.getKeyFactory()
+					.newKeyData(serializedKeyFormats[i]);
+				fail(
+					"An exception should be thrown for the string: " +
+						serializedKeyFormats[i]
+				);
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					ExceptionText.invalidSerializedKeyFormat()
+				);
+				continue;
+			}
+		}
+	});
 
-  it('new key data, from valid key format', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const manager = new EcdsaPrivateKeyManager();
-    for (const keyFormat of keyFormats) {
-      const serializedKeyFormat = keyFormat.serializeBinary();
-      const keyData =
-          await manager.getKeyFactory().newKeyData(serializedKeyFormat);
-      expect(keyData.getTypeUrl()).toBe(PRIVATE_KEY_TYPE);
-      expect(keyData.getKeyMaterialType()).toBe(PRIVATE_KEY_MATERIAL_TYPE);
+	it("new key data, from valid key format", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const manager = new EcdsaPrivateKeyManager();
+		for (const keyFormat of keyFormats) {
+			const serializedKeyFormat = keyFormat.serializeBinary();
+			const keyData = await manager
+				.getKeyFactory()
+				.newKeyData(serializedKeyFormat);
+			expect(keyData.getTypeUrl()).toBe(PRIVATE_KEY_TYPE);
+			expect(keyData.getKeyMaterialType()).toBe(
+				PRIVATE_KEY_MATERIAL_TYPE
+			);
 
-      const key = PbEcdsaPrivateKey.deserializeBinary(keyData.getValue());
-      expect(key.getPublicKey()?.getParams()).toEqual(keyFormat.getParams());
-      // The keys are tested more in tests for getPrimitive method below, where
-      // the primitive based on the created key is tested.
-    }
-  });
+			const key = PbEcdsaPrivateKey.deserializeBinary(keyData.getValue());
+			expect(key.getPublicKey()?.getParams()).toEqual(
+				keyFormat.getParams()
+			);
+			// The keys are tested more in tests for getPrimitive method below, where
+			// the primitive based on the created key is tested.
+		}
+	});
 
-  it('get public key data, invalid private key serialization', function() {
-    const manager = new EcdsaPrivateKeyManager();
+	it("get public key data, invalid private key serialization", () => {
+		const manager = new EcdsaPrivateKeyManager();
 
-    const privateKey = new Uint8Array([0, 1]);  // not a serialized private key
-    try {
-      const factory = manager.getKeyFactory();
-      factory.getPublicKeyData(privateKey);
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-    }
-  });
+		const privateKey = new Uint8Array([0, 1]); // not a serialized private key
+		try {
+			const factory = manager.getKeyFactory();
+			factory.getPublicKeyData(privateKey);
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+		}
+	});
 
-  it('get public key data, should work', async function() {
-    const keyFormat = createKeyFormat();
-    const manager = new EcdsaPrivateKeyManager();
-    const privateKey = await manager.getKeyFactory().newKey(keyFormat);
-    const factory = (manager.getKeyFactory());
-    const publicKeyData =
-        factory.getPublicKeyData(privateKey.serializeBinary());
+	it("get public key data, should work", async () => {
+		const keyFormat = createKeyFormat();
+		const manager = new EcdsaPrivateKeyManager();
+		const privateKey = await manager.getKeyFactory().newKey(keyFormat);
+		const factory = manager.getKeyFactory();
+		const publicKeyData = factory.getPublicKeyData(
+			privateKey.serializeBinary()
+		);
 
-    expect(publicKeyData.getTypeUrl()).toBe(PUBLIC_KEY_TYPE);
-    expect(publicKeyData.getKeyMaterialType()).toBe(PUBLIC_KEY_MATERIAL_TYPE);
-    const publicKey =
-        PbEcdsaPublicKey.deserializeBinary(publicKeyData.getValue());
-    expect(publicKey.getVersion())
-        .toEqual(privateKey.getPublicKey()!.getVersion());
-    expect(publicKey.getParams())
-        .toEqual(privateKey.getPublicKey()!.getParams());
-    expect(publicKey.getX()).toEqual(privateKey.getPublicKey()!.getX());
-    expect(publicKey.getY()).toEqual(privateKey.getPublicKey()!.getY());
-  });
+		expect(publicKeyData.getTypeUrl()).toBe(PUBLIC_KEY_TYPE);
+		expect(publicKeyData.getKeyMaterialType()).toBe(
+			PUBLIC_KEY_MATERIAL_TYPE
+		);
+		const publicKey = PbEcdsaPublicKey.deserializeBinary(
+			publicKeyData.getValue()
+		);
+		expect(publicKey.getVersion()).toEqual(
+			privateKey.getPublicKey()!.getVersion()
+		);
+		expect(publicKey.getParams()).toEqual(
+			privateKey.getPublicKey()!.getParams()
+		);
+		expect(publicKey.getX()).toEqual(privateKey.getPublicKey()!.getX());
+		expect(publicKey.getY()).toEqual(privateKey.getPublicKey()!.getY());
+	});
 
-  it('get primitive, unsupported key data type', async function() {
-    const manager = new EcdsaPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const keyData =
-        (await manager.getKeyFactory().newKeyData(keyFormat.serializeBinary()))
-            .setTypeUrl('unsupported_key_type_url');
+	it("get primitive, unsupported key data type", async () => {
+		const manager = new EcdsaPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const keyData = (
+			await manager
+				.getKeyFactory()
+				.newKeyData(keyFormat.serializeBinary())
+		).setTypeUrl("unsupported_key_type_url");
 
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyType(keyData.getTypeUrl()));
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyType(keyData.getTypeUrl())
+			);
+		}
+	});
 
-  it('get primitive, unsupported key type', async function() {
-    const manager = new EcdsaPrivateKeyManager();
-    const key = new PbEcdsaPublicKey();
+	it("get primitive, unsupported key type", async () => {
+		const manager = new EcdsaPrivateKeyManager();
+		const key = new PbEcdsaPublicKey();
 
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
+		}
+	});
 
-  it('get primitive, high version', async function() {
-    const manager = new EcdsaPrivateKeyManager();
-    const version = manager.getVersion() + 1;
-    const keyFormat = createKeyFormat();
-    const key =
-        assertInstanceof(
-            await manager.getKeyFactory().newKey(keyFormat), PbEcdsaPrivateKey)
-            .setVersion(version);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
-    }
-  });
+	it("get primitive, high version", async () => {
+		const manager = new EcdsaPrivateKeyManager();
+		const version = manager.getVersion() + 1;
+		const keyFormat = createKeyFormat();
+		const key = assertInstanceof(
+			await manager.getKeyFactory().newKey(keyFormat),
+			PbEcdsaPrivateKey
+		).setVersion(version);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
+		}
+	});
 
-  it('get primitive, invalid params', async function() {
-    const manager = new EcdsaPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const key = assertInstanceof(
-        await manager.getKeyFactory().newKey(keyFormat), PbEcdsaPrivateKey);
+	it("get primitive, invalid params", async () => {
+		const manager = new EcdsaPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const key = assertInstanceof(
+			await manager.getKeyFactory().newKey(keyFormat),
+			PbEcdsaPrivateKey
+		);
 
-    // Unknown encoding.
-    key.getPublicKey()?.getParams()?.setEncoding(
-        PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownEncoding());
-    }
-    key.getPublicKey()?.getParams()?.setEncoding(PbEcdsaSignatureEncoding.DER);
+		// Unknown encoding.
+		key.getPublicKey()
+			?.getParams()
+			?.setEncoding(PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownEncoding());
+		}
+		key.getPublicKey()
+			?.getParams()
+			?.setEncoding(PbEcdsaSignatureEncoding.DER);
 
-    // Unknown hash.
-    key.getPublicKey()?.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHash());
-    }
-    key.getPublicKey()?.getParams()?.setHashType(PbHashType.SHA256);
+		// Unknown hash.
+		key.getPublicKey()?.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHash());
+		}
+		key.getPublicKey()?.getParams()?.setHashType(PbHashType.SHA256);
 
-    // Unknown curve.
-    key.getPublicKey()?.getParams()?.setCurve(
-        PbEllipticCurveType.UNKNOWN_CURVE);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownCurve());
-    }
+		// Unknown curve.
+		key.getPublicKey()
+			?.getParams()
+			?.setCurve(PbEllipticCurveType.UNKNOWN_CURVE);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownCurve());
+		}
 
-    // Bad hash + curve combinations.
-    key.getPublicKey()?.getParams()?.setCurve(PbEllipticCurveType.NIST_P384);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256');
-    }
-    key.getPublicKey()?.getParams()?.setCurve(PbEllipticCurveType.NIST_P521);
-    try {
-      await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256');
-    }
-  });
+		// Bad hash + curve combinations.
+		key.getPublicKey()
+			?.getParams()
+			?.setCurve(PbEllipticCurveType.NIST_P384);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256"
+			);
+		}
+		key.getPublicKey()
+			?.getParams()
+			?.setCurve(PbEllipticCurveType.NIST_P521);
+		try {
+			await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256"
+			);
+		}
+	});
 
-  it('get primitive, invalid serialized key', async function() {
-    const manager = new EcdsaPrivateKeyManager();
-    const keyFormat = createKeyFormat();
-    const keyData =
-        await manager.getKeyFactory().newKeyData(keyFormat.serializeBinary());
+	it("get primitive, invalid serialized key", async () => {
+		const manager = new EcdsaPrivateKeyManager();
+		const keyFormat = createKeyFormat();
+		const keyData = await manager
+			.getKeyFactory()
+			.newKeyData(keyFormat.serializeBinary());
 
+		for (let i = 0; i < 2; ++i) {
+			// Set the value of keyData to something which is not a serialization of a
+			// proper key.
+			keyData.setValue(new Uint8Array(i));
+			try {
+				await manager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					keyData
+				);
+				fail("An exception should be thrown " + i.toString());
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+			}
+		}
+	});
 
-    for (let i = 0; i < 2; ++i) {
-      // Set the value of keyData to something which is not a serialization of a
-      // proper key.
-      keyData.setValue(new Uint8Array(i));
-      try {
-        await manager.getPrimitive(PRIVATE_KEY_MANAGER_PRIMITIVE, keyData);
-        fail('An exception should be thrown ' + i.toString());
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-      }
-    }
-  });
+	it("get primitive, from key", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const privateKeyManager = new EcdsaPrivateKeyManager();
+		const publicKeyManager = new EcdsaPublicKeyManager();
+		for (const keyFormat of keyFormats) {
+			const key = assertInstanceof(
+				await privateKeyManager.getKeyFactory().newKey(keyFormat),
+				PbEcdsaPrivateKey
+			);
+			const publicKeyVerify: PublicKeyVerify = assertExists(
+				await publicKeyManager.getPrimitive(
+					PUBLIC_KEY_MANAGER_PRIMITIVE,
+					assertExists(key.getPublicKey())
+				)
+			);
+			const publicKeySign: PublicKeySign = assertExists(
+				await privateKeyManager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					key
+				)
+			);
 
-  it('get primitive, from key', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const privateKeyManager = new EcdsaPrivateKeyManager();
-    const publicKeyManager = new EcdsaPublicKeyManager();
-    for (const keyFormat of keyFormats) {
-      const key = assertInstanceof(
-          await privateKeyManager.getKeyFactory().newKey(keyFormat),
-          PbEcdsaPrivateKey);
-      const publicKeyVerify: PublicKeyVerify =
-          assertExists(await publicKeyManager.getPrimitive(
-              PUBLIC_KEY_MANAGER_PRIMITIVE, assertExists(key.getPublicKey())));
-      const publicKeySign: PublicKeySign =
-          assertExists(await privateKeyManager.getPrimitive(
-              PRIVATE_KEY_MANAGER_PRIMITIVE, key));
+			const data = Random.randBytes(10);
+			const signature = await publicKeySign.sign(data);
+			const isValid = await publicKeyVerify.verify(signature, data);
 
-      const data = Random.randBytes(10);
-      const signature = await publicKeySign.sign(data);
-      const isValid = await publicKeyVerify.verify(signature, data);
+			expect(isValid).toBe(true);
+		}
+	});
 
-      expect(isValid).toBe(true);
-    }
-  });
+	it("get primitive, from key data", async () => {
+		const keyFormats = createTestSetOfKeyFormats();
+		const privateKeyManager = new EcdsaPrivateKeyManager();
+		const publicKeyManager = new EcdsaPublicKeyManager();
 
-  it('get primitive, from key data', async function() {
-    const keyFormats = createTestSetOfKeyFormats();
-    const privateKeyManager = new EcdsaPrivateKeyManager();
-    const publicKeyManager = new EcdsaPublicKeyManager();
+		for (const keyFormat of keyFormats) {
+			const serializedKeyFormat = keyFormat.serializeBinary();
+			const keyData = await privateKeyManager
+				.getKeyFactory()
+				.newKeyData(serializedKeyFormat);
+			const factory = privateKeyManager.getKeyFactory();
+			const publicKeyData = factory.getPublicKeyData(
+				bytesAsU8(keyData.getValue())
+			);
 
-    for (const keyFormat of keyFormats) {
-      const serializedKeyFormat = keyFormat.serializeBinary();
-      const keyData = await privateKeyManager.getKeyFactory().newKeyData(
-          serializedKeyFormat);
-      const factory = privateKeyManager.getKeyFactory();
-      const publicKeyData =
-          factory.getPublicKeyData(bytesAsU8(keyData.getValue()));
+			const publicKeyVerify: PublicKeyVerify = assertExists(
+				await publicKeyManager.getPrimitive(
+					PUBLIC_KEY_MANAGER_PRIMITIVE,
+					publicKeyData
+				)
+			);
+			const publicKeySign: PublicKeySign = assertExists(
+				await privateKeyManager.getPrimitive(
+					PRIVATE_KEY_MANAGER_PRIMITIVE,
+					keyData
+				)
+			);
 
-      const publicKeyVerify: PublicKeyVerify =
-          assertExists(await publicKeyManager.getPrimitive(
-              PUBLIC_KEY_MANAGER_PRIMITIVE, publicKeyData));
-      const publicKeySign: PublicKeySign =
-          assertExists(await privateKeyManager.getPrimitive(
-              PRIVATE_KEY_MANAGER_PRIMITIVE, keyData));
+			const data = Random.randBytes(10);
+			const signature = await publicKeySign.sign(data);
+			const isValid = await publicKeyVerify.verify(signature, data);
 
-      const data = Random.randBytes(10);
-      const signature = await publicKeySign.sign(data);
-      const isValid = await publicKeyVerify.verify(signature, data);
+			expect(isValid).toBe(true);
+		}
+	});
 
-      expect(isValid).toBe(true);
-    }
-  });
+	it("does support", () => {
+		const manager = new EcdsaPrivateKeyManager();
+		expect(manager.doesSupport(PRIVATE_KEY_TYPE)).toBe(true);
+	});
 
-  it('does support', function() {
-    const manager = new EcdsaPrivateKeyManager();
-    expect(manager.doesSupport(PRIVATE_KEY_TYPE)).toBe(true);
-  });
+	it("get key type", () => {
+		const manager = new EcdsaPrivateKeyManager();
+		expect(manager.getKeyType()).toBe(PRIVATE_KEY_TYPE);
+	});
 
-  it('get key type', function() {
-    const manager = new EcdsaPrivateKeyManager();
-    expect(manager.getKeyType()).toBe(PRIVATE_KEY_TYPE);
-  });
+	it("get primitive type", () => {
+		const manager = new EcdsaPrivateKeyManager();
+		expect(manager.getPrimitiveType()).toBe(PRIVATE_KEY_MANAGER_PRIMITIVE);
+	});
 
-  it('get primitive type', function() {
-    const manager = new EcdsaPrivateKeyManager();
-    expect(manager.getPrimitiveType()).toBe(PRIVATE_KEY_MANAGER_PRIMITIVE);
-  });
-
-  it('get version', function() {
-    const manager = new EcdsaPrivateKeyManager();
-    expect(manager.getVersion()).toBe(VERSION);
-  });
+	it("get version", () => {
+		const manager = new EcdsaPrivateKeyManager();
+		expect(manager.getVersion()).toBe(VERSION);
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static nullKeyFormat(): string {
-    return 'SecurityException: Key format has to be non-null.';
-  }
+	static nullKeyFormat(): string {
+		return "SecurityException: Key format has to be non-null.";
+	}
 
-  static invalidSerializedKeyFormat(): string {
-    return 'SecurityException: Input cannot be parsed as ' + PRIVATE_KEY_TYPE +
-        ' key format proto.';
-  }
+	static invalidSerializedKeyFormat(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			PRIVATE_KEY_TYPE +
+			" key format proto."
+		);
+	}
 
-  static unsupportedPrimitive(): string {
-    return 'SecurityException: Requested primitive type which is not supported by ' +
-        'this key manager.';
-  }
+	static unsupportedPrimitive(): string {
+		return (
+			"SecurityException: Requested primitive type which is not supported by " +
+			"this key manager."
+		);
+	}
 
-  static unsupportedKeyFormat(): string {
-    return 'SecurityException: Expected ' + PRIVATE_KEY_TYPE +
-        ' key format proto.';
-  }
+	static unsupportedKeyFormat(): string {
+		return (
+			"SecurityException: Expected " +
+			PRIVATE_KEY_TYPE +
+			" key format proto."
+		);
+	}
 
-  static unsupportedKeyType(opt_requestedKeyType?: string): string {
-    const prefix = 'SecurityException: Key type';
-    const suffix =
-        'is not supported. This key manager supports ' + PRIVATE_KEY_TYPE + '.';
-    if (opt_requestedKeyType) {
-      return prefix + ' ' + opt_requestedKeyType + ' ' + suffix;
-    } else {
-      return prefix + ' ' + suffix;
-    }
-  }
+	static unsupportedKeyType(opt_requestedKeyType?: string): string {
+		const prefix = "SecurityException: Key type";
+		const suffix =
+			"is not supported. This key manager supports " +
+			PRIVATE_KEY_TYPE +
+			".";
+		if (opt_requestedKeyType) {
+			return prefix + " " + opt_requestedKeyType + " " + suffix;
+		} else {
+			return prefix + " " + suffix;
+		}
+	}
 
-  static unknownEncoding(): string {
-    return 'SecurityException: Invalid public key - missing signature encoding.';
-  }
+	static unknownEncoding(): string {
+		return "SecurityException: Invalid public key - missing signature encoding.";
+	}
 
-  static unknownHash(): string {
-    return 'SecurityException: Unknown hash type.';
-  }
+	static unknownHash(): string {
+		return "SecurityException: Unknown hash type.";
+	}
 
-  static unknownCurve(): string {
-    return 'SecurityException: Unknown curve type.';
-  }
+	static unknownCurve(): string {
+		return "SecurityException: Unknown curve type.";
+	}
 
-  static versionOutOfBounds(): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        VERSION + '.';
-  }
+	static versionOutOfBounds(): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			VERSION +
+			"."
+		);
+	}
 
-  static invalidKeyFormatMissingParams(): string {
-    return 'SecurityException: Invalid key format - missing params.';
-  }
+	static invalidKeyFormatMissingParams(): string {
+		return "SecurityException: Invalid key format - missing params.";
+	}
 
-  static invalidSerializedKey(): string {
-    return 'SecurityException: Input cannot be parsed as ' + PRIVATE_KEY_TYPE +
-        ' key-proto.';
-  }
+	static invalidSerializedKey(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			PRIVATE_KEY_TYPE +
+			" key-proto."
+		);
+	}
 }
 
 function createParams(
-    curveType: PbEllipticCurveType, hashType: PbHashType,
-    encoding: PbEcdsaSignatureEncoding): PbEcdsaParams {
-  const params =
-      new PbEcdsaParams().setCurve(curveType).setHashType(hashType).setEncoding(
-          encoding);
+	curveType: PbEllipticCurveType,
+	hashType: PbHashType,
+	encoding: PbEcdsaSignatureEncoding
+): PbEcdsaParams {
+	const params = new PbEcdsaParams()
+		.setCurve(curveType)
+		.setHashType(hashType)
+		.setEncoding(encoding);
 
-  return params;
+	return params;
 }
 
 function createKeyFormat(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256,
-    opt_encodingType: PbEcdsaSignatureEncoding =
-        PbEcdsaSignatureEncoding.DER): PbEcdsaKeyFormat {
-  const keyFormat = new PbEcdsaKeyFormat().setParams(
-      createParams(opt_curveType, opt_hashType, opt_encodingType));
-  return keyFormat;
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256,
+	opt_encodingType: PbEcdsaSignatureEncoding = PbEcdsaSignatureEncoding.DER
+): PbEcdsaKeyFormat {
+	const keyFormat = new PbEcdsaKeyFormat().setParams(
+		createParams(opt_curveType, opt_hashType, opt_encodingType)
+	);
+	return keyFormat;
 }
 
 /**
  * Create set of key formats with all possible predefined/supported parameters.
  */
 function createTestSetOfKeyFormats(): PbEcdsaKeyFormat[] {
-  const keyFormats: PbEcdsaKeyFormat[] = [];
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P256, PbHashType.SHA256,
-      PbEcdsaSignatureEncoding.DER));
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P256, PbHashType.SHA256,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P384, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.DER));
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P384, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P521, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.DER));
-  keyFormats.push(createKeyFormat(
-      PbEllipticCurveType.NIST_P521, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  return keyFormats;
+	const keyFormats: PbEcdsaKeyFormat[] = [];
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P256,
+			PbHashType.SHA256,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P256,
+			PbHashType.SHA256,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P384,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P384,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P521,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keyFormats.push(
+		createKeyFormat(
+			PbEllipticCurveType.NIST_P521,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	return keyFormats;
 }

--- a/javascript/signature/ecdsa_public_key_manager_test.ts
+++ b/javascript/signature/ecdsa_public_key_manager_test.ts
@@ -4,381 +4,428 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbEcdsaParams, PbEcdsaPublicKey, PbEcdsaSignatureEncoding, PbEllipticCurveType, PbHashType, PbKeyData} from '../internal/proto';
-import * as Registry from '../internal/registry';
-import * as Util from '../internal/util';
-import * as Bytes from '../subtle/bytes';
-import * as EllipticCurves from '../subtle/elliptic_curves';
-import {assertExists} from '../testing/internal/test_utils';
+import {
+	PbEcdsaParams,
+	PbEcdsaPublicKey,
+	PbEcdsaSignatureEncoding,
+	PbEllipticCurveType,
+	PbHashType,
+	PbKeyData,
+} from "../internal/proto";
+import * as Registry from "../internal/registry";
+import * as Util from "../internal/util";
+import * as Bytes from "../subtle/bytes";
+import * as EllipticCurves from "../subtle/elliptic_curves";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {EcdsaPublicKeyManager} from './ecdsa_public_key_manager';
-import {PublicKeyVerify} from './internal/public_key_verify';
+import { EcdsaPublicKeyManager } from "./ecdsa_public_key_manager";
+import { PublicKeyVerify } from "./internal/public_key_verify";
 
-const KEY_TYPE = 'type.googleapis.com/google.crypto.tink.EcdsaPublicKey';
+const KEY_TYPE = "type.googleapis.com/google.crypto.tink.EcdsaPublicKey";
 const VERSION = 0;
 const PRIMITIVE = PublicKeyVerify;
 
-describe('ecdsa public key manager test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecdsa public key manager test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new key', function() {
-    const manager = new EcdsaPublicKeyManager();
+	it("new key", () => {
+		const manager = new EcdsaPublicKeyManager();
 
-    try {
-      manager.getKeyFactory().newKey(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notSupported());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKey(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.notSupported());
+		}
+	});
 
-  it('new key data', function() {
-    const manager = new EcdsaPublicKeyManager();
+	it("new key data", () => {
+		const manager = new EcdsaPublicKeyManager();
 
-    try {
-      manager.getKeyFactory().newKeyData(new Uint8Array(0));
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.notSupported());
-    }
-  });
+		try {
+			manager.getKeyFactory().newKeyData(new Uint8Array(0));
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.notSupported());
+		}
+	});
 
-  it('get primitive, unsupported key data type', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const keyData =
-        (await createKeyData()).setTypeUrl('unsupported_key_type_url');
+	it("get primitive, unsupported key data type", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const keyData = (await createKeyData()).setTypeUrl(
+			"unsupported_key_type_url"
+		);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, keyData);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(ExceptionText.unsupportedKeyType(keyData.getTypeUrl()));
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, keyData);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				ExceptionText.unsupportedKeyType(keyData.getTypeUrl())
+			);
+		}
+	});
 
-  it('get primitive, unsupported key type', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const key = new PbEcdsaParams();
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
-    }
-  });
+	it("get primitive, unsupported key type", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const key = new PbEcdsaParams();
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unsupportedKeyType());
+		}
+	});
 
-  it('get primitive, high version', async function() {
-    const version = 1;
-    const manager = new EcdsaPublicKeyManager();
-    const key = (await createKey()).setVersion(version);
+	it("get primitive, high version", async () => {
+		const version = 1;
+		const manager = new EcdsaPublicKeyManager();
+		const key = (await createKey()).setVersion(version);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.versionOutOfBounds());
+		}
+	});
 
-  it('get primitive, missing params', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const key = (await createKey()).setParams(null);
+	it("get primitive, missing params", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const key = (await createKey()).setParams(null);
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.missingParams());
-    }
-  });
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.missingParams());
+		}
+	});
 
-  it('get primitive, invalid params', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const key = await createKey();
+	it("get primitive, invalid params", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const key = await createKey();
 
-    // Unknown encoding.
-    key.getParams()?.setEncoding(PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownEncoding());
-    }
-    key.getParams()?.setEncoding(PbEcdsaSignatureEncoding.DER);
+		// Unknown encoding.
+		key.getParams()?.setEncoding(PbEcdsaSignatureEncoding.UNKNOWN_ENCODING);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownEncoding());
+		}
+		key.getParams()?.setEncoding(PbEcdsaSignatureEncoding.DER);
 
-    // Unknown hash.
-    key.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownHash());
-    }
-    key.getParams()?.setHashType(PbHashType.SHA256);
+		// Unknown hash.
+		key.getParams()?.setHashType(PbHashType.UNKNOWN_HASH);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownHash());
+		}
+		key.getParams()?.setHashType(PbHashType.SHA256);
 
-    // Unknown curve.
-    key.getParams()?.setCurve(PbEllipticCurveType.UNKNOWN_CURVE);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString()).toBe(ExceptionText.unknownCurve());
-    }
+		// Unknown curve.
+		key.getParams()?.setCurve(PbEllipticCurveType.UNKNOWN_CURVE);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(ExceptionText.unknownCurve());
+		}
 
-    // Bad hash + curve combinations.
-    key.getParams()?.setCurve(PbEllipticCurveType.NIST_P384);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256');
-    }
-    key.getParams()?.setCurve(PbEllipticCurveType.NIST_P521);
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256');
-    }
-  });
+		// Bad hash + curve combinations.
+		key.getParams()?.setCurve(PbEllipticCurveType.NIST_P384);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256"
+			);
+		}
+		key.getParams()?.setCurve(PbEllipticCurveType.NIST_P521);
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256"
+			);
+		}
+	});
 
-  it('get primitive, invalid key', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const key = await createKey();
-    const x = key.getX();
-    key.setX(new Uint8Array([0]));
+	it("get primitive, invalid key", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const key = await createKey();
+		const x = key.getX();
+		key.setX(new Uint8Array([0]));
 
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(ExceptionText.webCryptoErrors()).toContain(e.toString());
-    }
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(ExceptionText.webCryptoErrors()).toContain(e.toString());
+		}
 
-    key.setX(x);
-    key.setY(new Uint8Array([0]));
-    try {
-      await manager.getPrimitive(PRIMITIVE, key);
-      fail('An exception should be thrown.');
-    } catch (e: any) {
-      expect(ExceptionText.webCryptoErrors()).toContain(e.toString());
-    }
-  });
+		key.setX(x);
+		key.setY(new Uint8Array([0]));
+		try {
+			await manager.getPrimitive(PRIMITIVE, key);
+			fail("An exception should be thrown.");
+		} catch (e: any) {
+			expect(ExceptionText.webCryptoErrors()).toContain(e.toString());
+		}
+	});
 
-  it('get primitive, invalid serialized key', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const keyData = await createKeyData();
+	it("get primitive, invalid serialized key", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const keyData = await createKeyData();
 
-    for (let i = 0; i < 2; ++i) {
-      // Set the value of keyData to something which is not a serialization of a
-      // proper key.
-      keyData.setValue(new Uint8Array(i));
-      try {
-        await manager.getPrimitive(PRIMITIVE, keyData);
-        fail('An exception should be thrown ' + i.toString());
-      } catch (e: any) {
-        expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
-      }
-    }
-  });
+		for (let i = 0; i < 2; ++i) {
+			// Set the value of keyData to something which is not a serialization of a
+			// proper key.
+			keyData.setValue(new Uint8Array(i));
+			try {
+				await manager.getPrimitive(PRIMITIVE, keyData);
+				fail("An exception should be thrown " + i.toString());
+			} catch (e: any) {
+				expect(e.toString()).toBe(ExceptionText.invalidSerializedKey());
+			}
+		}
+	});
 
-  // tests for getting primitive from valid key/keyData
-  it('get primitive, from key', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const keys = await createTestSetOfKeys();
-    for (const key of keys) {
-      await manager.getPrimitive(PRIMITIVE, key);
-    }
-  });
+	// tests for getting primitive from valid key/keyData
+	it("get primitive, from key", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const keys = await createTestSetOfKeys();
+		for (const key of keys) {
+			await manager.getPrimitive(PRIMITIVE, key);
+		}
+	});
 
-  it('get primitive, from key data', async function() {
-    const manager = new EcdsaPublicKeyManager();
-    const keyDatas = await createTestSetOfKeyDatas();
-    for (const key of keyDatas) {
-      await manager.getPrimitive(PRIMITIVE, key);
-    }
-  });
+	it("get primitive, from key data", async () => {
+		const manager = new EcdsaPublicKeyManager();
+		const keyDatas = await createTestSetOfKeyDatas();
+		for (const key of keyDatas) {
+			await manager.getPrimitive(PRIMITIVE, key);
+		}
+	});
 
-  it('does support', function() {
-    const manager = new EcdsaPublicKeyManager();
+	it("does support", () => {
+		const manager = new EcdsaPublicKeyManager();
 
-    expect(manager.doesSupport(KEY_TYPE)).toBe(true);
-  });
+		expect(manager.doesSupport(KEY_TYPE)).toBe(true);
+	});
 
-  it('get key type', function() {
-    const manager = new EcdsaPublicKeyManager();
+	it("get key type", () => {
+		const manager = new EcdsaPublicKeyManager();
 
-    expect(manager.getKeyType()).toBe(KEY_TYPE);
-  });
+		expect(manager.getKeyType()).toBe(KEY_TYPE);
+	});
 
-  it('get primitive type', function() {
-    const manager = new EcdsaPublicKeyManager();
+	it("get primitive type", () => {
+		const manager = new EcdsaPublicKeyManager();
 
-    expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
-  });
+		expect(manager.getPrimitiveType()).toBe(PRIMITIVE);
+	});
 
-  it('get version', function() {
-    const manager = new EcdsaPublicKeyManager();
-    expect(manager.getVersion()).toBe(VERSION);
-  });
+	it("get version", () => {
+		const manager = new EcdsaPublicKeyManager();
+		expect(manager.getVersion()).toBe(VERSION);
+	});
 });
 
 // Helper classes and functions
 class ExceptionText {
-  static notSupported(): string {
-    return 'SecurityException: This operation is not supported for public keys. ' +
-        'Use EcdsaPrivateKeyManager to generate new keys.';
-  }
+	static notSupported(): string {
+		return (
+			"SecurityException: This operation is not supported for public keys. " +
+			"Use EcdsaPrivateKeyManager to generate new keys."
+		);
+	}
 
-  static unsupportedPrimitive(): string {
-    return 'SecurityException: Requested primitive type which is not supported by ' +
-        'this key manager.';
-  }
+	static unsupportedPrimitive(): string {
+		return (
+			"SecurityException: Requested primitive type which is not supported by " +
+			"this key manager."
+		);
+	}
 
-  static unsupportedKeyType(opt_requestedKeyType?: string): string {
-    const prefix = 'SecurityException: Key type';
-    const suffix =
-        'is not supported. This key manager supports ' + KEY_TYPE + '.';
-    if (opt_requestedKeyType) {
-      return prefix + ' ' + opt_requestedKeyType + ' ' + suffix;
-    } else {
-      return prefix + ' ' + suffix;
-    }
-  }
+	static unsupportedKeyType(opt_requestedKeyType?: string): string {
+		const prefix = "SecurityException: Key type";
+		const suffix =
+			"is not supported. This key manager supports " + KEY_TYPE + ".";
+		if (opt_requestedKeyType) {
+			return prefix + " " + opt_requestedKeyType + " " + suffix;
+		} else {
+			return prefix + " " + suffix;
+		}
+	}
 
-  static versionOutOfBounds(): string {
-    return 'SecurityException: Version is out of bound, must be between 0 and ' +
-        VERSION + '.';
-  }
+	static versionOutOfBounds(): string {
+		return (
+			"SecurityException: Version is out of bound, must be between 0 and " +
+			VERSION +
+			"."
+		);
+	}
 
-  static unknownEncoding(): string {
-    return 'SecurityException: Invalid public key - missing signature encoding.';
-  }
+	static unknownEncoding(): string {
+		return "SecurityException: Invalid public key - missing signature encoding.";
+	}
 
-  static unknownHash(): string {
-    return 'SecurityException: Unknown hash type.';
-  }
+	static unknownHash(): string {
+		return "SecurityException: Unknown hash type.";
+	}
 
-  static unknownCurve(): string {
-    return 'SecurityException: Unknown curve type.';
-  }
+	static unknownCurve(): string {
+		return "SecurityException: Unknown curve type.";
+	}
 
-  static missingParams(): string {
-    return 'SecurityException: Invalid public key - missing params.';
-  }
+	static missingParams(): string {
+		return "SecurityException: Invalid public key - missing params.";
+	}
 
-  static missingXY(): string {
-    return 'SecurityException: Invalid public key - missing value of X or Y.';
-  }
+	static missingXY(): string {
+		return "SecurityException: Invalid public key - missing value of X or Y.";
+	}
 
-  static invalidSerializedKey(): string {
-    return 'SecurityException: Input cannot be parsed as ' + KEY_TYPE +
-        ' key-proto.';
-  }
+	static invalidSerializedKey(): string {
+		return (
+			"SecurityException: Input cannot be parsed as " +
+			KEY_TYPE +
+			" key-proto."
+		);
+	}
 
-  static webCryptoErrors(): string[] {
-    return [
-      'DataError',
-      // Firefox
-      'DataError: Data provided to an operation does not meet requirements',
-    ];
-  }
+	static webCryptoErrors(): string[] {
+		return [
+			"DataError",
+			// Firefox
+			"DataError: Data provided to an operation does not meet requirements",
+		];
+	}
 }
 
 function createParams(
-    curveType: PbEllipticCurveType, hashType: PbHashType,
-    encoding: PbEcdsaSignatureEncoding): PbEcdsaParams {
-  const params = (new PbEcdsaParams())
-                     .setCurve(curveType)
-                     .setHashType(hashType)
-                     .setEncoding(encoding);
-  return params;
+	curveType: PbEllipticCurveType,
+	hashType: PbHashType,
+	encoding: PbEcdsaSignatureEncoding
+): PbEcdsaParams {
+	const params = new PbEcdsaParams()
+		.setCurve(curveType)
+		.setHashType(hashType)
+		.setEncoding(encoding);
+	return params;
 }
 
 async function createKey(
-    opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
-    opt_hashType: PbHashType = PbHashType.SHA256,
-    opt_encoding: PbEcdsaSignatureEncoding =
-        PbEcdsaSignatureEncoding.DER): Promise<PbEcdsaPublicKey> {
-  const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
-  const curveName = EllipticCurves.curveToString(curveSubtleType);
-  const key =
-      (new PbEcdsaPublicKey())
-          .setVersion(0)
-          .setParams(createParams(opt_curveType, opt_hashType, opt_encoding));
-  const keyPair = await EllipticCurves.generateKeyPair('ECDSA', curveName);
-  const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-  key.setX(
-      Bytes.fromBase64(assertExists(publicKey['x']), /* opt_webSafe = */ true));
-  key.setY(
-      Bytes.fromBase64(assertExists(publicKey['y']), /* opt_webSafe = */ true));
-  return key;
+	opt_curveType: PbEllipticCurveType = PbEllipticCurveType.NIST_P256,
+	opt_hashType: PbHashType = PbHashType.SHA256,
+	opt_encoding: PbEcdsaSignatureEncoding = PbEcdsaSignatureEncoding.DER
+): Promise<PbEcdsaPublicKey> {
+	const curveSubtleType = Util.curveTypeProtoToSubtle(opt_curveType);
+	const curveName = EllipticCurves.curveToString(curveSubtleType);
+	const key = new PbEcdsaPublicKey()
+		.setVersion(0)
+		.setParams(createParams(opt_curveType, opt_hashType, opt_encoding));
+	const keyPair = await EllipticCurves.generateKeyPair("ECDSA", curveName);
+	const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
+	key.setX(
+		Bytes.fromBase64(assertExists(publicKey["x"]), /* opt_webSafe = */ true)
+	);
+	key.setY(
+		Bytes.fromBase64(assertExists(publicKey["y"]), /* opt_webSafe = */ true)
+	);
+	return key;
 }
 
 function createKeyDataFromKey(key: PbEcdsaPublicKey): PbKeyData {
-  const keyData =
-      new PbKeyData()
-          .setTypeUrl(KEY_TYPE)
-          .setValue(key.serializeBinary())
-          .setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
+	const keyData = new PbKeyData()
+		.setTypeUrl(KEY_TYPE)
+		.setValue(key.serializeBinary())
+		.setKeyMaterialType(PbKeyData.KeyMaterialType.ASYMMETRIC_PUBLIC);
 
-  return keyData;
+	return keyData;
 }
 
 async function createKeyData(
-    opt_curveType?: PbEllipticCurveType, opt_hashType?: PbHashType,
-    opt_encoding?: PbEcdsaSignatureEncoding): Promise<PbKeyData> {
-  const key = await createKey(opt_curveType, opt_hashType, opt_encoding);
-  return createKeyDataFromKey(key);
+	opt_curveType?: PbEllipticCurveType,
+	opt_hashType?: PbHashType,
+	opt_encoding?: PbEcdsaSignatureEncoding
+): Promise<PbKeyData> {
+	const key = await createKey(opt_curveType, opt_hashType, opt_encoding);
+	return createKeyDataFromKey(key);
 }
 
 // Create set of keys with all possible predefined/supported parameters.
 async function createTestSetOfKeys(): Promise<PbEcdsaPublicKey[]> {
-  const keys: PbEcdsaPublicKey[] = [];
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P256, PbHashType.SHA256,
-      PbEcdsaSignatureEncoding.DER));
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P256, PbHashType.SHA256,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P384, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.DER));
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P384, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P521, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.DER));
-  keys.push(await createKey(
-      PbEllipticCurveType.NIST_P521, PbHashType.SHA512,
-      PbEcdsaSignatureEncoding.IEEE_P1363));
-  return keys;
+	const keys: PbEcdsaPublicKey[] = [];
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P256,
+			PbHashType.SHA256,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P256,
+			PbHashType.SHA256,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P384,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P384,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P521,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.DER
+		)
+	);
+	keys.push(
+		await createKey(
+			PbEllipticCurveType.NIST_P521,
+			PbHashType.SHA512,
+			PbEcdsaSignatureEncoding.IEEE_P1363
+		)
+	);
+	return keys;
 }
 
 // Create set of keyData protos with keys of all possible predefined/supported
 // parameters.
 async function createTestSetOfKeyDatas(): Promise<PbKeyData[]> {
-  const keys = await createTestSetOfKeys();
-  const keyDatas: PbKeyData[] = [];
-  for (const key of keys) {
-    const keyData = await createKeyDataFromKey(key);
-    keyDatas.push(keyData);
-  }
+	const keys = await createTestSetOfKeys();
+	const keyDatas: PbKeyData[] = [];
+	for (const key of keys) {
+		const keyData = await createKeyDataFromKey(key);
+		keyDatas.push(keyData);
+	}
 
-  return keyDatas;
+	return keyDatas;
 }

--- a/javascript/signature/public_key_sign_wrapper_test.ts
+++ b/javascript/signature/public_key_sign_wrapper_test.ts
@@ -4,46 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {CryptoFormat} from '../internal/crypto_format';
-import * as PrimitiveSet from '../internal/primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Random from '../subtle/random';
-import {assertExists} from '../testing/internal/test_utils';
+import { CryptoFormat } from "../internal/crypto_format";
+import * as PrimitiveSet from "../internal/primitive_set";
+import {
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Random from "../subtle/random";
+import { assertExists } from "../testing/internal/test_utils";
 
-import {PublicKeySign} from './internal/public_key_sign';
-import {PublicKeySignWrapper} from './public_key_sign_wrapper';
+import { PublicKeySign } from "./internal/public_key_sign";
+import { PublicKeySignWrapper } from "./public_key_sign_wrapper";
 
-describe('public key sign wrapper test', function() {
-  it('new public key sign, primitive set without primary', function() {
-    const primitiveSet = createDummyPrimitiveSet(/* opt_withPrimary = */ false);
-    try {
-      new PublicKeySignWrapper().wrap(primitiveSet);
-      fail('Should throw an exception.');
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: Primary has to be non-null.');
-    }
-  });
+describe("public key sign wrapper test", () => {
+	it("new public key sign, primitive set without primary", () => {
+		const primitiveSet = createDummyPrimitiveSet(
+			/* opt_withPrimary = */ false
+		);
+		try {
+			new PublicKeySignWrapper().wrap(primitiveSet);
+			fail("Should throw an exception.");
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Primary has to be non-null."
+			);
+		}
+	});
 
-  it('new public key sign, should work', function() {
-    const primitiveSet = createDummyPrimitiveSet();
-    const publicKeySign = new PublicKeySignWrapper().wrap(primitiveSet);
-    expect(publicKeySign != null && publicKeySign != undefined).toBe(true);
-  });
+	it("new public key sign, should work", () => {
+		const primitiveSet = createDummyPrimitiveSet();
+		const publicKeySign = new PublicKeySignWrapper().wrap(primitiveSet);
+		expect(publicKeySign != null && publicKeySign != undefined).toBe(true);
+	});
 
-  it('sign, should work', async function() {
-    const primitiveSet = createDummyPrimitiveSet();
-    const publicKeySign = new PublicKeySignWrapper().wrap(primitiveSet);
+	it("sign, should work", async () => {
+		const primitiveSet = createDummyPrimitiveSet();
+		const publicKeySign = new PublicKeySignWrapper().wrap(primitiveSet);
 
-    const data = Random.randBytes(10);
+		const data = Random.randBytes(10);
 
-    const signature = await publicKeySign.sign(data);
-    expect(signature != null).toBe(true);
+		const signature = await publicKeySign.sign(data);
+		expect(signature != null).toBe(true);
 
-    // Signature should begin with primary key output prefix.
-    expect(signature.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE))
-        .toEqual(assertExists(primitiveSet.getPrimary()).getIdentifier());
-  });
+		// Signature should begin with primary key output prefix.
+		expect(signature.subarray(0, CryptoFormat.NON_RAW_PREFIX_SIZE)).toEqual(
+			assertExists(primitiveSet.getPrimary()).getIdentifier()
+		);
+	});
 });
 
 /**
@@ -51,81 +59,91 @@ describe('public key sign wrapper test', function() {
  * @final
  */
 class ExceptionText {
-  static nullPrimitiveSet(): string {
-    return 'CustomError: Primitive set has to be non-null.';
-  }
+	static nullPrimitiveSet(): string {
+		return "CustomError: Primitive set has to be non-null.";
+	}
 
-  static primitiveSetWithoutPrimary(): string {
-    return 'CustomError: Primary has to be non-null.';
-  }
+	static primitiveSetWithoutPrimary(): string {
+		return "CustomError: Primary has to be non-null.";
+	}
 
-  static nullPlaintext(): string {
-    return 'CustomError: Plaintext has to be non-null.';
-  }
+	static nullPlaintext(): string {
+		return "CustomError: Plaintext has to be non-null.";
+	}
 }
 
 /** Function for creating keys for testing purposes. */
 function createDummyKeysetKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
 
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  return key;
+	return key;
 }
 
 /**
- * Creates a primitive set with 'numberOfPrimitives' primitives. The keys
+ * Creates a primitive set with "numberOfPrimitives" primitives. The keys
  * corresponding to the primitives have ids from the set
  * [1, ..., numberOfPrimitives] and the primitive corresponding to key with id
- * 'numberOfPrimitives' is set to be primary whenever opt_withPrimary is set to
+ * "numberOfPrimitives" is set to be primary whenever opt_withPrimary is set to
  * true (where true is the default value).
  */
-function createDummyPrimitiveSet(opt_withPrimary: boolean = true):
-    PrimitiveSet.PrimitiveSet<DummyPublicKeySign> {
-  const numberOfPrimitives = 5;
-  const primitiveSet =
-      new PrimitiveSet.PrimitiveSet<DummyPublicKeySign>(DummyPublicKeySign);
-  for (let i = 1; i < numberOfPrimitives; i++) {
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    const key =
-        createDummyKeysetKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
-    const publicKeySign = new DummyPublicKeySign();
-    primitiveSet.addPrimitive(publicKeySign, key);
-  }
+function createDummyPrimitiveSet(
+	opt_withPrimary: boolean = true
+): PrimitiveSet.PrimitiveSet<DummyPublicKeySign> {
+	const numberOfPrimitives = 5;
+	const primitiveSet = new PrimitiveSet.PrimitiveSet<DummyPublicKeySign>(
+		DummyPublicKeySign
+	);
+	for (let i = 1; i < numberOfPrimitives; i++) {
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		const key = createDummyKeysetKey(
+			i,
+			outputPrefix,
+			/* enabled = */ i % 4 < 2
+		);
+		const publicKeySign = new DummyPublicKeySign();
+		primitiveSet.addPrimitive(publicKeySign, key);
+	}
 
-  const key = createDummyKeysetKey(
-      numberOfPrimitives, PbOutputPrefixType.TINK, /* enabled = */ true);
-  const publicKeySign = new DummyPublicKeySign();
-  const entry = primitiveSet.addPrimitive(publicKeySign, key);
-  if (opt_withPrimary) {
-    primitiveSet.setPrimary(entry);
-  }
+	const key = createDummyKeysetKey(
+		numberOfPrimitives,
+		PbOutputPrefixType.TINK,
+		/* enabled = */ true
+	);
+	const publicKeySign = new DummyPublicKeySign();
+	const entry = primitiveSet.addPrimitive(publicKeySign, key);
+	if (opt_withPrimary) {
+		primitiveSet.setPrimary(entry);
+	}
 
-  return primitiveSet;
+	return primitiveSet;
 }
 
 /** @final */
 class DummyPublicKeySign extends PublicKeySign {
-  async sign(data: Uint8Array) {
-    return data;
-  }
+	async sign(data: Uint8Array) {
+		return data;
+	}
 }

--- a/javascript/signature/public_key_verify_wrapper_test.ts
+++ b/javascript/signature/public_key_verify_wrapper_test.ts
@@ -4,199 +4,232 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as PrimitiveSet from '../internal/primitive_set';
-import {PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import * as Bytes from '../subtle/bytes';
-import * as Random from '../subtle/random';
+import * as PrimitiveSet from "../internal/primitive_set";
+import {
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import * as Bytes from "../subtle/bytes";
+import * as Random from "../subtle/random";
 
-import {PublicKeySign} from './internal/public_key_sign';
-import {PublicKeyVerify} from './internal/public_key_verify';
-import {PublicKeySignWrapper} from './public_key_sign_wrapper';
-import {PublicKeyVerifyWrapper} from './public_key_verify_wrapper';
+import { PublicKeySign } from "./internal/public_key_sign";
+import { PublicKeyVerify } from "./internal/public_key_verify";
+import { PublicKeySignWrapper } from "./public_key_sign_wrapper";
+import { PublicKeyVerifyWrapper } from "./public_key_verify_wrapper";
 
-describe('public key verify wrapper test', function() {
-  it('verify, with empty signature', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const primitiveSet = primitiveSets['publicPrimitiveSet'];
-    const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
-    expect(
-        await publicKeyVerify.verify(new Uint8Array(0), Random.randBytes(10)))
-        .toBe(false);
-  });
+describe("public key verify wrapper test", () => {
+	it("verify, with empty signature", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const primitiveSet = primitiveSets["publicPrimitiveSet"];
+		const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
+		expect(
+			await publicKeyVerify.verify(
+				new Uint8Array(0),
+				Random.randBytes(10)
+			)
+		).toBe(false);
+	});
 
-  it('verify, should work', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const data = Random.randBytes(10);
-    // As keys are just dummy keys which do not contain key data, the same key
-    // is used for both sign and verify.
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.TINK,
-        /** enabled = */ true);
-    const signatureSuffix = Random.randBytes(10);
+	it("verify, should work", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const data = Random.randBytes(10);
+		// As keys are just dummy keys which do not contain key data, the same key
+		// is used for both sign and verify.
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.TINK,
+			/** enabled = */ true
+		);
+		const signatureSuffix = Random.randBytes(10);
 
-    // Get the signature
-    const privatePrimitiveSet = primitiveSets['privatePrimitiveSet'];
-    const signPrimitive = new DummyPublicKeySign(signatureSuffix);
-    const entry = privatePrimitiveSet.addPrimitive(signPrimitive, key);
-    // Has to be set to primary as then it is used in signing.
-    privatePrimitiveSet.setPrimary(entry);
-    const publicKeySign = new PublicKeySignWrapper().wrap(privatePrimitiveSet);
-    const signature = await publicKeySign.sign(data);
+		// Get the signature
+		const privatePrimitiveSet = primitiveSets["privatePrimitiveSet"];
+		const signPrimitive = new DummyPublicKeySign(signatureSuffix);
+		const entry = privatePrimitiveSet.addPrimitive(signPrimitive, key);
+		// Has to be set to primary as then it is used in signing.
+		privatePrimitiveSet.setPrimary(entry);
+		const publicKeySign = new PublicKeySignWrapper().wrap(
+			privatePrimitiveSet
+		);
+		const signature = await publicKeySign.sign(data);
 
-    // Create a primitive set containing the primitives which can be used for
-    // verification. Add also few more primitives with the same key as the
-    // primitive set should verify the signature whenever there is at least
-    // one primitive which does not fail to verify the signature.
-    const publicPrimitiveSet = primitiveSets['publicPrimitiveSet'];
-    const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
-    publicPrimitiveSet.addPrimitive(
-        new DummyPublicKeyVerify(Random.randBytes(5)), key);
-    publicPrimitiveSet.addPrimitive(verifyPrimitive, key);
-    publicPrimitiveSet.addPrimitive(
-        new DummyPublicKeyVerify(Random.randBytes(5)), key);
+		// Create a primitive set containing the primitives which can be used for
+		// verification. Add also few more primitives with the same key as the
+		// primitive set should verify the signature whenever there is at least
+		// one primitive which does not fail to verify the signature.
+		const publicPrimitiveSet = primitiveSets["publicPrimitiveSet"];
+		const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
+		publicPrimitiveSet.addPrimitive(
+			new DummyPublicKeyVerify(Random.randBytes(5)),
+			key
+		);
+		publicPrimitiveSet.addPrimitive(verifyPrimitive, key);
+		publicPrimitiveSet.addPrimitive(
+			new DummyPublicKeyVerify(Random.randBytes(5)),
+			key
+		);
 
-    // Verify the signature.
-    const publicKeyVerify =
-        new PublicKeyVerifyWrapper().wrap(publicPrimitiveSet);
+		// Verify the signature.
+		const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(
+			publicPrimitiveSet
+		);
 
-    const isValid = await publicKeyVerify.verify(signature, data);
-    expect(isValid).toBe(true);
-  });
+		const isValid = await publicKeyVerify.verify(signature, data);
+		expect(isValid).toBe(true);
+	});
 
-  it('verify, raw primitive', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const data = Random.randBytes(10);
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.RAW,
-        /** enabled = */ true);
-    const signatureSuffix = Random.randBytes(10);
+	it("verify, raw primitive", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const data = Random.randBytes(10);
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.RAW,
+			/** enabled = */ true
+		);
+		const signatureSuffix = Random.randBytes(10);
 
-    // Get the signature.
-    const signPrimitive = new DummyPublicKeySign(signatureSuffix);
-    const signature = await signPrimitive.sign(data);
+		// Get the signature.
+		const signPrimitive = new DummyPublicKeySign(signatureSuffix);
+		const signature = await signPrimitive.sign(data);
 
-    // Verify the signature.
-    const primitiveSet = primitiveSets['publicPrimitiveSet'];
-    const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
-    primitiveSet.addPrimitive(verifyPrimitive, key);
-    const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
+		// Verify the signature.
+		const primitiveSet = primitiveSets["publicPrimitiveSet"];
+		const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
+		primitiveSet.addPrimitive(verifyPrimitive, key);
+		const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
 
-    const isValid = await publicKeyVerify.verify(signature, data);
-    expect(isValid).toBe(true);
-  });
+		const isValid = await publicKeyVerify.verify(signature, data);
+		expect(isValid).toBe(true);
+	});
 
-  it('verify, with disabled primitive', async function() {
-    const primitiveSets = createDummyPrimitiveSets();
-    const data = Random.randBytes(10);
-    const key = createDummyKeysetKey(
-        /** keyId = */ 0xFFFFFFFF, PbOutputPrefixType.RAW,
-        /** enabled = */ false);
-    const signatureSuffix = new Uint8Array([0, 0, 0, 0xFF]);
+	it("verify, with disabled primitive", async () => {
+		const primitiveSets = createDummyPrimitiveSets();
+		const data = Random.randBytes(10);
+		const key = createDummyKeysetKey(
+			/** keyId = */ 0xffffffff,
+			PbOutputPrefixType.RAW,
+			/** enabled = */ false
+		);
+		const signatureSuffix = new Uint8Array([0, 0, 0, 0xff]);
 
-    const signPrimitive = new DummyPublicKeySign(signatureSuffix);
-    const signature = await signPrimitive.sign(data);
+		const signPrimitive = new DummyPublicKeySign(signatureSuffix);
+		const signature = await signPrimitive.sign(data);
 
-    const primitiveSet = primitiveSets['publicPrimitiveSet'];
-    const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
-    primitiveSet.addPrimitive(verifyPrimitive, key);
-    const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
+		const primitiveSet = primitiveSets["publicPrimitiveSet"];
+		const verifyPrimitive = new DummyPublicKeyVerify(signatureSuffix);
+		primitiveSet.addPrimitive(verifyPrimitive, key);
+		const publicKeyVerify = new PublicKeyVerifyWrapper().wrap(primitiveSet);
 
-    const isValid = await publicKeyVerify.verify(signature, data);
-    expect(isValid).toBe(false);
-  });
+		const isValid = await publicKeyVerify.verify(signature, data);
+		expect(isValid).toBe(false);
+	});
 });
 
 /** Function for creating keys for testing purposes. */
 function createDummyKeysetKey(
-    keyId: number, outputPrefix: PbOutputPrefixType,
-    enabled: boolean): PbKeysetKey {
-  const key = new PbKeysetKey();
-  if (enabled) {
-    key.setStatus(PbKeyStatusType.ENABLED);
-  } else {
-    key.setStatus(PbKeyStatusType.DISABLED);
-  }
+	keyId: number,
+	outputPrefix: PbOutputPrefixType,
+	enabled: boolean
+): PbKeysetKey {
+	const key = new PbKeysetKey();
+	if (enabled) {
+		key.setStatus(PbKeyStatusType.ENABLED);
+	} else {
+		key.setStatus(PbKeyStatusType.DISABLED);
+	}
 
-  key.setOutputPrefixType(outputPrefix);
-  key.setKeyId(keyId);
+	key.setOutputPrefixType(outputPrefix);
+	key.setKeyId(keyId);
 
-  return key;
+	return key;
 }
 
 /**
  * Creates a primitive sets for PublicKeySign and PublicKeyVerify with
- * 'numberOfPrimitives' primitives. The keys corresponding to the primitives
+ * "numberOfPrimitives" primitives. The keys corresponding to the primitives
  * have ids from the set [1, ..., numberOfPrimitives] and the primitive
- * corresponding to key with id 'numberOfPrimitives' is set to be primary
+ * corresponding to key with id "numberOfPrimitives" is set to be primary
  * whenever opt_withPrimary is set to true (where true is the default value).
  */
 function createDummyPrimitiveSets(opt_withPrimary: boolean = true): {
-  publicPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyPublicKeyVerify>,
-  privatePrimitiveSet: PrimitiveSet.PrimitiveSet<DummyPublicKeySign>,
+	publicPrimitiveSet: PrimitiveSet.PrimitiveSet<DummyPublicKeyVerify>;
+	privatePrimitiveSet: PrimitiveSet.PrimitiveSet<DummyPublicKeySign>;
 } {
-  const numberOfPrimitives = 5;
+	const numberOfPrimitives = 5;
 
-  const publicPrimitiveSet =
-      new PrimitiveSet.PrimitiveSet<DummyPublicKeyVerify>(DummyPublicKeyVerify);
-  const privatePrimitiveSet =
-      new PrimitiveSet.PrimitiveSet<DummyPublicKeySign>(DummyPublicKeySign);
-  for (let i = 1; i < numberOfPrimitives; i++) {
-    let outputPrefix: PbOutputPrefixType;
-    switch (i % 3) {
-      case 0:
-        outputPrefix = PbOutputPrefixType.TINK;
-        break;
-      case 1:
-        outputPrefix = PbOutputPrefixType.LEGACY;
-        break;
-      default:
-        outputPrefix = PbOutputPrefixType.RAW;
-    }
-    const key =
-        createDummyKeysetKey(i, outputPrefix, /* enabled = */ i % 4 < 2);
-    const signatureSuffix = new Uint8Array([0, 0, i]);
-    const publicKeySign = new DummyPublicKeySign(signatureSuffix);
-    privatePrimitiveSet.addPrimitive(publicKeySign, key);
-    const publicKeyVerify = new DummyPublicKeyVerify(signatureSuffix);
-    publicPrimitiveSet.addPrimitive(publicKeyVerify, key);
-  }
+	const publicPrimitiveSet =
+		new PrimitiveSet.PrimitiveSet<DummyPublicKeyVerify>(
+			DummyPublicKeyVerify
+		);
+	const privatePrimitiveSet =
+		new PrimitiveSet.PrimitiveSet<DummyPublicKeySign>(DummyPublicKeySign);
+	for (let i = 1; i < numberOfPrimitives; i++) {
+		let outputPrefix: PbOutputPrefixType;
+		switch (i % 3) {
+			case 0:
+				outputPrefix = PbOutputPrefixType.TINK;
+				break;
+			case 1:
+				outputPrefix = PbOutputPrefixType.LEGACY;
+				break;
+			default:
+				outputPrefix = PbOutputPrefixType.RAW;
+		}
+		const key = createDummyKeysetKey(
+			i,
+			outputPrefix,
+			/* enabled = */ i % 4 < 2
+		);
+		const signatureSuffix = new Uint8Array([0, 0, i]);
+		const publicKeySign = new DummyPublicKeySign(signatureSuffix);
+		privatePrimitiveSet.addPrimitive(publicKeySign, key);
+		const publicKeyVerify = new DummyPublicKeyVerify(signatureSuffix);
+		publicPrimitiveSet.addPrimitive(publicKeyVerify, key);
+	}
 
-  const key = createDummyKeysetKey(
-      numberOfPrimitives, PbOutputPrefixType.TINK, /* enabled = */ true);
-  const signatureSuffix = new Uint8Array([0, 0, numberOfPrimitives]);
-  const publicKeySign = new DummyPublicKeySign(signatureSuffix);
-  const signEntry = privatePrimitiveSet.addPrimitive(publicKeySign, key);
-  const publicKeyVerify = new DummyPublicKeyVerify(signatureSuffix);
-  const verifyEntry = publicPrimitiveSet.addPrimitive(publicKeyVerify, key);
-  if (opt_withPrimary) {
-    publicPrimitiveSet.setPrimary(verifyEntry);
-    privatePrimitiveSet.setPrimary(signEntry);
-  }
+	const key = createDummyKeysetKey(
+		numberOfPrimitives,
+		PbOutputPrefixType.TINK,
+		/* enabled = */ true
+	);
+	const signatureSuffix = new Uint8Array([0, 0, numberOfPrimitives]);
+	const publicKeySign = new DummyPublicKeySign(signatureSuffix);
+	const signEntry = privatePrimitiveSet.addPrimitive(publicKeySign, key);
+	const publicKeyVerify = new DummyPublicKeyVerify(signatureSuffix);
+	const verifyEntry = publicPrimitiveSet.addPrimitive(publicKeyVerify, key);
+	if (opt_withPrimary) {
+		publicPrimitiveSet.setPrimary(verifyEntry);
+		privatePrimitiveSet.setPrimary(signEntry);
+	}
 
-  return {
-    'publicPrimitiveSet': publicPrimitiveSet,
-    'privatePrimitiveSet': privatePrimitiveSet
-  };
+	return {
+		publicPrimitiveSet: publicPrimitiveSet,
+		privatePrimitiveSet: privatePrimitiveSet,
+	};
 }
 
 /** @final */
 class DummyPublicKeySign extends PublicKeySign {
-  constructor(private readonly signatureSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly signatureSuffix: Uint8Array) {
+		super();
+	}
 
-  async sign(data: Uint8Array) {
-    return Bytes.concat(data, this.signatureSuffix);
-  }
+	async sign(data: Uint8Array) {
+		return Bytes.concat(data, this.signatureSuffix);
+	}
 }
 
 /** @final */
 class DummyPublicKeyVerify extends PublicKeyVerify {
-  constructor(private readonly signatureSuffix: Uint8Array) {
-    super();
-  }
+	constructor(private readonly signatureSuffix: Uint8Array) {
+		super();
+	}
 
-  async verify(signature: Uint8Array, data: Uint8Array) {
-    return Bytes.isEqual(Bytes.concat(data, this.signatureSuffix), signature);
-  }
+	async verify(signature: Uint8Array, data: Uint8Array) {
+		return Bytes.isEqual(
+			Bytes.concat(data, this.signatureSuffix),
+			signature
+		);
+	}
 }

--- a/javascript/signature/signature_config_test.ts
+++ b/javascript/signature/signature_config_test.ts
@@ -4,105 +4,125 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {KeysetHandle} from '../internal/keyset_handle';
-import {PbKeyData, PbKeyset, PbKeysetKey, PbKeyStatusType, PbOutputPrefixType} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
-import * as Registry from '../internal/registry';
-import * as Random from '../subtle/random';
+import { KeysetHandle } from "../internal/keyset_handle";
+import {
+	PbKeyData,
+	PbKeyset,
+	PbKeysetKey,
+	PbKeyStatusType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
+import * as Registry from "../internal/registry";
+import * as Random from "../subtle/random";
 
-import {EcdsaPrivateKeyManager} from './ecdsa_private_key_manager';
-import {EcdsaPublicKeyManager} from './ecdsa_public_key_manager';
-import {PublicKeySign} from './internal/public_key_sign';
-import {PublicKeyVerify} from './internal/public_key_verify';
-import * as SignatureConfig from './signature_config';
-import {SignatureKeyTemplates} from './signature_key_templates';
+import { EcdsaPrivateKeyManager } from "./ecdsa_private_key_manager";
+import { EcdsaPublicKeyManager } from "./ecdsa_public_key_manager";
+import { PublicKeySign } from "./internal/public_key_sign";
+import { PublicKeyVerify } from "./internal/public_key_verify";
+import * as SignatureConfig from "./signature_config";
+import { SignatureKeyTemplates } from "./signature_key_templates";
 
-describe('signature config test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("signature config test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('constants', function() {
-    expect(SignatureConfig.VERIFY_PRIMITIVE_NAME).toBe(VERIFY_PRIMITIVE_NAME);
-    expect(SignatureConfig.SIGN_PRIMITIVE_NAME).toBe(SIGN_PRIMITIVE_NAME);
+	it("constants", () => {
+		expect(SignatureConfig.VERIFY_PRIMITIVE_NAME).toBe(
+			VERIFY_PRIMITIVE_NAME
+		);
+		expect(SignatureConfig.SIGN_PRIMITIVE_NAME).toBe(SIGN_PRIMITIVE_NAME);
 
-    expect(SignatureConfig.ECDSA_PUBLIC_KEY_TYPE).toBe(ECDSA_PUBLIC_KEY_TYPE);
-    expect(SignatureConfig.ECDSA_PRIVATE_KEY_TYPE).toBe(ECDSA_PRIVATE_KEY_TYPE);
-  });
+		expect(SignatureConfig.ECDSA_PUBLIC_KEY_TYPE).toBe(
+			ECDSA_PUBLIC_KEY_TYPE
+		);
+		expect(SignatureConfig.ECDSA_PRIVATE_KEY_TYPE).toBe(
+			ECDSA_PRIVATE_KEY_TYPE
+		);
+	});
 
-  it('register, correct key managers were registered', function() {
-    SignatureConfig.register();
+	it("register, correct key managers were registered", () => {
+		SignatureConfig.register();
 
-    // Test that the corresponding key managers were registered.
-    const publicKeyManager = Registry.getKeyManager(ECDSA_PUBLIC_KEY_TYPE);
-    expect(publicKeyManager instanceof EcdsaPublicKeyManager).toBe(true);
+		// Test that the corresponding key managers were registered.
+		const publicKeyManager = Registry.getKeyManager(ECDSA_PUBLIC_KEY_TYPE);
+		expect(publicKeyManager instanceof EcdsaPublicKeyManager).toBe(true);
 
-    const privateKeyManager = Registry.getKeyManager(ECDSA_PRIVATE_KEY_TYPE);
-    expect(privateKeyManager instanceof EcdsaPrivateKeyManager).toBe(true);
-  });
+		const privateKeyManager = Registry.getKeyManager(
+			ECDSA_PRIVATE_KEY_TYPE
+		);
+		expect(privateKeyManager instanceof EcdsaPrivateKeyManager).toBe(true);
+	});
 
-  // Check that everything was registered correctly and thus new keys may be
-  // generated using the predefined key templates and then they may be used for
-  // encryption and decryption.
-  it('register, predefined templates should work', async function() {
-    SignatureConfig.register();
-    let templates = [
-      SignatureKeyTemplates.ecdsaP256(),
-      SignatureKeyTemplates.ecdsaP256IeeeEncoding(),
-      SignatureKeyTemplates.ecdsaP384(),
-      SignatureKeyTemplates.ecdsaP384IeeeEncoding(),
-      SignatureKeyTemplates.ecdsaP521(),
-      SignatureKeyTemplates.ecdsaP521IeeeEncoding(),
+	// Check that everything was registered correctly and thus new keys may be
+	// generated using the predefined key templates and then they may be used for
+	// encryption and decryption.
+	it("register, predefined templates should work", async () => {
+		SignatureConfig.register();
+		let templates = [
+			SignatureKeyTemplates.ecdsaP256(),
+			SignatureKeyTemplates.ecdsaP256IeeeEncoding(),
+			SignatureKeyTemplates.ecdsaP384(),
+			SignatureKeyTemplates.ecdsaP384IeeeEncoding(),
+			SignatureKeyTemplates.ecdsaP521(),
+			SignatureKeyTemplates.ecdsaP521IeeeEncoding(),
+		];
+		for (const template of templates) {
+			const privateKeyData = await Registry.newKeyData(template);
+			const privateKeysetHandle =
+				createKeysetHandleFromKeyData(privateKeyData);
+			const publicKeySign =
+				await privateKeysetHandle.getPrimitive<PublicKeySign>(
+					PublicKeySign
+				);
+			const publicKeyData = Registry.getPublicKeyData(
+				privateKeyData.getTypeUrl(),
+				bytesAsU8(privateKeyData.getValue())
+			);
+			const publicKeysetHandle =
+				createKeysetHandleFromKeyData(publicKeyData);
+			const publicKeyVerify =
+				await publicKeysetHandle.getPrimitive<PublicKeyVerify>(
+					PublicKeyVerify
+				);
+			const data = Random.randBytes(10);
+			const signature = await publicKeySign.sign(data);
+			const isValid = await publicKeyVerify.verify(signature, data);
 
-    ];
-    for (const template of templates) {
-      const privateKeyData = await Registry.newKeyData(template);
-      const privateKeysetHandle = createKeysetHandleFromKeyData(privateKeyData);
-      const publicKeySign =
-          await privateKeysetHandle.getPrimitive<PublicKeySign>(PublicKeySign);
-      const publicKeyData = Registry.getPublicKeyData(
-          privateKeyData.getTypeUrl(), bytesAsU8(privateKeyData.getValue()));
-      const publicKeysetHandle = createKeysetHandleFromKeyData(publicKeyData);
-      const publicKeyVerify =
-          await publicKeysetHandle.getPrimitive<PublicKeyVerify>(
-              PublicKeyVerify);
-      const data = Random.randBytes(10);
-      const signature = await publicKeySign.sign(data);
-      const isValid = await publicKeyVerify.verify(signature, data);
-
-      expect(isValid).toBe(true);
-    }
-  });
+			expect(isValid).toBe(true);
+		}
+	});
 });
 
 // Constants used in tests.
-const VERIFY_PRIMITIVE_NAME = 'PublicKeyVerify';
-const SIGN_PRIMITIVE_NAME = 'PublicKeySign';
+const VERIFY_PRIMITIVE_NAME = "PublicKeyVerify";
+const SIGN_PRIMITIVE_NAME = "PublicKeySign";
 const ECDSA_PUBLIC_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EcdsaPublicKey';
+	"type.googleapis.com/google.crypto.tink.EcdsaPublicKey";
 const ECDSA_PRIVATE_KEY_TYPE =
-    'type.googleapis.com/google.crypto.tink.EcdsaPrivateKey';
+	"type.googleapis.com/google.crypto.tink.EcdsaPrivateKey";
 
 /**
  * Creates a keyset containing only the key given by keyData and returns it
  * wrapped in a KeysetHandle.
  */
 function createKeysetHandleFromKeyData(keyData: PbKeyData): KeysetHandle {
-  const keyId = 1;
-  const key = new PbKeysetKey()
-                  .setKeyData(keyData)
-                  .setStatus(PbKeyStatusType.ENABLED)
-                  .setKeyId(keyId)
-                  .setOutputPrefixType(PbOutputPrefixType.TINK);
-  const keyset = new PbKeyset();
-  keyset.addKey(key);
-  keyset.setPrimaryKeyId(keyId);
-  return new KeysetHandle(keyset);
+	const keyId = 1;
+	const key = new PbKeysetKey()
+		.setKeyData(keyData)
+		.setStatus(PbKeyStatusType.ENABLED)
+		.setKeyId(keyId)
+		.setOutputPrefixType(PbOutputPrefixType.TINK);
+	const keyset = new PbKeyset();
+	keyset.addKey(key);
+	keyset.setPrimaryKeyId(keyId);
+	return new KeysetHandle(keyset);
 }

--- a/javascript/signature/signature_key_templates_test.ts
+++ b/javascript/signature/signature_key_templates_test.ts
@@ -4,40 +4,47 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PbEcdsaKeyFormat, PbEcdsaSignatureEncoding, PbEllipticCurveType, PbHashType, PbOutputPrefixType} from '../internal/proto';
-import {bytesAsU8} from '../internal/proto_shims';
+import {
+	PbEcdsaKeyFormat,
+	PbEcdsaSignatureEncoding,
+	PbEllipticCurveType,
+	PbHashType,
+	PbOutputPrefixType,
+} from "../internal/proto";
+import { bytesAsU8 } from "../internal/proto_shims";
 
-import {EcdsaPrivateKeyManager} from './ecdsa_private_key_manager';
-import {SignatureKeyTemplates} from './signature_key_templates';
+import { EcdsaPrivateKeyManager } from "./ecdsa_private_key_manager";
+import { SignatureKeyTemplates } from "./signature_key_templates";
 
-describe('signature key templates test', function() {
-  it('ecdsa p256', function() {
-    // Expects function to create a key with following parameters.
-    const expectedCurve = PbEllipticCurveType.NIST_P256;
-    const expectedHashFunction = PbHashType.SHA256;
-    const expectedEncoding = PbEcdsaSignatureEncoding.DER;
-    const expectedOutputPrefix = PbOutputPrefixType.TINK;
+describe("signature key templates test", () => {
+	it("ecdsa p256", () => {
+		// Expects function to create a key with following parameters.
+		const expectedCurve = PbEllipticCurveType.NIST_P256;
+		const expectedHashFunction = PbHashType.SHA256;
+		const expectedEncoding = PbEcdsaSignatureEncoding.DER;
+		const expectedOutputPrefix = PbOutputPrefixType.TINK;
 
-    // Expected type URL is the one supported by EcdsaPrivateKeyManager.
-    const manager = new EcdsaPrivateKeyManager();
-    const expectedTypeUrl = manager.getKeyType();
+		// Expected type URL is the one supported by EcdsaPrivateKeyManager.
+		const manager = new EcdsaPrivateKeyManager();
+		const expectedTypeUrl = manager.getKeyType();
 
-    const keyTemplate = SignatureKeyTemplates.ecdsaP256();
+		const keyTemplate = SignatureKeyTemplates.ecdsaP256();
 
-    expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
-    expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
+		expect(keyTemplate.getTypeUrl()).toBe(expectedTypeUrl);
+		expect(keyTemplate.getOutputPrefixType()).toBe(expectedOutputPrefix);
 
-    // Test values in key format.
-    const keyFormat =
-        PbEcdsaKeyFormat.deserializeBinary(keyTemplate.getValue());
-    const params = keyFormat.getParams();
-    expect(params!.getEncoding()).toBe(expectedEncoding);
+		// Test values in key format.
+		const keyFormat = PbEcdsaKeyFormat.deserializeBinary(
+			keyTemplate.getValue()
+		);
+		const params = keyFormat.getParams();
+		expect(params!.getEncoding()).toBe(expectedEncoding);
 
-    // Test key params.
-    expect(params!.getCurve()).toBe(expectedCurve);
-    expect(params!.getHashType()).toBe(expectedHashFunction);
+		// Test key params.
+		expect(params!.getCurve()).toBe(expectedCurve);
+		expect(params!.getHashType()).toBe(expectedHashFunction);
 
-    // Test that the template works with EcdsaPrivateKeyManager.
-    manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
-  });
+		// Test that the template works with EcdsaPrivateKeyManager.
+		manager.getKeyFactory().newKey(bytesAsU8(keyTemplate.getValue()));
+	});
 });

--- a/javascript/subtle/aes_ctr_test.ts
+++ b/javascript/subtle/aes_ctr_test.ts
@@ -4,140 +4,144 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {fromRawKey as aesCtrFromRawKey} from './aes_ctr';
-import * as Bytes from './bytes';
-import * as Random from './random';
+import { fromRawKey as aesCtrFromRawKey } from "./aes_ctr";
+import * as Bytes from "./bytes";
+import * as Random from "./random";
 
-describe('aes ctr test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("aes ctr test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the timeout.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the timeout.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('basic', async function() {
-    // Set longer time for promiseTimout as the test sometimes takes longer than
-    // 1 second in Firefox.
-    const key = Random.randBytes(16);
-    for (let i = 0; i < 100; i++) {
-      const msg = Random.randBytes(20);
-      const cipher = await aesCtrFromRawKey(key, 16);
-      let ciphertext = await cipher.encrypt(msg);
-      let plaintext = await cipher.decrypt(ciphertext);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
-    }
-  });
+	it("basic", async () => {
+		// Set longer time for promiseTimout as the test sometimes takes longer than
+		// 1 second in Firefox.
+		const key = Random.randBytes(16);
+		for (let i = 0; i < 100; i++) {
+			const msg = Random.randBytes(20);
+			const cipher = await aesCtrFromRawKey(key, 16);
+			let ciphertext = await cipher.encrypt(msg);
+			let plaintext = await cipher.decrypt(ciphertext);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+		}
+	});
 
-  it('probabilistic encryption', async function() {
-    const cipher = await aesCtrFromRawKey(Random.randBytes(16), 16);
-    const msg = Random.randBytes(20);
-    const results = new Set();
-    for (let i = 0; i < 100; i++) {
-      const ciphertext = await cipher.encrypt(msg);
-      results.add(Bytes.toHex(ciphertext));
-    }
-    expect(results.size).toBe(100);
-  });
+	it("probabilistic encryption", async () => {
+		const cipher = await aesCtrFromRawKey(Random.randBytes(16), 16);
+		const msg = Random.randBytes(20);
+		const results = new Set();
+		for (let i = 0; i < 100; i++) {
+			const ciphertext = await cipher.encrypt(msg);
+			results.add(Bytes.toHex(ciphertext));
+		}
+		expect(results.size).toBe(100);
+	});
 
-  it('constructor', async function() {
-    try {
-      await aesCtrFromRawKey(Random.randBytes(16), 11);  // IV size too short
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: invalid IV length, must be at least 12 and at most 16');
-    }
-    try {
-      await aesCtrFromRawKey(Random.randBytes(16), 17);  // IV size too long
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: invalid IV length, must be at least 12 and at most 16');
-    }
-    try {
-      await aesCtrFromRawKey(
-          Random.randBytes(24), 12);  // 192-bit keys not supported
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: unsupported AES key size: 24');
-    }
-  });
+	it("constructor", async () => {
+		try {
+			await aesCtrFromRawKey(Random.randBytes(16), 11); // IV size too short
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: invalid IV length, must be at least 12 and at most 16"
+			);
+		}
+		try {
+			await aesCtrFromRawKey(Random.randBytes(16), 17); // IV size too long
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: invalid IV length, must be at least 12 and at most 16"
+			);
+		}
+		try {
+			await aesCtrFromRawKey(Random.randBytes(24), 12); // 192-bit keys not supported
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: unsupported AES key size: 24"
+			);
+		}
+	});
 
-  it('constructor, invalid iv sizes', async function() {
-    try {
-      await aesCtrFromRawKey(Random.randBytes(16), NaN);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: invalid IV length, must be an integer');
-    }
+	it("constructor, invalid iv sizes", async () => {
+		try {
+			await aesCtrFromRawKey(Random.randBytes(16), NaN);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: invalid IV length, must be an integer"
+			);
+		}
 
-    try {
-      await aesCtrFromRawKey(Random.randBytes(16), 12.5);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: invalid IV length, must be an integer');
-    }
+		try {
+			await aesCtrFromRawKey(Random.randBytes(16), 12.5);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: invalid IV length, must be an integer"
+			);
+		}
 
-    try {
-      await aesCtrFromRawKey(Random.randBytes(16), 0);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: invalid IV length, must be at least 12 and at most 16');
-    }
-  });
+		try {
+			await aesCtrFromRawKey(Random.randBytes(16), 0);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: invalid IV length, must be at least 12 and at most 16"
+			);
+		}
+	});
 
-  it('with test vectors', async function() {
-    // Test data from NIST SP 800-38A pp 55.
-    const NIST_TEST_VECTORS = [
-      {
-        'key': '2b7e151628aed2a6abf7158809cf4f3c',
-        'message':
-            '6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51' +
-            '30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710',
-        'ciphertext':
-            '874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff' +
-            '5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee',
-        'iv': 'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff'
-      },
-    ];
-    for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
-      const testVector = NIST_TEST_VECTORS[i];
-      const key = Bytes.fromHex(testVector['key']);
-      const iv = Bytes.fromHex(testVector['iv']);
-      const msg = Bytes.fromHex(testVector['message']);
-      const ciphertext = Bytes.fromHex(testVector['ciphertext']);
-      const aesctr = await aesCtrFromRawKey(key, iv.length);
-      const plaintext = await aesctr.decrypt(Bytes.concat(iv, ciphertext));
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
-    }
-  });
+	it("with test vectors", async () => {
+		// Test data from NIST SP 800-38A pp 55.
+		const NIST_TEST_VECTORS = [
+			{
+				key: "2b7e151628aed2a6abf7158809cf4f3c",
+				message:
+					"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51" +
+					"30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+				ciphertext:
+					"874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff" +
+					"5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee",
+				iv: "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+			},
+		];
+		for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
+			const testVector = NIST_TEST_VECTORS[i];
+			const key = Bytes.fromHex(testVector["key"]);
+			const iv = Bytes.fromHex(testVector["iv"]);
+			const msg = Bytes.fromHex(testVector["message"]);
+			const ciphertext = Bytes.fromHex(testVector["ciphertext"]);
+			const aesctr = await aesCtrFromRawKey(key, iv.length);
+			const plaintext = await aesctr.decrypt(
+				Bytes.concat(iv, ciphertext)
+			);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+		}
+	});
 });

--- a/javascript/subtle/aes_gcm_test.ts
+++ b/javascript/subtle/aes_gcm_test.ts
@@ -4,626 +4,555 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {fromRawKey as aesGcmFromRawKey} from './aes_gcm';
-import * as Bytes from './bytes';
-import * as Random from './random';
+import { fromRawKey as aesGcmFromRawKey } from "./aes_gcm";
+import * as Bytes from "./bytes";
+import * as Random from "./random";
 
 /** Asserts that an exception is the result of a Web Crypto error. */
 function assertCryptoError(exception: unknown) {
-  const message = String(exception);
-  expect(message.startsWith('SecurityException: OperationError')).toBe(true);
+	const message = String(exception);
+	expect(message.startsWith("SecurityException: OperationError")).toBe(true);
 }
 
-describe('aes gcm test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("aes gcm test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the timeout.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the timeout.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('basic', async function() {
-    const aead = await aesGcmFromRawKey(Random.randBytes(16));
-    for (let i = 0; i < 100; i++) {
-      const msg = Random.randBytes(i);
-      let ciphertext = await aead.encrypt(msg);
-      let plaintext = await aead.decrypt(ciphertext);
-      expect(ciphertext.length).toBe(12 /* iv */ + msg.length + 16 /* tag */);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+	it("basic", async () => {
+		const aead = await aesGcmFromRawKey(Random.randBytes(16));
+		for (let i = 0; i < 100; i++) {
+			const msg = Random.randBytes(i);
+			let ciphertext = await aead.encrypt(msg);
+			let plaintext = await aead.decrypt(ciphertext);
+			expect(ciphertext.length).toBe(
+				12 /* iv */ + msg.length + 16 /* tag */
+			);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
 
-      let aad = null;
-      ciphertext = await aead.encrypt(msg, aad);
-      plaintext = await aead.decrypt(ciphertext, aad);
-      expect(ciphertext.length).toBe(12 /* iv */ + msg.length + 16 /* tag */);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+			let aad = null;
+			ciphertext = await aead.encrypt(msg, aad);
+			plaintext = await aead.decrypt(ciphertext, aad);
+			expect(ciphertext.length).toBe(
+				12 /* iv */ + msg.length + 16 /* tag */
+			);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
 
-      aad = Random.randBytes(20);
-      ciphertext = await aead.encrypt(msg, aad);
-      plaintext = await aead.decrypt(ciphertext, aad);
-      expect(ciphertext.length).toBe(12 /* iv */ + msg.length + 16 /* tag */);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
-    }
-  });
+			aad = Random.randBytes(20);
+			ciphertext = await aead.encrypt(msg, aad);
+			plaintext = await aead.decrypt(ciphertext, aad);
+			expect(ciphertext.length).toBe(
+				12 /* iv */ + msg.length + 16 /* tag */
+			);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+		}
+	});
 
-  it('probabilistic encryption', async function() {
-    const aead = await aesGcmFromRawKey(Random.randBytes(16));
-    const msg = Random.randBytes(20);
-    const aad = Random.randBytes(20);
-    const results = new Set();
-    for (let i = 0; i < 100; i++) {
-      const ciphertext = await aead.encrypt(msg, aad);
-      results.add(Bytes.toHex(ciphertext));
-    }
-    expect(results.size).toBe(100);
-  });
+	it("probabilistic encryption", async () => {
+		const aead = await aesGcmFromRawKey(Random.randBytes(16));
+		const msg = Random.randBytes(20);
+		const aad = Random.randBytes(20);
+		const results = new Set();
+		for (let i = 0; i < 100; i++) {
+			const ciphertext = await aead.encrypt(msg, aad);
+			results.add(Bytes.toHex(ciphertext));
+		}
+		expect(results.size).toBe(100);
+	});
 
-  it('bit flip ciphertext', async function() {
-    const aead = await aesGcmFromRawKey(Random.randBytes(16));
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 0; i < ciphertext.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const c1 = new Uint8Array(ciphertext);
-        c1[i] = (c1[i] ^ (1 << j));
-        try {
-          await aead.decrypt(c1, aad);
-          fail('expected aead.decrypt to fail');
-        } catch (e) {
-          assertCryptoError(e);
-        }
-      }
-    }
-  });
+	it("bit flip ciphertext", async () => {
+		const aead = await aesGcmFromRawKey(Random.randBytes(16));
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 0; i < ciphertext.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const c1 = new Uint8Array(ciphertext);
+				c1[i] = c1[i] ^ (1 << j);
+				try {
+					await aead.decrypt(c1, aad);
+					fail("expected aead.decrypt to fail");
+				} catch (e) {
+					assertCryptoError(e);
+				}
+			}
+		}
+	});
 
-  it('bit flip aad', async function() {
-    const aead = await aesGcmFromRawKey(Random.randBytes(16));
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 0; i < aad.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const aad1 = new Uint8Array(aad);
-        aad1[i] = (aad1[i] ^ (1 << j));
-        try {
-          await aead.decrypt(ciphertext, aad1);
-          fail('expected aead.decrypt to fail');
-        } catch (e) {
-          assertCryptoError(e);
-        }
-      }
-    }
-  });
+	it("bit flip aad", async () => {
+		const aead = await aesGcmFromRawKey(Random.randBytes(16));
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 0; i < aad.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const aad1 = new Uint8Array(aad);
+				aad1[i] = aad1[i] ^ (1 << j);
+				try {
+					await aead.decrypt(ciphertext, aad1);
+					fail("expected aead.decrypt to fail");
+				} catch (e) {
+					assertCryptoError(e);
+				}
+			}
+		}
+	});
 
-  it('truncation', async function() {
-    const aead = await aesGcmFromRawKey(Random.randBytes(16));
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 1; i <= ciphertext.length; i++) {
-      const c1 = new Uint8Array(ciphertext.buffer, 0, ciphertext.length - i);
-      try {
-        await aead.decrypt(c1, aad);
-        fail('expected aead.decrypt to fail');
-        // Preserving old behavior when moving to
-        // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-        // tslint:disable-next-line:no-any
-      } catch (e: any) {
-        if (c1.length < 12 /* iv */ + 16 /* tag */) {
-          expect(e.toString()).toBe('SecurityException: ciphertext too short');
-        } else {
-          assertCryptoError(e);
-        }
-      }
-    }
-  });
+	it("truncation", async () => {
+		const aead = await aesGcmFromRawKey(Random.randBytes(16));
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 1; i <= ciphertext.length; i++) {
+			const c1 = new Uint8Array(
+				ciphertext.buffer,
+				0,
+				ciphertext.length - i
+			);
+			try {
+				await aead.decrypt(c1, aad);
+				fail("expected aead.decrypt to fail");
+				// Preserving old behavior when moving to
+				// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+				// tslint:disable-next-line:no-any
+			} catch (e: any) {
+				if (c1.length < 12 /* iv */ + 16 /* tag */) {
+					expect(e.toString()).toBe(
+						"SecurityException: ciphertext too short"
+					);
+				} else {
+					assertCryptoError(e);
+				}
+			}
+		}
+	});
 
-  it('with nist test vectors', async function() {
-    // Download from
-    // https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES.
-    const NIST_TEST_VECTORS =
-        [
-          {
-            'Key':
-                'b52c505a37d78eda5dd34f20c22540ea1b58963cf8e5bf8ffa85f9f2492505b4',
-            'IV': '516c33929df5a3284ff463d7',
-            'PT': '',
-            'AAD': '',
-            'CT': '',
-            'Tag': 'bdc1ac884d332457a1d2664f168c76f0',
-          },
-          {
-            'Key':
-                '78dc4e0aaf52d935c3c01eea57428f00ca1fd475f5da86a49c8dd73d68c8e223',
-            'IV': 'd79cf22d504cc793c3fb6c8a',
-            'PT': '',
-            'AAD': 'b96baa8c1c75a671bfb2d08d06be5f36',
-            'CT': '',
-            'Tag': '3e5d486aa2e30b22e040b85723a06e76',
-          },
-          {
-            'Key':
-                '886cff5f3e6b8d0e1ad0a38fcdb26de97e8acbe79f6bed66959a598fa5047d65',
-            'IV': '3a8efa1cd74bbab5448f9945',
-            'PT': '',
-            'AAD': '519fee519d25c7a304d6c6aa1897ee1eb8c59655',
-            'CT': '',
-            'Tag': 'f6d47505ec96c98a42dc3ae719877b87',
-          },
-          {
-            'Key':
-                'f4069bb739d07d0cafdcbc609ca01597f985c43db63bbaaa0debbb04d384e49c',
-            'IV': 'd25ff30fdc3d464fe173e805',
-            'PT': '',
-            'AAD':
-                '3e1449c4837f0892f9d55127c75c4b25d69be334baf5f19394d2d8bb460cbf2120e14736d0f634aa792feca20e455f11',
-            'CT': '',
-            'Tag': '805ec2931c2181e5bfb74fa0a975f0cf',
-          },
-          {
-            'Key':
-                '03ccb7dbc7b8425465c2c3fc39ed0593929ffd02a45ff583bd89b79c6f646fe9',
-            'IV': 'fd119985533bd5520b301d12',
-            'PT': '',
-            'AAD':
-                '98e68c10bf4b5ae62d434928fc6405147c6301417303ef3a703dcfd2c0c339a4d0a89bd29fe61fecf1066ab06d7a5c31a48ffbfed22f749b17e9bd0dc1c6f8fbd6fd4587184db964d5456132106d782338c3f117ec05229b0899',
-            'CT': '',
-            'Tag': 'cf54e7141349b66f248154427810c87a',
-          },
-          {
-            'Key':
-                '31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22',
-            'IV': '0d18e06c7c725ac9e362e1ce',
-            'PT': '2db5168e932556f8089a0622981d017d',
-            'AAD': '',
-            'CT': 'fa4362189661d163fcd6a56d8bf0405a',
-            'Tag': 'd636ac1bbedd5cc3ee727dc2ab4a9489',
-          },
-          {
-            'Key':
-                '92e11dcdaa866f5ce790fd24501f92509aacf4cb8b1339d50c9c1240935dd08b',
-            'IV': 'ac93a1a6145299bde902f21a',
-            'PT': '2d71bcfa914e4ac045b2aa60955fad24',
-            'AAD': '1e0889016f67601c8ebea4943bc23ad6',
-            'CT': '8995ae2e6df3dbf96fac7b7137bae67f',
-            'Tag': 'eca5aa77d51d4a0a14d9c51e1da474ab',
-          },
-          {
-            'Key':
-                '83688deb4af8007f9b713b47cfa6c73e35ea7a3aa4ecdb414dded03bf7a0fd3a',
-            'IV': '0b459724904e010a46901cf3',
-            'PT': '33d893a2114ce06fc15d55e454cf90c3',
-            'AAD': '794a14ccd178c8ebfd1379dc704c5e208f9d8424',
-            'CT': 'cc66bee423e3fcd4c0865715e9586696',
-            'Tag': '0fb291bd3dba94a1dfd8b286cfb97ac5',
-          },
-          {
-            'Key':
-                'e4fed339c7b0cd267305d11ab0d5c3273632e8872d35bdc367a1363438239a35',
-            'IV': '0365882cf75432cfd23cbd42',
-            'PT': 'fff39a087de39a03919fbd2f2fa5f513',
-            'AAD':
-                '8a97d2af5d41160ac2ff7dd8ba098e7aa4d618f0f455957d6a6d0801796747ba57c32dfbaaaf15176528fe3a0e4550c9',
-            'CT': '8d9e68f03f7e5f4a0ffaa7650d026d08',
-            'Tag': '3554542c478c0635285a61d1b51f6afa',
-          },
-          {
-            'Key':
-                '80d755e24d129e68a5259ec2cf618e39317074a83c8961d3768ceb2ed8d5c3d7',
-            'IV': '7598c07ba7b16cd12cf50813',
-            'PT': '5e7fd1298c4f15aa0f1c1e47217aa7a9',
-            'AAD':
-                '0e94f4c48fd0c9690c853ad2a5e197c5de262137b69ed0cdfa28d8d12413e4ffff15374e1cccb0423e8ed829a954a335ed705a272ad7f9abd1057c849bb0d54b768e9d79879ec552461cc04adb6ca0040c5dd5bc733d21a93702',
-            'CT': '5762a38cf3f2fdf3645d2f6696a7eead',
-            'Tag': '8a6708e69468915c5367573924fe1ae3',
-          },
-          {
-            'Key':
-                '82c4f12eeec3b2d3d157b0f992d292b237478d2cecc1d5f161389b97f999057a',
-            'IV': '7b40b20f5f397177990ef2d1',
-            'PT': '982a296ee1cd7086afad976945',
-            'AAD': '',
-            'CT': 'ec8e05a0471d6b43a59ca5335f',
-            'Tag': '113ddeafc62373cac2f5951bb9165249',
-          },
-          {
-            'Key':
-                'dad89d9be9bba138cdcf8752c45b579d7e27c3dbb40f53e771dd8cfd500aa2d5',
-            'IV': 'cfb2aec82cfa6c7d89ee72ff',
-            'PT': 'b526ba1050177d05b0f72f8d67',
-            'AAD': '6e43784a91851a77667a02198e28dc32',
-            'CT': '8b29e66e924ecae84f6d8f7d68',
-            'Tag': '1e365805c8f28b2ed8a5cadfd9079158',
-          },
-          {
-            'Key':
-                '69b458f2644af9020463b40ee503cdf083d693815e2659051ae0d039e606a970',
-            'IV': '8d1da8ab5f91ccd09205944b',
-            'PT': 'f3e0e09224256bf21a83a5de8d',
-            'AAD': '036ad5e5494ef817a8af2f5828784a4bfedd1653',
-            'CT': 'c0a62d77e6031bfdc6b13ae217',
-            'Tag': 'a794a9aaee48cd92e47761bf1baff0af',
-          },
-          {
-            'Key':
-                '5f671466378f470ba5f5160e2209f3d95a48b7e560625d5a08654414de23aee2',
-            'IV': '6b3c08a663d04132243dd96c',
-            'PT': 'c428592d9f8a7f107ec4d0df05',
-            'AAD':
-                '12965559c31d538f937bda6eee9c93b0387318dc5d9496fb1c3a0b9b978dbfebff2a5823974ee9d679834dbe59f7ec51',
-            'CT': '1d8d7fe4357080c817303ce19c',
-            'Tag': 'e88d6b566fdc7b4fd62106bd2eb806ec',
-          },
-          {
-            'Key':
-                'ff9506b4d46ba54128876fadfcc673a4c927c618ea7d95cfcaa508cbc8f7fc66',
-            'IV': '3742ad2208a0484345eee1be',
-            'PT': '7fd0d6cadc92cad27bb2d7d8c8',
-            'AAD':
-                'f1360a27fdc244be8739d85af6491c762a693aafe668c449515fdeeedb6a90aeee3891bbc8b69adc6a6426cb12fcdebc32c9f58c5259d128b91efa28620a3a9a0168b0ff5e76951cb41647ba4aa1f87fac0d97ac580e42cffc7e',
-            'CT': 'bdb8346b28eb4d7226493611a6',
-            'Tag': '7484d827b767647f44c7f94a39f8175c',
-          },
-          {
-            'Key':
-                '268ed1b5d7c9c7304f9cae5fc437b4cd3aebe2ec65f0d85c3918d3d3b5bba89b',
-            'IV': '9ed9d8180564e0e945f5e5d4',
-            'PT':
-                'fe29a40d8ebf57262bdb87191d01843f4ca4b2de97d88273154a0b7d9e2fdb80',
-            'AAD': '',
-            'CT':
-                '791a4a026f16f3a5ea06274bf02baab469860abde5e645f3dd473a5acddeecfc',
-            'Tag': '05b2b74db0662550435ef1900e136b15',
-          },
-          {
-            'Key':
-                '37ccdba1d929d6436c16bba5b5ff34deec88ed7df3d15d0f4ddf80c0c731ee1f',
-            'IV': '5c1b21c8998ed6299006d3f9',
-            'PT':
-                'ad4260e3cdc76bcc10c7b2c06b80b3be948258e5ef20c508a81f51e96a518388',
-            'AAD': '22ed235946235a85a45bc5fad7140bfa',
-            'CT':
-                '3b335f8b08d33ccdcad228a74700f1007542a4d1e7fc1ebe3f447fe71af29816',
-            'Tag': '1fbf49cc46f458bf6e88f6370975e6d4',
-          },
-          {
-            'Key':
-                '5853c020946b35f2c58ec427152b840420c40029636adcbb027471378cfdde0f',
-            'IV': 'eec313dd07cc1b3e6b068a47',
-            'PT':
-                'ce7458e56aef9061cb0c42ec2315565e6168f5a6249ffd31610b6d17ab64935e',
-            'AAD': '1389b522c24a774181700553f0246bbabdd38d6f',
-            'CT':
-                'eadc3b8766a77ded1a58cb727eca2a9790496c298654cda78febf0da16b6903b',
-            'Tag': '3d49a5b32fde7eafcce90079217ffb57',
-          },
-          {
-            'Key':
-                'dc776f0156c15d032623854b625c61868e5db84b7b6f9fbd3672f12f0025e0f6',
-            'IV': '67130951c4a57f6ae7f13241',
-            'PT':
-                '9378a727a5119595ad631b12a5a6bc8a91756ef09c8d6eaa2b718fe86876da20',
-            'AAD':
-                'fd0920faeb7b212932280a009bac969145e5c316cf3922622c3705c3457c4e9f124b2076994323fbcfb523f8ed16d241',
-            'CT':
-                '6d958c20870d401a3c1f7a0ac092c97774d451c09f7aae992a8841ff0ab9d60d',
-            'Tag': 'b876831b4ecd7242963b040aa45c4114',
-          },
-          {
-            'Key':
-                '26bf255bee60ef0f653769e7034db95b8c791752754e575c761059e9ee8dcf78',
-            'IV': 'cecd97ab07ce57c1612744f5',
-            'PT':
-                '96983917a036650763aca2b4e927d95ffc74339519ed40c4336dba91edfbf9ad',
-            'AAD':
-                'afebbe9f260f8c118e52b84d8880a34622675faef334cdb41be9385b7d059b79c0f8a432d25f8b71e781b177fce4d4c57ac5734543e85d7513f96382ff4b2d4b95b2f1fdbaf9e78bbd1db13a7dd26e8a4ac83a3e8ab42d1d545f',
-            'CT':
-                'e34b1540a769f7913331d66796e00bdc3ee0f258cf244eb7663375cc5ad6c658',
-            'Tag': '3841f02beb7a7fca7e578922d0a2f80c',
-          },
-          {
-            'Key':
-                '1fded32d5999de4a76e0f8082108823aef60417e1896cf4218a2fa90f632ec8a',
-            'IV': '1f3afa4711e9474f32e70462',
-            'PT':
-                '06b2c75853df9aeb17befd33cea81c630b0fc53667ff45199c629c8e15dce41e530aa792f796b8138eeab2e86c7b7bee1d40b0',
-            'AAD': '',
-            'CT':
-                '91fbd061ddc5a7fcc9513fcdfdc9c3a7c5d4d64cedf6a9c24ab8a77c36eefbf1c5dc00bc50121b96456c8cd8b6ff1f8b3e480f',
-            'Tag': '30096d340f3d5c42d82a6f475def23eb',
-          },
-          {
-            'Key':
-                '5fe01c4baf01cbe07796d5aaef6ec1f45193a98a223594ae4f0ef4952e82e330',
-            'IV': 'bd587321566c7f1a5dd8652d',
-            'PT':
-                '881dc6c7a5d4509f3c4bd2daab08f165ddc204489aa8134562a4eac3d0bcad7965847b102733bb63d1e5c598ece0c3e5dadddd',
-            'AAD': '9013617817dda947e135ee6dd3653382',
-            'CT':
-                '16e375b4973b339d3f746c1c5a568bc7526e909ddff1e19c95c94a6ccff210c9a4a40679de5760c396ac0e2ceb1234f9f5fe26',
-            'Tag': 'abd3d26d65a6275f7a4f56b422acab49',
-          },
-          {
-            'Key':
-                '24501ad384e473963d476edcfe08205237acfd49b5b8f33857f8114e863fec7f',
-            'IV': '9ff18563b978ec281b3f2794',
-            'PT':
-                '27f348f9cdc0c5bd5e66b1ccb63ad920ff2219d14e8d631b3872265cf117ee86757accb158bd9abb3868fdc0d0b074b5f01b2c',
-            'AAD': 'adb5ec720ccf9898500028bf34afccbcaca126ef',
-            'CT':
-                'eb7cb754c824e8d96f7c6d9b76c7d26fb874ffbf1d65c6f64a698d839b0b06145dae82057ad55994cf59ad7f67c0fa5e85fab8',
-            'Tag': 'bc95c532fecc594c36d1550286a7a3f0',
-          },
-          {
-            'Key':
-                '463b412911767d57a0b33969e674ffe7845d313b88c6fe312f3d724be68e1fca',
-            'IV': '611ce6f9a6880750de7da6cb',
-            'PT':
-                'e7d1dcf668e2876861940e012fe52a98dacbd78ab63c08842cc9801ea581682ad54af0c34d0d7f6f59e8ee0bf4900e0fd85042',
-            'AAD':
-                '0a682fbc6192e1b47a5e0868787ffdafe5a50cead3575849990cdd2ea9b3597749403efb4a56684f0c6bde352d4aeec5',
-            'CT':
-                '8886e196010cb3849d9c1a182abe1eeab0a5f3ca423c3669a4a8703c0f146e8e956fb122e0d721b869d2b6fcd4216d7d4d3758',
-            'Tag': '2469cecd70fd98fec9264f71df1aee9a',
-          },
-          {
-            'Key':
-                '148579a3cbca86d5520d66c0ec71ca5f7e41ba78e56dc6eebd566fed547fe691',
-            'IV': 'b08a5ea1927499c6ecbfd4e0',
-            'PT':
-                '9d0b15fdf1bd595f91f8b3abc0f7dec927dfd4799935a1795d9ce00c9b879434420fe42c275a7cd7b39d638fb81ca52b49dc41',
-            'AAD':
-                'e4f963f015ffbb99ee3349bbaf7e8e8e6c2a71c230a48f9d59860a29091d2747e01a5ca572347e247d25f56ba7ae8e05cde2be3c97931292c02370208ecd097ef692687fecf2f419d3200162a6480a57dad408a0dfeb492e2c5d',
-            'CT':
-                '2097e372950a5e9383c675e89eea1c314f999159f5611344b298cda45e62843716f215f82ee663919c64002a5c198d7878fd3f',
-            'Tag': 'adbecdb0d5c2224d804d2886ff9a5760',
-          },
-          {
-            'Key': '11754cd72aec309bf52f7687212e8957',
-            'IV': '3c819d9a9bed087615030b65',
-            'PT': '',
-            'AAD': '',
-            'CT': '',
-            'Tag': '250327c674aaf477aef2675748cf6971',
-          },
-          {
-            'Key': '77be63708971c4e240d1cb79e8d77feb',
-            'IV': 'e0e00f19fed7ba0136a797f3',
-            'PT': '',
-            'AAD': '7a43ec1d9c0a5a78a0b16533a6213cab',
-            'CT': '',
-            'Tag': '209fcc8d3675ed938e9c7166709dd946',
-          },
-          {
-            'Key': '2fb45e5b8f993a2bfebc4b15b533e0b4',
-            'IV': '5b05755f984d2b90f94b8027',
-            'PT': '',
-            'AAD': 'e85491b2202caf1d7dce03b97e09331c32473941',
-            'CT': '',
-            'Tag': 'c75b7832b2a2d9bd827412b6ef5769db',
-          },
-          {
-            'Key': '99e3e8793e686e571d8285c564f75e2b',
-            'IV': 'c2dd0ab868da6aa8ad9c0d23',
-            'PT': '',
-            'AAD':
-                'b668e42d4e444ca8b23cfdd95a9fedd5178aa521144890b093733cf5cf22526c5917ee476541809ac6867a8c399309fc',
-            'CT': '',
-            'Tag': '3f4fba100eaf1f34b0baadaae9995d85',
-          },
-          {
-            'Key': '20b5b6b854e187b058a84d57bc1538b6',
-            'IV': '94c1935afc061cbf254b936f',
-            'PT': '',
-            'AAD':
-                'ca418e71dbf810038174eaa3719b3fcb80531c7110ad9192d105eeaafa15b819ac005668752b344ed1b22faf77048baf03dbddb3b47d6b00e95c4f005e0cc9b7627ccafd3f21b3312aa8d91d3fa0893fe5bff7d44ca46f23afe0',
-            'CT': '',
-            'Tag': 'b37286ebaf4a54e0ffc2a1deafc9f6db',
-          },
-          {
-            'Key': '7fddb57453c241d03efbed3ac44e371c',
-            'IV': 'ee283a3fc75575e33efd4887',
-            'PT': 'd5de42b461646c255c87bd2962d3b9a2',
-            'AAD': '',
-            'CT': '2ccda4a5415cb91e135c2a0f78c9b2fd',
-            'Tag': 'b36d1df9b9d5e596f83e8b7f52971cb3',
-          },
-          {
-            'Key': 'c939cc13397c1d37de6ae0e1cb7c423c',
-            'IV': 'b3d8cc017cbb89b39e0f67e2',
-            'PT': 'c3b3c41f113a31b73d9a5cd432103069',
-            'AAD': '24825602bd12a984e0092d3e448eda5f',
-            'CT': '93fe7d9e9bfd10348a5606e5cafa7354',
-            'Tag': '0032a1dc85f1c9786925a2e71d8272dd',
-          },
-          {
-            'Key': 'd4a22488f8dd1d5c6c19a7d6ca17964c',
-            'IV': 'f3d5837f22ac1a0425e0d1d5',
-            'PT': '7b43016a16896497fb457be6d2a54122',
-            'AAD': 'f1c5d424b83f96c6ad8cb28ca0d20e475e023b5a',
-            'CT': 'c2bd67eef5e95cac27e3b06e3031d0a8',
-            'Tag': 'f23eacf9d1cdf8737726c58648826e9c',
-          },
-          {
-            'Key': '89850dd398e1f1e28443a33d40162664',
-            'IV': 'e462c58482fe8264aeeb7231',
-            'PT': '2805cdefb3ef6cc35cd1f169f98da81a',
-            'AAD':
-                'd74e99d1bdaa712864eec422ac507bddbe2b0d4633cd3dff29ce5059b49fe868526c59a2a3a604457bc2afea866e7606',
-            'CT': 'ba80e244b7fc9025cd031d0f63677e06',
-            'Tag': 'd84a8c3eac57d1bb0e890a8f461d1065',
-          },
-          {
-            'Key': 'bd7c5c63b7542b56a00ebe71336a1588',
-            'IV': '87721f23ba9c3c8ea5571abc',
-            'PT': 'de15ddbb1e202161e8a79af6a55ac6f3',
-            'AAD':
-                'a6ec8075a0d3370eb7598918f3b93e48444751624997b899a87fa6a9939f844e008aa8b70e9f4c3b1a19d3286bf543e7127bfecba1ad17a5ec53fccc26faecacc4c75369498eaa7d706aef634d0009279b11e4ba6c993e5e9ed9',
-            'CT': '41eb28c0fee4d762de972361c863bc80',
-            'Tag': '9cb567220d0b252eb97bff46e4b00ff8',
-          },
-          {
-            'Key': 'fe9bb47deb3a61e423c2231841cfd1fb',
-            'IV': '4d328eb776f500a2f7fb47aa',
-            'PT': 'f1cc3818e421876bb6b8bbd6c9',
-            'AAD': '',
-            'CT': 'b88c5c1977b35b517b0aeae967',
-            'Tag': '43fd4727fe5cdb4b5b42818dea7ef8c9',
-          },
-          {
-            'Key': 'dfefde23c6122bf0370ab5890e804b73',
-            'IV': '92d6a8029990670f16de79e2',
-            'PT': '64260a8c287de978e96c7521d0',
-            'AAD': 'a2b16d78251de6c191ce350e5c5ef242',
-            'CT': 'bf78de948a847c173649d4b4d0',
-            'Tag': '9da3829968cdc50794d1c30d41cd4515',
-          },
-          {
-            'Key': 'fe0121f42e599f88ff02a985403e19bb',
-            'IV': '3bb9eb7724cbe1943d43de21',
-            'PT': 'fd331ca8646091c29f21e5f0a1',
-            'AAD': '2662d895035b6519f3510eae0faa3900ad23cfdf',
-            'CT': '59fe29b07b0de8d869efbbd9b4',
-            'Tag': 'd24c3e9c1c73c0af1097e26061c857de',
-          },
-          {
-            'Key': 'cbd3b8dbfcfb11ce345706e6cd73881a',
-            'IV': 'dc62bb68d0ec9a5d759d6741',
-            'PT': '85f83bf598dfd55bc8bfde2a64',
-            'AAD':
-                '0944b661fe6294f3c92abb087ec1b259b032dc4e0c5f28681cbe6e63c2178f474326f35ad3ca80c28e3485e7e5b252c8',
-            'CT': '206f6b3bb032dfecd39f8340b1',
-            'Tag': '425a21b2ea90580c889134032b914bb5',
-          },
-          {
-            'Key': 'e5b1e7a94e9e1fda0873571eec713429',
-            'IV': '5ddde829a81713346af8e5b7',
-            'PT': '850069e5ed768b5dc9ed7ad485',
-            'AAD':
-                'b0ce75da427fba93da6d3455b2b440a877599a6d8d6d2d66ee90b5cf9a33baaa8329a9ffaac290e8e33f2af2548c2a8a181b3d4d9f8fac860cc26b0d26b9cc53bc9f405afa73605ebeb376f2d1d7fcb065bab92f20f295556ade',
-            'CT': 'c211d9079d5562659db01e17d1',
-            'Tag': '884893fb035d3d7237d47c363de62bb3',
-          },
-          {
-            'Key': '9971071059abc009e4f2bd69869db338',
-            'IV': '07a9a95ea3821e9c13c63251',
-            'PT':
-                'f54bc3501fed4f6f6dfb5ea80106df0bd836e6826225b75c0222f6e859b35983',
-            'AAD': '',
-            'CT':
-                '0556c159f84ef36cb1602b4526b12009c775611bffb64dc0d9ca9297cd2c6a01',
-            'Tag': '7870d9117f54811a346970f1de090c41',
-          },
-          {
-            'Key': '298efa1ccf29cf62ae6824bfc19557fc',
-            'IV': '6f58a93fe1d207fae4ed2f6d',
-            'PT':
-                'cc38bccd6bc536ad919b1395f5d63801f99f8068d65ca5ac63872daf16b93901',
-            'AAD': '021fafd238463973ffe80256e5b1c6b1',
-            'CT':
-                'dfce4e9cd291103d7fe4e63351d9e79d3dfd391e3267104658212da96521b7db',
-            'Tag': '542465ef599316f73a7a560509a2d9f2',
-          },
-          {
-            'Key': 'fedc7155192d00b23cdd98750db9ebba',
-            'IV': 'a76b74f55c1a1756a08338b1',
-            'PT':
-                '6831435b8857daf1c513b148820d13b5a72cc490bda79a98a6f520d8763c39d1',
-            'AAD': '2ad206c4176e7e552aa08836886816fafa77e759',
-            'CT':
-                '15823805da89a1923bfc1d6f87784d56bad1128b4dffdbdeefbb2fa562c35e68',
-            'Tag': 'd23dc455ced49887c717e8eabeec2984',
-          },
-          {
-            'Key': '48b7f337cdf9252687ecc760bd8ec184',
-            'IV': '3e894ebb16ce82a53c3e05b2',
-            'PT':
-                'bb2bac67a4709430c39c2eb9acfabc0d456c80d30aa1734e57997d548a8f0603',
-            'AAD':
-                '7d924cfd37b3d046a96eb5e132042405c8731e06509787bbeb41f258275746495e884d69871f77634c584bb007312234',
-            'CT':
-                'd263228b8ce051f67e9baf1ce7df97d10cd5f3bc972362055130c7d13c3ab2e7',
-            'Tag': '71446737ca1fa92e6d026d7d2ed1aa9c',
-          },
-          {
-            'Key': '8fbf7ca12fd525dde91e625873fe51c2',
-            'IV': '200bea517b9790a1cfadaf5e',
-            'PT':
-                '39d3e6277c4b4963840d1642e6faae0a5be2da97f61c4e55bb57ce021903d4c4',
-            'AAD':
-                'a414c07fe2e60bec9ccc409e9e899c6fe60580bb2607c861f7f08523e69cda1b9c3a711d1d9c35091771e4c950b9996d0ad04f2e00d1b3105853542a96e09ffffc2ec80f8cf88728f594f0aeb14f98a688234e8bfbf70327b364',
-            'CT':
-                'fe678ef76f69ac95db553b6dadd5a07a9dc8e151fe6a9fa3a1cd621636b87868',
-            'Tag': '7c860774f88332b9a7ce6bbd0272a727',
-          },
-          {
-            'Key': '594157ec4693202b030f33798b07176d',
-            'IV': '49b12054082660803a1df3df',
-            'PT':
-                '3feef98a976a1bd634f364ac428bb59cd51fb159ec1789946918dbd50ea6c9d594a3a31a5269b0da6936c29d063a5fa2cc8a1c',
-            'AAD': '',
-            'CT':
-                'c1b7a46a335f23d65b8db4008a49796906e225474f4fe7d39e55bf2efd97fd82d4167de082ae30fa01e465a601235d8d68bc69',
-            'Tag': 'ba92d3661ce8b04687e8788d55417dc2',
-          },
-          {
-            'Key': 'b61553bb854895b929751cd0c5f80384',
-            'IV': '8863f999ae64e55d0bbd7457',
-            'PT':
-                '9b1b113217d0c4ea7943cf123c69c6ad2e3c97368c51c9754145d155dde1ee8640c8cafff17a5c9737d26a137eee4bf369096d',
-            'AAD': 'd914b5f2d1b08ce53ea59cb310587245',
-            'CT':
-                'acfab4632b8a25805112f13d85e082bc89dc49bd92164fa8a2dad242c3a1b2f2696f2fdff579025f3f146ea97da3e47dc34b65',
-            'Tag': '5d9b5f4a9868c1c69cbd6fd851f01340',
-          },
-          {
-            'Key': 'fe47fcce5fc32665d2ae399e4eec72ba',
-            'IV': '5adb9609dbaeb58cbd6e7275',
-            'PT':
-                '7c0e88c88899a779228465074797cd4c2e1498d259b54390b85e3eef1c02df60e743f1b840382c4bccaf3bafb4ca8429bea063',
-            'AAD': '88319d6e1d3ffa5f987199166c8a9b56c2aeba5a',
-            'CT':
-                '98f4826f05a265e6dd2be82db241c0fbbbf9ffb1c173aa83964b7cf5393043736365253ddbc5db8778371495da76d269e5db3e',
-            'Tag': '291ef1982e4defedaa2249f898556b47',
-          },
-          {
-            'Key': '3c50622868f450aa0928990c15e1eb36',
-            'IV': '811d5290768d57e7d87bb6c7',
-            'PT':
-                'edd0a8f82833e919740fe2bf9edecf4ac86c72dc89490cef7b6983aaaf99fc856c5cc87d63f98a7c861bf3271fea6da86a15ab',
-            'AAD':
-                'dae2c7e0a3d3fd2bc04eca19b15178a003b5cf84890c28c2a615f20f8adb427f70698c12b2ef87780c1193fbb8cd1674',
-            'CT':
-                'a51425b0608d3b4b46d4ec05ca1ddaf02bdd2089ae0554ecfb2a1c84c63d82dc71ddb9ab1b1f0b49de2ad27c2b5173e7000aa6',
-            'Tag': 'bd9b5efca48008cd973a4f7d2c723844',
-          },
-          {
-            'Key': '2c1f21cf0f6fb3661943155c3e3d8492',
-            'IV': '23cb5ff362e22426984d1907',
-            'PT':
-                '42f758836986954db44bf37c6ef5e4ac0adaf38f27252a1b82d02ea949c8a1a2dbc0d68b5615ba7c1220ff6510e259f06655d8',
-            'AAD':
-                '5d3624879d35e46849953e45a32a624d6a6c536ed9857c613b572b0333e701557a713e3f010ecdf9a6bd6c9e3e44b065208645aff4aabee611b391528514170084ccf587177f4488f33cfb5e979e42b6e1cfc0a60238982a7aec',
-            'CT':
-                '81824f0e0d523db30d3da369fdc0d60894c7a0a20646dd015073ad2732bd989b14a222b6ad57af43e1895df9dca2a5344a62cc',
-            'Tag': '57a3ee28136e94c74838997ae9823f3a',
-          },
-        ];
-    for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
-      const testVector = NIST_TEST_VECTORS[i];
-      const aead = await aesGcmFromRawKey(Bytes.fromHex(testVector['Key']));
-      const ciphertext = Bytes.fromHex(
-          testVector['IV'] + testVector['CT'] + testVector['Tag']);
-      const aad = Bytes.fromHex(testVector['AAD']);
-      try {
-        const plaintext = await aead.decrypt(ciphertext, aad);
-        expect(testVector['PT']).toBe(Bytes.toHex(plaintext));
-      } catch (e) {
-        fail(e);
-      }
-    }
-  });
+	it("with nist test vectors", async () => {
+		// Download from
+		// https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES.
+		const NIST_TEST_VECTORS = [
+			{
+				Key: "b52c505a37d78eda5dd34f20c22540ea1b58963cf8e5bf8ffa85f9f2492505b4",
+				IV: "516c33929df5a3284ff463d7",
+				PT: "",
+				AAD: "",
+				CT: "",
+				Tag: "bdc1ac884d332457a1d2664f168c76f0",
+			},
+			{
+				Key: "78dc4e0aaf52d935c3c01eea57428f00ca1fd475f5da86a49c8dd73d68c8e223",
+				IV: "d79cf22d504cc793c3fb6c8a",
+				PT: "",
+				AAD: "b96baa8c1c75a671bfb2d08d06be5f36",
+				CT: "",
+				Tag: "3e5d486aa2e30b22e040b85723a06e76",
+			},
+			{
+				Key: "886cff5f3e6b8d0e1ad0a38fcdb26de97e8acbe79f6bed66959a598fa5047d65",
+				IV: "3a8efa1cd74bbab5448f9945",
+				PT: "",
+				AAD: "519fee519d25c7a304d6c6aa1897ee1eb8c59655",
+				CT: "",
+				Tag: "f6d47505ec96c98a42dc3ae719877b87",
+			},
+			{
+				Key: "f4069bb739d07d0cafdcbc609ca01597f985c43db63bbaaa0debbb04d384e49c",
+				IV: "d25ff30fdc3d464fe173e805",
+				PT: "",
+				AAD: "3e1449c4837f0892f9d55127c75c4b25d69be334baf5f19394d2d8bb460cbf2120e14736d0f634aa792feca20e455f11",
+				CT: "",
+				Tag: "805ec2931c2181e5bfb74fa0a975f0cf",
+			},
+			{
+				Key: "03ccb7dbc7b8425465c2c3fc39ed0593929ffd02a45ff583bd89b79c6f646fe9",
+				IV: "fd119985533bd5520b301d12",
+				PT: "",
+				AAD: "98e68c10bf4b5ae62d434928fc6405147c6301417303ef3a703dcfd2c0c339a4d0a89bd29fe61fecf1066ab06d7a5c31a48ffbfed22f749b17e9bd0dc1c6f8fbd6fd4587184db964d5456132106d782338c3f117ec05229b0899",
+				CT: "",
+				Tag: "cf54e7141349b66f248154427810c87a",
+			},
+			{
+				Key: "31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22",
+				IV: "0d18e06c7c725ac9e362e1ce",
+				PT: "2db5168e932556f8089a0622981d017d",
+				AAD: "",
+				CT: "fa4362189661d163fcd6a56d8bf0405a",
+				Tag: "d636ac1bbedd5cc3ee727dc2ab4a9489",
+			},
+			{
+				Key: "92e11dcdaa866f5ce790fd24501f92509aacf4cb8b1339d50c9c1240935dd08b",
+				IV: "ac93a1a6145299bde902f21a",
+				PT: "2d71bcfa914e4ac045b2aa60955fad24",
+				AAD: "1e0889016f67601c8ebea4943bc23ad6",
+				CT: "8995ae2e6df3dbf96fac7b7137bae67f",
+				Tag: "eca5aa77d51d4a0a14d9c51e1da474ab",
+			},
+			{
+				Key: "83688deb4af8007f9b713b47cfa6c73e35ea7a3aa4ecdb414dded03bf7a0fd3a",
+				IV: "0b459724904e010a46901cf3",
+				PT: "33d893a2114ce06fc15d55e454cf90c3",
+				AAD: "794a14ccd178c8ebfd1379dc704c5e208f9d8424",
+				CT: "cc66bee423e3fcd4c0865715e9586696",
+				Tag: "0fb291bd3dba94a1dfd8b286cfb97ac5",
+			},
+			{
+				Key: "e4fed339c7b0cd267305d11ab0d5c3273632e8872d35bdc367a1363438239a35",
+				IV: "0365882cf75432cfd23cbd42",
+				PT: "fff39a087de39a03919fbd2f2fa5f513",
+				AAD: "8a97d2af5d41160ac2ff7dd8ba098e7aa4d618f0f455957d6a6d0801796747ba57c32dfbaaaf15176528fe3a0e4550c9",
+				CT: "8d9e68f03f7e5f4a0ffaa7650d026d08",
+				Tag: "3554542c478c0635285a61d1b51f6afa",
+			},
+			{
+				Key: "80d755e24d129e68a5259ec2cf618e39317074a83c8961d3768ceb2ed8d5c3d7",
+				IV: "7598c07ba7b16cd12cf50813",
+				PT: "5e7fd1298c4f15aa0f1c1e47217aa7a9",
+				AAD: "0e94f4c48fd0c9690c853ad2a5e197c5de262137b69ed0cdfa28d8d12413e4ffff15374e1cccb0423e8ed829a954a335ed705a272ad7f9abd1057c849bb0d54b768e9d79879ec552461cc04adb6ca0040c5dd5bc733d21a93702",
+				CT: "5762a38cf3f2fdf3645d2f6696a7eead",
+				Tag: "8a6708e69468915c5367573924fe1ae3",
+			},
+			{
+				Key: "82c4f12eeec3b2d3d157b0f992d292b237478d2cecc1d5f161389b97f999057a",
+				IV: "7b40b20f5f397177990ef2d1",
+				PT: "982a296ee1cd7086afad976945",
+				AAD: "",
+				CT: "ec8e05a0471d6b43a59ca5335f",
+				Tag: "113ddeafc62373cac2f5951bb9165249",
+			},
+			{
+				Key: "dad89d9be9bba138cdcf8752c45b579d7e27c3dbb40f53e771dd8cfd500aa2d5",
+				IV: "cfb2aec82cfa6c7d89ee72ff",
+				PT: "b526ba1050177d05b0f72f8d67",
+				AAD: "6e43784a91851a77667a02198e28dc32",
+				CT: "8b29e66e924ecae84f6d8f7d68",
+				Tag: "1e365805c8f28b2ed8a5cadfd9079158",
+			},
+			{
+				Key: "69b458f2644af9020463b40ee503cdf083d693815e2659051ae0d039e606a970",
+				IV: "8d1da8ab5f91ccd09205944b",
+				PT: "f3e0e09224256bf21a83a5de8d",
+				AAD: "036ad5e5494ef817a8af2f5828784a4bfedd1653",
+				CT: "c0a62d77e6031bfdc6b13ae217",
+				Tag: "a794a9aaee48cd92e47761bf1baff0af",
+			},
+			{
+				Key: "5f671466378f470ba5f5160e2209f3d95a48b7e560625d5a08654414de23aee2",
+				IV: "6b3c08a663d04132243dd96c",
+				PT: "c428592d9f8a7f107ec4d0df05",
+				AAD: "12965559c31d538f937bda6eee9c93b0387318dc5d9496fb1c3a0b9b978dbfebff2a5823974ee9d679834dbe59f7ec51",
+				CT: "1d8d7fe4357080c817303ce19c",
+				Tag: "e88d6b566fdc7b4fd62106bd2eb806ec",
+			},
+			{
+				Key: "ff9506b4d46ba54128876fadfcc673a4c927c618ea7d95cfcaa508cbc8f7fc66",
+				IV: "3742ad2208a0484345eee1be",
+				PT: "7fd0d6cadc92cad27bb2d7d8c8",
+				AAD: "f1360a27fdc244be8739d85af6491c762a693aafe668c449515fdeeedb6a90aeee3891bbc8b69adc6a6426cb12fcdebc32c9f58c5259d128b91efa28620a3a9a0168b0ff5e76951cb41647ba4aa1f87fac0d97ac580e42cffc7e",
+				CT: "bdb8346b28eb4d7226493611a6",
+				Tag: "7484d827b767647f44c7f94a39f8175c",
+			},
+			{
+				Key: "268ed1b5d7c9c7304f9cae5fc437b4cd3aebe2ec65f0d85c3918d3d3b5bba89b",
+				IV: "9ed9d8180564e0e945f5e5d4",
+				PT: "fe29a40d8ebf57262bdb87191d01843f4ca4b2de97d88273154a0b7d9e2fdb80",
+				AAD: "",
+				CT: "791a4a026f16f3a5ea06274bf02baab469860abde5e645f3dd473a5acddeecfc",
+				Tag: "05b2b74db0662550435ef1900e136b15",
+			},
+			{
+				Key: "37ccdba1d929d6436c16bba5b5ff34deec88ed7df3d15d0f4ddf80c0c731ee1f",
+				IV: "5c1b21c8998ed6299006d3f9",
+				PT: "ad4260e3cdc76bcc10c7b2c06b80b3be948258e5ef20c508a81f51e96a518388",
+				AAD: "22ed235946235a85a45bc5fad7140bfa",
+				CT: "3b335f8b08d33ccdcad228a74700f1007542a4d1e7fc1ebe3f447fe71af29816",
+				Tag: "1fbf49cc46f458bf6e88f6370975e6d4",
+			},
+			{
+				Key: "5853c020946b35f2c58ec427152b840420c40029636adcbb027471378cfdde0f",
+				IV: "eec313dd07cc1b3e6b068a47",
+				PT: "ce7458e56aef9061cb0c42ec2315565e6168f5a6249ffd31610b6d17ab64935e",
+				AAD: "1389b522c24a774181700553f0246bbabdd38d6f",
+				CT: "eadc3b8766a77ded1a58cb727eca2a9790496c298654cda78febf0da16b6903b",
+				Tag: "3d49a5b32fde7eafcce90079217ffb57",
+			},
+			{
+				Key: "dc776f0156c15d032623854b625c61868e5db84b7b6f9fbd3672f12f0025e0f6",
+				IV: "67130951c4a57f6ae7f13241",
+				PT: "9378a727a5119595ad631b12a5a6bc8a91756ef09c8d6eaa2b718fe86876da20",
+				AAD: "fd0920faeb7b212932280a009bac969145e5c316cf3922622c3705c3457c4e9f124b2076994323fbcfb523f8ed16d241",
+				CT: "6d958c20870d401a3c1f7a0ac092c97774d451c09f7aae992a8841ff0ab9d60d",
+				Tag: "b876831b4ecd7242963b040aa45c4114",
+			},
+			{
+				Key: "26bf255bee60ef0f653769e7034db95b8c791752754e575c761059e9ee8dcf78",
+				IV: "cecd97ab07ce57c1612744f5",
+				PT: "96983917a036650763aca2b4e927d95ffc74339519ed40c4336dba91edfbf9ad",
+				AAD: "afebbe9f260f8c118e52b84d8880a34622675faef334cdb41be9385b7d059b79c0f8a432d25f8b71e781b177fce4d4c57ac5734543e85d7513f96382ff4b2d4b95b2f1fdbaf9e78bbd1db13a7dd26e8a4ac83a3e8ab42d1d545f",
+				CT: "e34b1540a769f7913331d66796e00bdc3ee0f258cf244eb7663375cc5ad6c658",
+				Tag: "3841f02beb7a7fca7e578922d0a2f80c",
+			},
+			{
+				Key: "1fded32d5999de4a76e0f8082108823aef60417e1896cf4218a2fa90f632ec8a",
+				IV: "1f3afa4711e9474f32e70462",
+				PT: "06b2c75853df9aeb17befd33cea81c630b0fc53667ff45199c629c8e15dce41e530aa792f796b8138eeab2e86c7b7bee1d40b0",
+				AAD: "",
+				CT: "91fbd061ddc5a7fcc9513fcdfdc9c3a7c5d4d64cedf6a9c24ab8a77c36eefbf1c5dc00bc50121b96456c8cd8b6ff1f8b3e480f",
+				Tag: "30096d340f3d5c42d82a6f475def23eb",
+			},
+			{
+				Key: "5fe01c4baf01cbe07796d5aaef6ec1f45193a98a223594ae4f0ef4952e82e330",
+				IV: "bd587321566c7f1a5dd8652d",
+				PT: "881dc6c7a5d4509f3c4bd2daab08f165ddc204489aa8134562a4eac3d0bcad7965847b102733bb63d1e5c598ece0c3e5dadddd",
+				AAD: "9013617817dda947e135ee6dd3653382",
+				CT: "16e375b4973b339d3f746c1c5a568bc7526e909ddff1e19c95c94a6ccff210c9a4a40679de5760c396ac0e2ceb1234f9f5fe26",
+				Tag: "abd3d26d65a6275f7a4f56b422acab49",
+			},
+			{
+				Key: "24501ad384e473963d476edcfe08205237acfd49b5b8f33857f8114e863fec7f",
+				IV: "9ff18563b978ec281b3f2794",
+				PT: "27f348f9cdc0c5bd5e66b1ccb63ad920ff2219d14e8d631b3872265cf117ee86757accb158bd9abb3868fdc0d0b074b5f01b2c",
+				AAD: "adb5ec720ccf9898500028bf34afccbcaca126ef",
+				CT: "eb7cb754c824e8d96f7c6d9b76c7d26fb874ffbf1d65c6f64a698d839b0b06145dae82057ad55994cf59ad7f67c0fa5e85fab8",
+				Tag: "bc95c532fecc594c36d1550286a7a3f0",
+			},
+			{
+				Key: "463b412911767d57a0b33969e674ffe7845d313b88c6fe312f3d724be68e1fca",
+				IV: "611ce6f9a6880750de7da6cb",
+				PT: "e7d1dcf668e2876861940e012fe52a98dacbd78ab63c08842cc9801ea581682ad54af0c34d0d7f6f59e8ee0bf4900e0fd85042",
+				AAD: "0a682fbc6192e1b47a5e0868787ffdafe5a50cead3575849990cdd2ea9b3597749403efb4a56684f0c6bde352d4aeec5",
+				CT: "8886e196010cb3849d9c1a182abe1eeab0a5f3ca423c3669a4a8703c0f146e8e956fb122e0d721b869d2b6fcd4216d7d4d3758",
+				Tag: "2469cecd70fd98fec9264f71df1aee9a",
+			},
+			{
+				Key: "148579a3cbca86d5520d66c0ec71ca5f7e41ba78e56dc6eebd566fed547fe691",
+				IV: "b08a5ea1927499c6ecbfd4e0",
+				PT: "9d0b15fdf1bd595f91f8b3abc0f7dec927dfd4799935a1795d9ce00c9b879434420fe42c275a7cd7b39d638fb81ca52b49dc41",
+				AAD: "e4f963f015ffbb99ee3349bbaf7e8e8e6c2a71c230a48f9d59860a29091d2747e01a5ca572347e247d25f56ba7ae8e05cde2be3c97931292c02370208ecd097ef692687fecf2f419d3200162a6480a57dad408a0dfeb492e2c5d",
+				CT: "2097e372950a5e9383c675e89eea1c314f999159f5611344b298cda45e62843716f215f82ee663919c64002a5c198d7878fd3f",
+				Tag: "adbecdb0d5c2224d804d2886ff9a5760",
+			},
+			{
+				Key: "11754cd72aec309bf52f7687212e8957",
+				IV: "3c819d9a9bed087615030b65",
+				PT: "",
+				AAD: "",
+				CT: "",
+				Tag: "250327c674aaf477aef2675748cf6971",
+			},
+			{
+				Key: "77be63708971c4e240d1cb79e8d77feb",
+				IV: "e0e00f19fed7ba0136a797f3",
+				PT: "",
+				AAD: "7a43ec1d9c0a5a78a0b16533a6213cab",
+				CT: "",
+				Tag: "209fcc8d3675ed938e9c7166709dd946",
+			},
+			{
+				Key: "2fb45e5b8f993a2bfebc4b15b533e0b4",
+				IV: "5b05755f984d2b90f94b8027",
+				PT: "",
+				AAD: "e85491b2202caf1d7dce03b97e09331c32473941",
+				CT: "",
+				Tag: "c75b7832b2a2d9bd827412b6ef5769db",
+			},
+			{
+				Key: "99e3e8793e686e571d8285c564f75e2b",
+				IV: "c2dd0ab868da6aa8ad9c0d23",
+				PT: "",
+				AAD: "b668e42d4e444ca8b23cfdd95a9fedd5178aa521144890b093733cf5cf22526c5917ee476541809ac6867a8c399309fc",
+				CT: "",
+				Tag: "3f4fba100eaf1f34b0baadaae9995d85",
+			},
+			{
+				Key: "20b5b6b854e187b058a84d57bc1538b6",
+				IV: "94c1935afc061cbf254b936f",
+				PT: "",
+				AAD: "ca418e71dbf810038174eaa3719b3fcb80531c7110ad9192d105eeaafa15b819ac005668752b344ed1b22faf77048baf03dbddb3b47d6b00e95c4f005e0cc9b7627ccafd3f21b3312aa8d91d3fa0893fe5bff7d44ca46f23afe0",
+				CT: "",
+				Tag: "b37286ebaf4a54e0ffc2a1deafc9f6db",
+			},
+			{
+				Key: "7fddb57453c241d03efbed3ac44e371c",
+				IV: "ee283a3fc75575e33efd4887",
+				PT: "d5de42b461646c255c87bd2962d3b9a2",
+				AAD: "",
+				CT: "2ccda4a5415cb91e135c2a0f78c9b2fd",
+				Tag: "b36d1df9b9d5e596f83e8b7f52971cb3",
+			},
+			{
+				Key: "c939cc13397c1d37de6ae0e1cb7c423c",
+				IV: "b3d8cc017cbb89b39e0f67e2",
+				PT: "c3b3c41f113a31b73d9a5cd432103069",
+				AAD: "24825602bd12a984e0092d3e448eda5f",
+				CT: "93fe7d9e9bfd10348a5606e5cafa7354",
+				Tag: "0032a1dc85f1c9786925a2e71d8272dd",
+			},
+			{
+				Key: "d4a22488f8dd1d5c6c19a7d6ca17964c",
+				IV: "f3d5837f22ac1a0425e0d1d5",
+				PT: "7b43016a16896497fb457be6d2a54122",
+				AAD: "f1c5d424b83f96c6ad8cb28ca0d20e475e023b5a",
+				CT: "c2bd67eef5e95cac27e3b06e3031d0a8",
+				Tag: "f23eacf9d1cdf8737726c58648826e9c",
+			},
+			{
+				Key: "89850dd398e1f1e28443a33d40162664",
+				IV: "e462c58482fe8264aeeb7231",
+				PT: "2805cdefb3ef6cc35cd1f169f98da81a",
+				AAD: "d74e99d1bdaa712864eec422ac507bddbe2b0d4633cd3dff29ce5059b49fe868526c59a2a3a604457bc2afea866e7606",
+				CT: "ba80e244b7fc9025cd031d0f63677e06",
+				Tag: "d84a8c3eac57d1bb0e890a8f461d1065",
+			},
+			{
+				Key: "bd7c5c63b7542b56a00ebe71336a1588",
+				IV: "87721f23ba9c3c8ea5571abc",
+				PT: "de15ddbb1e202161e8a79af6a55ac6f3",
+				AAD: "a6ec8075a0d3370eb7598918f3b93e48444751624997b899a87fa6a9939f844e008aa8b70e9f4c3b1a19d3286bf543e7127bfecba1ad17a5ec53fccc26faecacc4c75369498eaa7d706aef634d0009279b11e4ba6c993e5e9ed9",
+				CT: "41eb28c0fee4d762de972361c863bc80",
+				Tag: "9cb567220d0b252eb97bff46e4b00ff8",
+			},
+			{
+				Key: "fe9bb47deb3a61e423c2231841cfd1fb",
+				IV: "4d328eb776f500a2f7fb47aa",
+				PT: "f1cc3818e421876bb6b8bbd6c9",
+				AAD: "",
+				CT: "b88c5c1977b35b517b0aeae967",
+				Tag: "43fd4727fe5cdb4b5b42818dea7ef8c9",
+			},
+			{
+				Key: "dfefde23c6122bf0370ab5890e804b73",
+				IV: "92d6a8029990670f16de79e2",
+				PT: "64260a8c287de978e96c7521d0",
+				AAD: "a2b16d78251de6c191ce350e5c5ef242",
+				CT: "bf78de948a847c173649d4b4d0",
+				Tag: "9da3829968cdc50794d1c30d41cd4515",
+			},
+			{
+				Key: "fe0121f42e599f88ff02a985403e19bb",
+				IV: "3bb9eb7724cbe1943d43de21",
+				PT: "fd331ca8646091c29f21e5f0a1",
+				AAD: "2662d895035b6519f3510eae0faa3900ad23cfdf",
+				CT: "59fe29b07b0de8d869efbbd9b4",
+				Tag: "d24c3e9c1c73c0af1097e26061c857de",
+			},
+			{
+				Key: "cbd3b8dbfcfb11ce345706e6cd73881a",
+				IV: "dc62bb68d0ec9a5d759d6741",
+				PT: "85f83bf598dfd55bc8bfde2a64",
+				AAD: "0944b661fe6294f3c92abb087ec1b259b032dc4e0c5f28681cbe6e63c2178f474326f35ad3ca80c28e3485e7e5b252c8",
+				CT: "206f6b3bb032dfecd39f8340b1",
+				Tag: "425a21b2ea90580c889134032b914bb5",
+			},
+			{
+				Key: "e5b1e7a94e9e1fda0873571eec713429",
+				IV: "5ddde829a81713346af8e5b7",
+				PT: "850069e5ed768b5dc9ed7ad485",
+				AAD: "b0ce75da427fba93da6d3455b2b440a877599a6d8d6d2d66ee90b5cf9a33baaa8329a9ffaac290e8e33f2af2548c2a8a181b3d4d9f8fac860cc26b0d26b9cc53bc9f405afa73605ebeb376f2d1d7fcb065bab92f20f295556ade",
+				CT: "c211d9079d5562659db01e17d1",
+				Tag: "884893fb035d3d7237d47c363de62bb3",
+			},
+			{
+				Key: "9971071059abc009e4f2bd69869db338",
+				IV: "07a9a95ea3821e9c13c63251",
+				PT: "f54bc3501fed4f6f6dfb5ea80106df0bd836e6826225b75c0222f6e859b35983",
+				AAD: "",
+				CT: "0556c159f84ef36cb1602b4526b12009c775611bffb64dc0d9ca9297cd2c6a01",
+				Tag: "7870d9117f54811a346970f1de090c41",
+			},
+			{
+				Key: "298efa1ccf29cf62ae6824bfc19557fc",
+				IV: "6f58a93fe1d207fae4ed2f6d",
+				PT: "cc38bccd6bc536ad919b1395f5d63801f99f8068d65ca5ac63872daf16b93901",
+				AAD: "021fafd238463973ffe80256e5b1c6b1",
+				CT: "dfce4e9cd291103d7fe4e63351d9e79d3dfd391e3267104658212da96521b7db",
+				Tag: "542465ef599316f73a7a560509a2d9f2",
+			},
+			{
+				Key: "fedc7155192d00b23cdd98750db9ebba",
+				IV: "a76b74f55c1a1756a08338b1",
+				PT: "6831435b8857daf1c513b148820d13b5a72cc490bda79a98a6f520d8763c39d1",
+				AAD: "2ad206c4176e7e552aa08836886816fafa77e759",
+				CT: "15823805da89a1923bfc1d6f87784d56bad1128b4dffdbdeefbb2fa562c35e68",
+				Tag: "d23dc455ced49887c717e8eabeec2984",
+			},
+			{
+				Key: "48b7f337cdf9252687ecc760bd8ec184",
+				IV: "3e894ebb16ce82a53c3e05b2",
+				PT: "bb2bac67a4709430c39c2eb9acfabc0d456c80d30aa1734e57997d548a8f0603",
+				AAD: "7d924cfd37b3d046a96eb5e132042405c8731e06509787bbeb41f258275746495e884d69871f77634c584bb007312234",
+				CT: "d263228b8ce051f67e9baf1ce7df97d10cd5f3bc972362055130c7d13c3ab2e7",
+				Tag: "71446737ca1fa92e6d026d7d2ed1aa9c",
+			},
+			{
+				Key: "8fbf7ca12fd525dde91e625873fe51c2",
+				IV: "200bea517b9790a1cfadaf5e",
+				PT: "39d3e6277c4b4963840d1642e6faae0a5be2da97f61c4e55bb57ce021903d4c4",
+				AAD: "a414c07fe2e60bec9ccc409e9e899c6fe60580bb2607c861f7f08523e69cda1b9c3a711d1d9c35091771e4c950b9996d0ad04f2e00d1b3105853542a96e09ffffc2ec80f8cf88728f594f0aeb14f98a688234e8bfbf70327b364",
+				CT: "fe678ef76f69ac95db553b6dadd5a07a9dc8e151fe6a9fa3a1cd621636b87868",
+				Tag: "7c860774f88332b9a7ce6bbd0272a727",
+			},
+			{
+				Key: "594157ec4693202b030f33798b07176d",
+				IV: "49b12054082660803a1df3df",
+				PT: "3feef98a976a1bd634f364ac428bb59cd51fb159ec1789946918dbd50ea6c9d594a3a31a5269b0da6936c29d063a5fa2cc8a1c",
+				AAD: "",
+				CT: "c1b7a46a335f23d65b8db4008a49796906e225474f4fe7d39e55bf2efd97fd82d4167de082ae30fa01e465a601235d8d68bc69",
+				Tag: "ba92d3661ce8b04687e8788d55417dc2",
+			},
+			{
+				Key: "b61553bb854895b929751cd0c5f80384",
+				IV: "8863f999ae64e55d0bbd7457",
+				PT: "9b1b113217d0c4ea7943cf123c69c6ad2e3c97368c51c9754145d155dde1ee8640c8cafff17a5c9737d26a137eee4bf369096d",
+				AAD: "d914b5f2d1b08ce53ea59cb310587245",
+				CT: "acfab4632b8a25805112f13d85e082bc89dc49bd92164fa8a2dad242c3a1b2f2696f2fdff579025f3f146ea97da3e47dc34b65",
+				Tag: "5d9b5f4a9868c1c69cbd6fd851f01340",
+			},
+			{
+				Key: "fe47fcce5fc32665d2ae399e4eec72ba",
+				IV: "5adb9609dbaeb58cbd6e7275",
+				PT: "7c0e88c88899a779228465074797cd4c2e1498d259b54390b85e3eef1c02df60e743f1b840382c4bccaf3bafb4ca8429bea063",
+				AAD: "88319d6e1d3ffa5f987199166c8a9b56c2aeba5a",
+				CT: "98f4826f05a265e6dd2be82db241c0fbbbf9ffb1c173aa83964b7cf5393043736365253ddbc5db8778371495da76d269e5db3e",
+				Tag: "291ef1982e4defedaa2249f898556b47",
+			},
+			{
+				Key: "3c50622868f450aa0928990c15e1eb36",
+				IV: "811d5290768d57e7d87bb6c7",
+				PT: "edd0a8f82833e919740fe2bf9edecf4ac86c72dc89490cef7b6983aaaf99fc856c5cc87d63f98a7c861bf3271fea6da86a15ab",
+				AAD: "dae2c7e0a3d3fd2bc04eca19b15178a003b5cf84890c28c2a615f20f8adb427f70698c12b2ef87780c1193fbb8cd1674",
+				CT: "a51425b0608d3b4b46d4ec05ca1ddaf02bdd2089ae0554ecfb2a1c84c63d82dc71ddb9ab1b1f0b49de2ad27c2b5173e7000aa6",
+				Tag: "bd9b5efca48008cd973a4f7d2c723844",
+			},
+			{
+				Key: "2c1f21cf0f6fb3661943155c3e3d8492",
+				IV: "23cb5ff362e22426984d1907",
+				PT: "42f758836986954db44bf37c6ef5e4ac0adaf38f27252a1b82d02ea949c8a1a2dbc0d68b5615ba7c1220ff6510e259f06655d8",
+				AAD: "5d3624879d35e46849953e45a32a624d6a6c536ed9857c613b572b0333e701557a713e3f010ecdf9a6bd6c9e3e44b065208645aff4aabee611b391528514170084ccf587177f4488f33cfb5e979e42b6e1cfc0a60238982a7aec",
+				CT: "81824f0e0d523db30d3da369fdc0d60894c7a0a20646dd015073ad2732bd989b14a222b6ad57af43e1895df9dca2a5344a62cc",
+				Tag: "57a3ee28136e94c74838997ae9823f3a",
+			},
+		];
+		for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
+			const testVector = NIST_TEST_VECTORS[i];
+			const aead = await aesGcmFromRawKey(
+				Bytes.fromHex(testVector["Key"])
+			);
+			const ciphertext = Bytes.fromHex(
+				testVector["IV"] + testVector["CT"] + testVector["Tag"]
+			);
+			const aad = Bytes.fromHex(testVector["AAD"]);
+			try {
+				const plaintext = await aead.decrypt(ciphertext, aad);
+				expect(testVector["PT"]).toBe(Bytes.toHex(plaintext));
+			} catch (e) {
+				fail(e);
+			}
+		}
+	});
 });

--- a/javascript/subtle/bytes_test.ts
+++ b/javascript/subtle/bytes_test.ts
@@ -4,172 +4,183 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InvalidArgumentsException} from '../exception/invalid_arguments_exception';
+import { InvalidArgumentsException } from "../exception/invalid_arguments_exception";
 
-import * as Bytes from './bytes';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import * as Random from "./random";
 
-describe('bytes test', function() {
-  it('concat', function() {
-    let ba1 = new Uint8Array(0);
-    let ba2 = new Uint8Array(0);
-    let ba3 = new Uint8Array(0);
-    let result = Bytes.concat(ba1, ba2, ba3);
-    expect(result.length).toBe(0);
+describe("bytes test", () => {
+	it("concat", () => {
+		let ba1 = new Uint8Array(0);
+		let ba2 = new Uint8Array(0);
+		let ba3 = new Uint8Array(0);
+		let result = Bytes.concat(ba1, ba2, ba3);
+		expect(result.length).toBe(0);
 
-    ba1 = Random.randBytes(10);
-    result = Bytes.concat(ba1, ba2, ba3);
-    expect(result.length).toBe(ba1.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
+		ba1 = Random.randBytes(10);
+		result = Bytes.concat(ba1, ba2, ba3);
+		expect(result.length).toBe(ba1.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
 
-    result = Bytes.concat(ba2, ba1, ba3);
-    expect(result.length).toBe(ba1.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
+		result = Bytes.concat(ba2, ba1, ba3);
+		expect(result.length).toBe(ba1.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
 
-    result = Bytes.concat(ba3, ba2, ba1);
-    expect(result.length).toBe(ba1.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
+		result = Bytes.concat(ba3, ba2, ba1);
+		expect(result.length).toBe(ba1.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1));
 
-    ba2 = Random.randBytes(11);
-    result = Bytes.concat(ba1, ba2, ba3);
-    expect(result.length).toBe(ba1.length + ba2.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
+		ba2 = Random.randBytes(11);
+		result = Bytes.concat(ba1, ba2, ba3);
+		expect(result.length).toBe(ba1.length + ba2.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
 
-    result = Bytes.concat(ba1, ba3, ba2);
-    expect(result.length).toBe(ba1.length + ba2.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
+		result = Bytes.concat(ba1, ba3, ba2);
+		expect(result.length).toBe(ba1.length + ba2.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
 
-    result = Bytes.concat(ba3, ba1, ba2);
-    expect(result.length).toBe(ba1.length + ba2.length);
-    expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
+		result = Bytes.concat(ba3, ba1, ba2);
+		expect(result.length).toBe(ba1.length + ba2.length);
+		expect(Bytes.toHex(result)).toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2));
 
-    ba3 = Random.randBytes(12);
-    result = Bytes.concat(ba1, ba2, ba3);
-    expect(result.length).toBe(ba1.length + ba2.length + ba3.length);
-    expect(Bytes.toHex(result))
-        .toBe(Bytes.toHex(ba1) + Bytes.toHex(ba2) + Bytes.toHex(ba3));
-  });
+		ba3 = Random.randBytes(12);
+		result = Bytes.concat(ba1, ba2, ba3);
+		expect(result.length).toBe(ba1.length + ba2.length + ba3.length);
+		expect(Bytes.toHex(result)).toBe(
+			Bytes.toHex(ba1) + Bytes.toHex(ba2) + Bytes.toHex(ba3)
+		);
+	});
 
-  it('from number', function() {
-    let number = 0;
-    expect(Array.from(Bytes.fromNumber(number))).toEqual([
-      0, 0, 0, 0, 0, 0, 0, 0
-    ]);
-    number = 1;
-    expect(Array.from(Bytes.fromNumber(number))).toEqual([
-      0, 0, 0, 0, 0, 0, 0, 1
-    ]);
-    number = 4294967296;  // 2^32
-    expect(Array.from(Bytes.fromNumber(number))).toEqual([
-      0, 0, 0, 1, 0, 0, 0, 0
-    ]);
-    number = 4294967297;  // 2^32 + 1
-    expect(Array.from(Bytes.fromNumber(number))).toEqual([
-      0, 0, 0, 1, 0, 0, 0, 1
-    ]);
-    number = Number.MAX_SAFE_INTEGER; // 2^53 - 1
-    expect(Array.from(Bytes.fromNumber(number))).toEqual([
-      0, 31, 255, 255, 255, 255, 255, 255
-    ]);
+	it("from number", () => {
+		let number = 0;
+		expect(Array.from(Bytes.fromNumber(number))).toEqual([
+			0, 0, 0, 0, 0, 0, 0, 0,
+		]);
+		number = 1;
+		expect(Array.from(Bytes.fromNumber(number))).toEqual([
+			0, 0, 0, 0, 0, 0, 0, 1,
+		]);
+		number = 4294967296; // 2^32
+		expect(Array.from(Bytes.fromNumber(number))).toEqual([
+			0, 0, 0, 1, 0, 0, 0, 0,
+		]);
+		number = 4294967297; // 2^32 + 1
+		expect(Array.from(Bytes.fromNumber(number))).toEqual([
+			0, 0, 0, 1, 0, 0, 0, 1,
+		]);
+		number = Number.MAX_SAFE_INTEGER; // 2^53 - 1
+		expect(Array.from(Bytes.fromNumber(number))).toEqual([
+			0, 31, 255, 255, 255, 255, 255, 255,
+		]);
 
-    expect(function() {
-      Bytes.fromNumber(3.14);
-    }).toThrow();
-    expect(function() {
-      Bytes.fromNumber(-1);
-    }).toThrow();
-    expect(function() {
-      Bytes.fromNumber(Number.MAX_SAFE_INTEGER + 1);
-    }).toThrow();
-  });
+		expect(() => {
+			Bytes.fromNumber(3.14);
+		}).toThrow();
+		expect(() => {
+			Bytes.fromNumber(-1);
+		}).toThrow();
+		expect(() => {
+			Bytes.fromNumber(Number.MAX_SAFE_INTEGER + 1);
+		}).toThrow();
+	});
 
-  it('to base64, remove all padding', function() {
-    for (let i = 0; i < 10; i++) {
-      const array = new Uint8Array(i);
-      const base64Representation = Bytes.toBase64(array, true);
-      expect(base64Representation[base64Representation.length - 1])
-          .not.toBe('=');
-    }
-  });
+	it("to base64, remove all padding", () => {
+		for (let i = 0; i < 10; i++) {
+			const array = new Uint8Array(i);
+			const base64Representation = Bytes.toBase64(array, true);
+			expect(
+				base64Representation[base64Representation.length - 1]
+			).not.toBe("=");
+		}
+	});
 
-  it('to base64, from base64', function() {
-    for (let i = 0; i < 100; i++) {
-      const array = Random.randBytes(i);
-      const base64Representation = Bytes.toBase64(array, true);
-      const arrayRepresentation = Bytes.fromBase64(base64Representation, true);
-      expect(arrayRepresentation).toEqual(array);
-    }
-  });
+	it("to base64, from base64", () => {
+		for (let i = 0; i < 100; i++) {
+			const array = Random.randBytes(i);
+			const base64Representation = Bytes.toBase64(array, true);
+			const arrayRepresentation = Bytes.fromBase64(
+				base64Representation,
+				true
+			);
+			expect(arrayRepresentation).toEqual(array);
+		}
+	});
 
-  it('from byte string', function() {
-    expect(Bytes.fromByteString(''))
-        .withContext('empty string')
-        .toEqual(new Uint8Array(0));
+	it("from byte string", () => {
+		expect(Bytes.fromByteString(""))
+			.withContext("empty string")
+			.toEqual(new Uint8Array(0));
 
-    let arr = new Uint8Array(
-        [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100]);
-    expect(Bytes.fromByteString('Hello, world'))
-        .withContext('ASCII')
-        .toEqual(arr);
+		let arr = new Uint8Array([
+			72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100,
+		]);
+		expect(Bytes.fromByteString("Hello, world"))
+			.withContext("ASCII")
+			.toEqual(arr);
 
-    arr = new Uint8Array([83, 99, 104, 246, 110]);
-    expect(Bytes.fromByteString('Sch\u00f6n'))
-        .withContext('Latin')
-        .toEqual(arr);
-  });
+		arr = new Uint8Array([83, 99, 104, 246, 110]);
+		expect(Bytes.fromByteString("Sch\u00f6n"))
+			.withContext("Latin")
+			.toEqual(arr);
+	});
 
-  it('to byte string', function() {
-    expect(Bytes.toByteString(new Uint8Array(0)))
-        .withContext('empty string')
-        .toBe('');
+	it("to byte string", () => {
+		expect(Bytes.toByteString(new Uint8Array(0)))
+			.withContext("empty string")
+			.toBe("");
 
-    let arr = new Uint8Array(
-        [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100]);
-    expect(Bytes.toByteString(arr)).withContext('ASCII').toBe('Hello, world');
+		let arr = new Uint8Array([
+			72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100,
+		]);
+		expect(Bytes.toByteString(arr))
+			.withContext("ASCII")
+			.toBe("Hello, world");
 
-    arr = new Uint8Array([83, 99, 104, 246, 110]);
-    expect(Bytes.toByteString(arr)).withContext('Latin').toBe('Sch\u00f6n');
-  });
+		arr = new Uint8Array([83, 99, 104, 246, 110]);
+		expect(Bytes.toByteString(arr)).withContext("Latin").toBe("Sch\u00f6n");
+	});
 
-  it('to string, from string', function() {
-    for (let i = 0; i < 100; i++) {
-      const array = Random.randBytes(i);
-      const str = Bytes.toByteString(array);
-      const arrayRepresentation = Bytes.fromByteString(str);
-      expect(arrayRepresentation).toEqual(array);
-    }
-  });
+	it("to string, from string", () => {
+		for (let i = 0; i < 100; i++) {
+			const array = Random.randBytes(i);
+			const str = Bytes.toByteString(array);
+			const arrayRepresentation = Bytes.fromByteString(str);
+			expect(arrayRepresentation).toEqual(array);
+		}
+	});
 });
 
-describe('xor', () => {
-  for (let i = 0; i < 100; i++) {
-    it(`should work on two byte arrays of size ${i} bytes`, () => {
-      const arr1 = Random.randBytes(i);
-      const arr2 = Random.randBytes(i);
+describe("xor", () => {
+	for (let i = 0; i < 100; i++) {
+		it(`should work on two byte arrays of size ${i} bytes`, () => {
+			const arr1 = Random.randBytes(i);
+			const arr2 = Random.randBytes(i);
 
-      const xor = Bytes.xor(arr1, arr2);
-      for (let j = 0; j < i; j++) {
-        expect(xor[j]).toEqual(arr1[j] ^ arr2[j]);
-      }
-    });
+			const xor = Bytes.xor(arr1, arr2);
+			for (let j = 0; j < i; j++) {
+				expect(xor[j]).toEqual(arr1[j] ^ arr2[j]);
+			}
+		});
 
-    it(`should be commutative on byte arrays of size ${i} bytes`, () => {
-      const arr1 = Random.randBytes(i);
-      const arr2 = Random.randBytes(i);
+		it(`should be commutative on byte arrays of size ${i} bytes`, () => {
+			const arr1 = Random.randBytes(i);
+			const arr2 = Random.randBytes(i);
 
-      expect(Bytes.xor(arr1, arr2)).toEqual(Bytes.xor(arr2, arr1));
-    });
-  }
+			expect(Bytes.xor(arr1, arr2)).toEqual(Bytes.xor(arr2, arr1));
+		});
+	}
 
-  it('should fail on byte arrays of different lengths', () => {
-    const arrLengthZero = Random.randBytes(0);
-    const arrLengthTen = Random.randBytes(10);
-    const arrLengthEleven = Random.randBytes(11);
+	it("should fail on byte arrays of different lengths", () => {
+		const arrLengthZero = Random.randBytes(0);
+		const arrLengthTen = Random.randBytes(10);
+		const arrLengthEleven = Random.randBytes(11);
 
-    expect(() => Bytes.xor(arrLengthZero, arrLengthTen))
-        .toThrowError(InvalidArgumentsException);
+		expect(() => Bytes.xor(arrLengthZero, arrLengthTen)).toThrowError(
+			InvalidArgumentsException
+		);
 
-    expect(() => Bytes.xor(arrLengthTen, arrLengthEleven))
-        .toThrowError(InvalidArgumentsException);
-  });
+		expect(() => Bytes.xor(arrLengthTen, arrLengthEleven)).toThrowError(
+			InvalidArgumentsException
+		);
+	});
 });

--- a/javascript/subtle/ecdsa_sign_test.ts
+++ b/javascript/subtle/ecdsa_sign_test.ts
@@ -4,142 +4,179 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {fromJsonWebKey} from './ecdsa_sign';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
+import { fromJsonWebKey } from "./ecdsa_sign";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
 
-describe('ecdsa sign test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecdsa sign test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('sign', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-    for (let i = 0; i < 100; i++) {
-      const data = Random.randBytes(i);
-      const signature = await signer.sign(data);
-      const isValid = await window.crypto.subtle.verify(
-          {
-            name: 'ECDSA',
-            hash: {
-              name: 'SHA-256',
-            },
-          },
-          keyPair.publicKey!, signature, data);
-      expect(isValid).toBe(true);
-    }
-  });
+	it("sign", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256"
+		);
+		for (let i = 0; i < 100; i++) {
+			const data = Random.randBytes(i);
+			const signature = await signer.sign(data);
+			const isValid = await window.crypto.subtle.verify(
+				{
+					name: "ECDSA",
+					hash: {
+						name: "SHA-256",
+					},
+				},
+				keyPair.publicKey!,
+				signature,
+				data
+			);
+			expect(isValid).toBe(true);
+		}
+	});
 
-  it('sign with der encoding', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256',
-        EllipticCurves.EcdsaSignatureEncodingType.DER);
-    for (let i = 0; i < 100; i++) {
-      const data = Random.randBytes(i);
-      let signature = await signer.sign(data);
-      // Should fail WebCrypto only accepts IEEE encoding.
-      let isValid = await window.crypto.subtle.verify(
-          {
-            name: 'ECDSA',
-            hash: {
-              name: 'SHA-256',
-            },
-          },
-          keyPair.publicKey!, signature, data);
-      expect(isValid).toBe(false);
-      // Convert the signature to IEEE encoding.
-      signature = EllipticCurves.ecdsaDer2Ieee(signature, 64);
-      isValid = await window.crypto.subtle.verify(
-          {
-            name: 'ECDSA',
-            hash: {
-              name: 'SHA-256',
-            },
-          },
-          keyPair.publicKey!, signature, data);
-      expect(isValid).toBe(true);
-    }
-  });
+	it("sign with der encoding", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256",
+			EllipticCurves.EcdsaSignatureEncodingType.DER
+		);
+		for (let i = 0; i < 100; i++) {
+			const data = Random.randBytes(i);
+			let signature = await signer.sign(data);
+			// Should fail WebCrypto only accepts IEEE encoding.
+			let isValid = await window.crypto.subtle.verify(
+				{
+					name: "ECDSA",
+					hash: {
+						name: "SHA-256",
+					},
+				},
+				keyPair.publicKey!,
+				signature,
+				data
+			);
+			expect(isValid).toBe(false);
+			// Convert the signature to IEEE encoding.
+			signature = EllipticCurves.ecdsaDer2Ieee(signature, 64);
+			isValid = await window.crypto.subtle.verify(
+				{
+					name: "ECDSA",
+					hash: {
+						name: "SHA-256",
+					},
+				},
+				keyPair.publicKey!,
+				signature,
+				data
+			);
+			expect(isValid).toBe(true);
+		}
+	});
 
-  it('sign always generate new signatures', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-    const signatures = new Set();
-    for (let i = 0; i < 100; i++) {
-      const data = Random.randBytes(i);
-      const signature = await signer.sign(data);
-      signatures.add(signature);
-    }
-    expect(signatures.size).toBe(100);
-  });
+	it("sign always generate new signatures", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256"
+		);
+		const signatures = new Set();
+		for (let i = 0; i < 100; i++) {
+			const data = Random.randBytes(i);
+			const signature = await signer.sign(data);
+			signatures.add(signature);
+		}
+		expect(signatures.size).toBe(100);
+	});
 
-  it('constructor with invalid hash', async function() {
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-      await fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-1');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-256 (because curve is P-256) but ' +
-              'got SHA-1');
-    }
+	it("constructor with invalid hash", async () => {
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-256"
+			);
+			await fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+				"SHA-1"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-256 (because curve is P-256) but " +
+					"got SHA-1"
+			);
+		}
 
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-384');
-      await fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256');
-    }
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-384"
+			);
+			await fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+				"SHA-256"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256"
+			);
+		}
 
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-521');
-      await fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256');
-    }
-  });
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-521"
+			);
+			await fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+				"SHA-256"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256"
+			);
+		}
+	});
 
-  it('constructor with invalid curve', async function() {
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-      const jwk = await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-      jwk.crv = 'blah';
-      await fromJsonWebKey(jwk, 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('SecurityException: unsupported curve: blah');
-    }
-  });
+	it("constructor with invalid curve", async () => {
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-256"
+			);
+			const jwk = await EllipticCurves.exportCryptoKey(
+				keyPair.privateKey!
+			);
+			jwk.crv = "blah";
+			await fromJsonWebKey(jwk, "SHA-256");
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: unsupported curve: blah"
+			);
+		}
+	});
 });

--- a/javascript/subtle/ecdsa_verify_test.ts
+++ b/javascript/subtle/ecdsa_verify_test.ts
@@ -4,173 +4,217 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PublicKeyVerify} from '../signature/internal/public_key_verify';
+import { PublicKeyVerify } from "../signature/internal/public_key_verify";
 
-import * as Bytes from './bytes';
-import * as ecdsaSign from './ecdsa_sign';
-import * as ecdsaVerify from './ecdsa_verify';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
-import * as Validators from './validators';
-import {WYCHEPROOF_ECDSA_TEST_VECTORS} from './wycheproof_ecdsa_test_vectors';
+import * as Bytes from "./bytes";
+import * as ecdsaSign from "./ecdsa_sign";
+import * as ecdsaVerify from "./ecdsa_verify";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
+import * as Validators from "./validators";
+import { WYCHEPROOF_ECDSA_TEST_VECTORS } from "./wycheproof_ecdsa_test_vectors";
 
-describe('ecdsa verify test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecdsa verify test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('verify', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await ecdsaSign.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-    const verifier = await ecdsaVerify.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-    for (let i = 0; i < 100; i++) {
-      const data = Random.randBytes(i);
-      const signature = await signer.sign(data);
-      expect(await verifier.verify(signature, data)).toBe(true);
-    }
-  });
+	it("verify", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await ecdsaSign.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256"
+		);
+		const verifier = await ecdsaVerify.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+			"SHA-256"
+		);
+		for (let i = 0; i < 100; i++) {
+			const data = Random.randBytes(i);
+			const signature = await signer.sign(data);
+			expect(await verifier.verify(signature, data)).toBe(true);
+		}
+	});
 
-  it('verify with der encoding', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await ecdsaSign.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256',
-        EllipticCurves.EcdsaSignatureEncodingType.DER);
-    const verifier = await ecdsaVerify.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-    const verifierDer = await ecdsaVerify.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256',
-        EllipticCurves.EcdsaSignatureEncodingType.DER);
-    for (let i = 0; i < 100; i++) {
-      const data = Random.randBytes(i);
-      const signature = await signer.sign(data);
-      expect(await verifier.verify(signature, data)).toBe(false);
-      expect(await verifierDer.verify(signature, data)).toBe(true);
-    }
-  });
+	it("verify with der encoding", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await ecdsaSign.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256",
+			EllipticCurves.EcdsaSignatureEncodingType.DER
+		);
+		const verifier = await ecdsaVerify.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+			"SHA-256"
+		);
+		const verifierDer = await ecdsaVerify.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+			"SHA-256",
+			EllipticCurves.EcdsaSignatureEncodingType.DER
+		);
+		for (let i = 0; i < 100; i++) {
+			const data = Random.randBytes(i);
+			const signature = await signer.sign(data);
+			expect(await verifier.verify(signature, data)).toBe(false);
+			expect(await verifierDer.verify(signature, data)).toBe(true);
+		}
+	});
 
-  it('constructor with invalid hash', async function() {
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-      await ecdsaVerify.fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-1');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-256 (because curve is P-256) but got SHA-1');
-    }
+	it("constructor with invalid hash", async () => {
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-256"
+			);
+			await ecdsaVerify.fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+				"SHA-1"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-256 (because curve is P-256) but got SHA-1"
+			);
+		}
 
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-384');
-      await ecdsaVerify.fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256');
-    }
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-384"
+			);
+			await ecdsaVerify.fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+				"SHA-256"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-384 or SHA-512 (because curve is P-384) but got SHA-256"
+			);
+		}
 
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-521');
-      await ecdsaVerify.fromJsonWebKey(
-          await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256');
-    }
-  });
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-521"
+			);
+			await ecdsaVerify.fromJsonWebKey(
+				await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+				"SHA-256"
+			);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: expected SHA-512 (because curve is P-521) but got SHA-256"
+			);
+		}
+	});
 
-  it('constructor with invalid curve', async function() {
-    try {
-      const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-      const jwk = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-      jwk.crv = 'blah';
-      await ecdsaVerify.fromJsonWebKey(jwk, 'SHA-256');
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('SecurityException: unsupported curve: blah');
-    }
-  });
+	it("constructor with invalid curve", async () => {
+		try {
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				"P-256"
+			);
+			const jwk = await EllipticCurves.exportCryptoKey(
+				keyPair.publicKey!
+			);
+			jwk.crv = "blah";
+			await ecdsaVerify.fromJsonWebKey(jwk, "SHA-256");
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: unsupported curve: blah"
+			);
+		}
+	});
 
-  it('verify modified signature', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await ecdsaSign.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-    const verifier = await ecdsaVerify.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-    const data = Random.randBytes(20);
-    const signature = await signer.sign(data);
+	it("verify modified signature", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await ecdsaSign.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256"
+		);
+		const verifier = await ecdsaVerify.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+			"SHA-256"
+		);
+		const data = Random.randBytes(20);
+		const signature = await signer.sign(data);
 
-    for (let i = 0; i < signature.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const s1 = new Uint8Array(signature);
-        s1[i] = (s1[i] ^ (1 << j));
-        expect(await verifier.verify(s1, data)).toBe(false);
-      }
-    }
-  });
+		for (let i = 0; i < signature.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const s1 = new Uint8Array(signature);
+				s1[i] = s1[i] ^ (1 << j);
+				expect(await verifier.verify(s1, data)).toBe(false);
+			}
+		}
+	});
 
-  it('verify modified data', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDSA', 'P-256');
-    const signer = await ecdsaSign.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!), 'SHA-256');
-    const verifier = await ecdsaVerify.fromJsonWebKey(
-        await EllipticCurves.exportCryptoKey(keyPair.publicKey!), 'SHA-256');
-    const data = Random.randBytes(20);
-    const signature = await signer.sign(data);
+	it("verify modified data", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDSA", "P-256");
+		const signer = await ecdsaSign.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.privateKey!),
+			"SHA-256"
+		);
+		const verifier = await ecdsaVerify.fromJsonWebKey(
+			await EllipticCurves.exportCryptoKey(keyPair.publicKey!),
+			"SHA-256"
+		);
+		const data = Random.randBytes(20);
+		const signature = await signer.sign(data);
 
-    for (let i = 0; i < data.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const data1 = new Uint8Array(data);
-        data1[i] = (data1[i] ^ (1 << j));
-        expect(await verifier.verify(signature, data1)).toBe(false);
-      }
-    }
-  });
+		for (let i = 0; i < data.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const data1 = new Uint8Array(data);
+				data1[i] = data1[i] ^ (1 << j);
+				expect(await verifier.verify(signature, data1)).toBe(false);
+			}
+		}
+	});
 
-  it('wycheproof', async function() {
-    for (const testGroup of WYCHEPROOF_ECDSA_TEST_VECTORS['testGroups']) {
-      try {
-        Validators.validateEcdsaParams(
-            testGroup['jwk']['crv'], testGroup['sha']);
-      } catch (e) {
-        // Tink does not support this config.
-        continue;
-      }
-      const verifier =
-          await ecdsaVerify.fromJsonWebKey(testGroup['jwk'], testGroup['sha']);
-      let errors = '';
-      for (const test of testGroup['tests']) {
-        errors += await runWycheproofTest(verifier, test);
-      }
-      if (errors !== '') {
-        fail(errors);
-      }
-    }
-  });
+	it("wycheproof", async () => {
+		for (const testGroup of WYCHEPROOF_ECDSA_TEST_VECTORS["testGroups"]) {
+			try {
+				Validators.validateEcdsaParams(
+					testGroup["jwk"]["crv"],
+					testGroup["sha"]
+				);
+			} catch (e) {
+				// Tink does not support this config.
+				continue;
+			}
+			const verifier = await ecdsaVerify.fromJsonWebKey(
+				testGroup["jwk"],
+				testGroup["sha"]
+			);
+			let errors = "";
+			for (const test of testGroup["tests"]) {
+				errors += await runWycheproofTest(verifier, test);
+			}
+			if (errors !== "") {
+				fail(errors);
+			}
+		}
+	});
 });
 
 /**
@@ -178,28 +222,37 @@ describe('ecdsa verify test', function() {
  * string or a text describing the failure.
  */
 async function runWycheproofTest(
-    verifier: PublicKeyVerify,
-    test: {'tcId': number, 'msg': string, 'sig': string, 'result': string}):
-    Promise<string> {
-  try {
-    const sig = Bytes.fromHex(test['sig']);
-    const msg = Bytes.fromHex(test['msg']);
-    const isValid = await verifier.verify(sig, msg);
-    if (isValid) {
-      if (test['result'] === 'invalid') {
-        return 'invalid signature accepted on test ' + test['tcId'] + '\n';
-      }
-    } else {
-      if (test['result'] === 'valid') {
-        return 'valid signature rejected on test ' + test['tcId'] + '\n';
-      }
-    }
-  } catch (e) {
-    if (test['result'] === 'valid') {
-      return 'valid signature rejected on test ' + test['tcId'] +
-          ': unexpected exception "' + String(e) + '".\n';
-    }
-  }
-  // If the test passes return an empty string.
-  return '';
+	verifier: PublicKeyVerify,
+	test: { tcId: number; msg: string; sig: string; result: string }
+): Promise<string> {
+	try {
+		const sig = Bytes.fromHex(test["sig"]);
+		const msg = Bytes.fromHex(test["msg"]);
+		const isValid = await verifier.verify(sig, msg);
+		if (isValid) {
+			if (test["result"] === "invalid") {
+				return (
+					"invalid signature accepted on test " + test["tcId"] + "\n"
+				);
+			}
+		} else {
+			if (test["result"] === "valid") {
+				return (
+					"valid signature rejected on test " + test["tcId"] + "\n"
+				);
+			}
+		}
+	} catch (e) {
+		if (test["result"] === "valid") {
+			return (
+				"valid signature rejected on test " +
+				test["tcId"] +
+				": unexpected exception "" +
+				String(e) +
+				"".\n"
+			);
+		}
+	}
+	// If the test passes return an empty string.
+	return "";
 }

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.ts
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_decrypt_test.ts
@@ -4,140 +4,192 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {RegistryEciesAeadHkdfDemHelper as DemHelper} from '../hybrid/registry_ecies_aead_hkdf_dem_helper';
-import * as Registry from '../internal/registry';
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import { RegistryEciesAeadHkdfDemHelper as DemHelper } from "../hybrid/registry_ecies_aead_hkdf_dem_helper";
+import * as Registry from "../internal/registry";
 
-import {fromJsonWebKey as decrypterFromJsonWebKey} from './ecies_aead_hkdf_hybrid_decrypt';
-import {fromJsonWebKey as encrypterFromJsonWebKey} from './ecies_aead_hkdf_hybrid_encrypt';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
+import { fromJsonWebKey as decrypterFromJsonWebKey } from "./ecies_aead_hkdf_hybrid_decrypt";
+import { fromJsonWebKey as encrypterFromJsonWebKey } from "./ecies_aead_hkdf_hybrid_encrypt";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
 
-describe('ecies aead hkdf hybrid decrypt test', function() {
-  beforeEach(function() {
-    AeadConfig.register();
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies aead hkdf hybrid decrypt test", () => {
+	beforeEach(() => {
+		AeadConfig.register();
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new instance, should work', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const privateKey =
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-    const hkdfSalt = new Uint8Array(0);
-    const hkdfHash = 'SHA-256';
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const demHelper = new DemHelper(AeadKeyTemplates.aes128CtrHmacSha256());
+	it("new instance, should work", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		const hkdfSalt = new Uint8Array(0);
+		const hkdfHash = "SHA-256";
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const demHelper = new DemHelper(AeadKeyTemplates.aes128CtrHmacSha256());
 
-    await decrypterFromJsonWebKey(
-        privateKey, hkdfHash, pointFormat, demHelper, hkdfSalt);
-  });
+		await decrypterFromJsonWebKey(
+			privateKey,
+			hkdfHash,
+			pointFormat,
+			demHelper,
+			hkdfSalt
+		);
+	});
 
-  it('decrypt, short ciphertext, should not work', async function() {
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const demHelper = new DemHelper(AeadKeyTemplates.aes128CtrHmacSha256());
-    const hkdfHash = 'SHA-512';
-    const curve = EllipticCurves.CurveType.P256;
+	it("decrypt, short ciphertext, should not work", async () => {
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const demHelper = new DemHelper(AeadKeyTemplates.aes128CtrHmacSha256());
+		const hkdfHash = "SHA-512";
+		const curve = EllipticCurves.CurveType.P256;
 
-    const curveName = EllipticCurves.curveToString(curve);
-    const curveEncodingSize =
-        EllipticCurves.encodingSizeInBytes(curve, pointFormat);
+		const curveName = EllipticCurves.curveToString(curve);
+		const curveEncodingSize = EllipticCurves.encodingSizeInBytes(
+			curve,
+			pointFormat
+		);
 
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
-    const privateKey =
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", curveName);
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
 
-    const hybridEncrypt = await encrypterFromJsonWebKey(
-        publicKey, hkdfHash, pointFormat, demHelper);
-    const hybridDecrypt = await decrypterFromJsonWebKey(
-        privateKey, hkdfHash, pointFormat, demHelper);
+		const hybridEncrypt = await encrypterFromJsonWebKey(
+			publicKey,
+			hkdfHash,
+			pointFormat,
+			demHelper
+		);
+		const hybridDecrypt = await decrypterFromJsonWebKey(
+			privateKey,
+			hkdfHash,
+			pointFormat,
+			demHelper
+		);
 
-    const plaintext = Random.randBytes(10);
-    const ciphertext = await hybridEncrypt.encrypt(plaintext);
-    try {
-      await hybridDecrypt.decrypt(ciphertext.slice(0, curveEncodingSize - 1));
-      fail('Should throw an exception');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('SecurityException: Ciphertext is too short.');
-    }
-  });
+		const plaintext = Random.randBytes(10);
+		const ciphertext = await hybridEncrypt.encrypt(plaintext);
+		try {
+			await hybridDecrypt.decrypt(
+				ciphertext.slice(0, curveEncodingSize - 1)
+			);
+			fail("Should throw an exception");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Ciphertext is too short."
+			);
+		}
+	});
 
-  it('decrypt, different dem helpers from one template, should work',
-     async function() {
-       const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-       const privateKey =
-           await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-       const publicKey =
-           await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-       const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-       const hkdfHash = 'SHA-256';
-       const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
+	it("decrypt, different dem helpers from one template, should work", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const hkdfHash = "SHA-256";
+		const keyTemplate = AeadKeyTemplates.aes256CtrHmacSha256();
 
-       const demHelperEncrypt = new DemHelper(keyTemplate);
-       const hybridEncrypt = await encrypterFromJsonWebKey(
-           publicKey, hkdfHash, pointFormat, demHelperEncrypt);
+		const demHelperEncrypt = new DemHelper(keyTemplate);
+		const hybridEncrypt = await encrypterFromJsonWebKey(
+			publicKey,
+			hkdfHash,
+			pointFormat,
+			demHelperEncrypt
+		);
 
-       const demHelperDecrypt = new DemHelper(keyTemplate);
-       const hybridDecrypt = await decrypterFromJsonWebKey(
-           privateKey, hkdfHash, pointFormat, demHelperDecrypt);
+		const demHelperDecrypt = new DemHelper(keyTemplate);
+		const hybridDecrypt = await decrypterFromJsonWebKey(
+			privateKey,
+			hkdfHash,
+			pointFormat,
+			demHelperDecrypt
+		);
 
-       const plaintext = Random.randBytes(15);
+		const plaintext = Random.randBytes(15);
 
-       const ciphertext = await hybridEncrypt.encrypt(plaintext);
-       const decryptedCipher = await hybridDecrypt.decrypt(ciphertext);
-       expect(decryptedCipher).toEqual(plaintext);
-     });
+		const ciphertext = await hybridEncrypt.encrypt(plaintext);
+		const decryptedCipher = await hybridDecrypt.decrypt(ciphertext);
+		expect(decryptedCipher).toEqual(plaintext);
+	});
 
-  it('decrypt, different pamarameters, should work', async function() {
-    const repetitions = 5;
-    const hkdfSalt = new Uint8Array(0);
+	it("decrypt, different pamarameters, should work", async () => {
+		const repetitions = 5;
+		const hkdfSalt = new Uint8Array(0);
 
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const hmacAlgorithms = ['SHA-1', 'SHA-256', 'SHA-512'];
-    const demHelper = new DemHelper(AeadKeyTemplates.aes256CtrHmacSha256());
-    const curves = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const hmacAlgorithms = ["SHA-1", "SHA-256", "SHA-512"];
+		const demHelper = new DemHelper(AeadKeyTemplates.aes256CtrHmacSha256());
+		const curves = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
 
-    // Test the encryption for different HMAC algorithms and different types of
-    // curves.
-    for (const hkdfHash of hmacAlgorithms) {
-      for (const curve of curves) {
-        const curveName = EllipticCurves.curveToString(curve);
-        const keyPair = await EllipticCurves.generateKeyPair('ECDH', curveName);
-        const privateKey =
-            await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-        const publicKey =
-            await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
+		// Test the encryption for different HMAC algorithms and different types of
+		// curves.
+		for (const hkdfHash of hmacAlgorithms) {
+			for (const curve of curves) {
+				const curveName = EllipticCurves.curveToString(curve);
+				const keyPair = await EllipticCurves.generateKeyPair(
+					"ECDH",
+					curveName
+				);
+				const privateKey = await EllipticCurves.exportCryptoKey(
+					keyPair.privateKey!
+				);
+				const publicKey = await EllipticCurves.exportCryptoKey(
+					keyPair.publicKey!
+				);
 
-        const hybridEncrypt = await encrypterFromJsonWebKey(
-            publicKey, hkdfHash, pointFormat, demHelper, hkdfSalt);
-        const hybridDecrypt = await decrypterFromJsonWebKey(
-            privateKey, hkdfHash, pointFormat, demHelper, hkdfSalt);
+				const hybridEncrypt = await encrypterFromJsonWebKey(
+					publicKey,
+					hkdfHash,
+					pointFormat,
+					demHelper,
+					hkdfSalt
+				);
+				const hybridDecrypt = await decrypterFromJsonWebKey(
+					privateKey,
+					hkdfHash,
+					pointFormat,
+					demHelper,
+					hkdfSalt
+				);
 
-        for (let i = 0; i < repetitions; ++i) {
-          const plaintext = Random.randBytes(15);
-          const contextInfo = Random.randBytes(i);
-          const ciphertext =
-              await hybridEncrypt.encrypt(plaintext, contextInfo);
-          const decryptedCiphertext =
-              await hybridDecrypt.decrypt(ciphertext, contextInfo);
+				for (let i = 0; i < repetitions; ++i) {
+					const plaintext = Random.randBytes(15);
+					const contextInfo = Random.randBytes(i);
+					const ciphertext = await hybridEncrypt.encrypt(
+						plaintext,
+						contextInfo
+					);
+					const decryptedCiphertext = await hybridDecrypt.decrypt(
+						ciphertext,
+						contextInfo
+					);
 
-          expect(decryptedCiphertext).toEqual(plaintext);
-        }
-      }
-    }
-  });
+					expect(decryptedCiphertext).toEqual(plaintext);
+				}
+			}
+		}
+	});
 });

--- a/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.ts
+++ b/javascript/subtle/ecies_aead_hkdf_hybrid_encrypt_test.ts
@@ -4,66 +4,80 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AeadConfig} from '../aead/aead_config';
-import {AeadKeyTemplates} from '../aead/aead_key_templates';
-import {RegistryEciesAeadHkdfDemHelper} from '../hybrid/registry_ecies_aead_hkdf_dem_helper';
-import * as Registry from '../internal/registry';
+import { AeadConfig } from "../aead/aead_config";
+import { AeadKeyTemplates } from "../aead/aead_key_templates";
+import { RegistryEciesAeadHkdfDemHelper } from "../hybrid/registry_ecies_aead_hkdf_dem_helper";
+import * as Registry from "../internal/registry";
 
-import {fromJsonWebKey} from './ecies_aead_hkdf_hybrid_encrypt';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
+import { fromJsonWebKey } from "./ecies_aead_hkdf_hybrid_encrypt";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
 
-describe('ecies aead hkdf hybrid encrypt test', function() {
-  beforeEach(function() {
-    AeadConfig.register();
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies aead hkdf hybrid encrypt test", () => {
+	beforeEach(() => {
+		AeadConfig.register();
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    Registry.reset();
-    // Reset the timeout.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		Registry.reset();
+		// Reset the timeout.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('new instance, should work', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    const hkdfHash = 'SHA-256';
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const demHelper = new RegistryEciesAeadHkdfDemHelper(
-        AeadKeyTemplates.aes128CtrHmacSha256());
+	it("new instance, should work", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const hkdfHash = "SHA-256";
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const demHelper = new RegistryEciesAeadHkdfDemHelper(
+			AeadKeyTemplates.aes128CtrHmacSha256()
+		);
 
-    await fromJsonWebKey(publicKey, hkdfHash, pointFormat, demHelper);
-  });
+		await fromJsonWebKey(publicKey, hkdfHash, pointFormat, demHelper);
+	});
 
-  it('encrypt, different arguments', async function() {
-    const hkdfSalt = new Uint8Array(0);
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const demHelper = new RegistryEciesAeadHkdfDemHelper(
-        AeadKeyTemplates.aes256CtrHmacSha256());
-    const hmacAlgorithms = ['SHA-1', 'SHA-256', 'SHA-512'];
+	it("encrypt, different arguments", async () => {
+		const hkdfSalt = new Uint8Array(0);
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const demHelper = new RegistryEciesAeadHkdfDemHelper(
+			AeadKeyTemplates.aes256CtrHmacSha256()
+		);
+		const hmacAlgorithms = ["SHA-1", "SHA-256", "SHA-512"];
 
-    // Test the encryption for different HMAC algorithms and different types of
-    // curves.
-    for (const hkdfHash of hmacAlgorithms) {
-      for (const curve
-               of [EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-                   EllipticCurves.CurveType.P521]) {
-        const curveName = EllipticCurves.curveToString(curve);
-        const keyPair =
-            await EllipticCurves.generateKeyPair('ECDH', curveName!);
-        const publicKey =
-            await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
+		// Test the encryption for different HMAC algorithms and different types of
+		// curves.
+		for (const hkdfHash of hmacAlgorithms) {
+			for (const curve of [
+				EllipticCurves.CurveType.P256,
+				EllipticCurves.CurveType.P384,
+				EllipticCurves.CurveType.P521,
+			]) {
+				const curveName = EllipticCurves.curveToString(curve);
+				const keyPair = await EllipticCurves.generateKeyPair(
+					"ECDH",
+					curveName!
+				);
+				const publicKey = await EllipticCurves.exportCryptoKey(
+					keyPair.publicKey!
+				);
 
-        const hybridEncrypt = await fromJsonWebKey(
-            publicKey, hkdfHash, pointFormat, demHelper, hkdfSalt);
+				const hybridEncrypt = await fromJsonWebKey(
+					publicKey,
+					hkdfHash,
+					pointFormat,
+					demHelper,
+					hkdfSalt
+				);
 
-        const plaintext = Random.randBytes(15);
-        const ciphertext = await hybridEncrypt.encrypt(plaintext);
+				const plaintext = Random.randBytes(15);
+				const ciphertext = await hybridEncrypt.encrypt(plaintext);
 
-        expect(ciphertext).not.toEqual(plaintext);
-      }
-    }
-  });
+				expect(ciphertext).not.toEqual(plaintext);
+			}
+		}
+	});
 });

--- a/javascript/subtle/ecies_hkdf_kem_recipient_test.ts
+++ b/javascript/subtle/ecies_hkdf_kem_recipient_test.ts
@@ -4,296 +4,396 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bytes from './bytes';
-import {EciesHkdfKemRecipient, fromJsonWebKey as recipientFromJsonWebKey} from './ecies_hkdf_kem_recipient';
-import {fromJsonWebKey as senderFromJsonWebKey} from './ecies_hkdf_kem_sender';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import {
+	EciesHkdfKemRecipient,
+	fromJsonWebKey as recipientFromJsonWebKey,
+} from "./ecies_hkdf_kem_recipient";
+import { fromJsonWebKey as senderFromJsonWebKey } from "./ecies_hkdf_kem_sender";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
 
-describe('ecies hkdf kem recipient test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("ecies hkdf kem recipient test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('encap decap', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    const privateKey = await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-    const sender = await senderFromJsonWebKey(publicKey);
-    const recipient = await recipientFromJsonWebKey(privateKey);
-    for (let i = 1; i < 20; i++) {
-      const keySizeInBytes = i;
-      const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-      const hkdfHash = 'SHA-256';
-      const hkdfInfo = Random.randBytes(i);
-      const hkdfSalt = Random.randBytes(i);
+	it("encap decap", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		const sender = await senderFromJsonWebKey(publicKey);
+		const recipient = await recipientFromJsonWebKey(privateKey);
+		for (let i = 1; i < 20; i++) {
+			const keySizeInBytes = i;
+			const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+			const hkdfHash = "SHA-256";
+			const hkdfInfo = Random.randBytes(i);
+			const hkdfSalt = Random.randBytes(i);
 
-      const kemKeyToken = await sender.encapsulate(
-          keySizeInBytes, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      const key = await recipient.decapsulate(
-          kemKeyToken['token'], keySizeInBytes, pointFormat, hkdfHash, hkdfInfo,
-          hkdfSalt);
+			const kemKeyToken = await sender.encapsulate(
+				keySizeInBytes,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			const key = await recipient.decapsulate(
+				kemKeyToken["token"],
+				keySizeInBytes,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
 
-      expect(kemKeyToken['key'].length).toBe(keySizeInBytes);
-      expect(Bytes.toHex(kemKeyToken['key'])).toBe(Bytes.toHex(key));
-    }
-  });
+			expect(kemKeyToken["key"].length).toBe(keySizeInBytes);
+			expect(Bytes.toHex(kemKeyToken["key"])).toBe(Bytes.toHex(key));
+		}
+	});
 
-  it('decap, non integer key size', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    const privateKey =
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-    const sender = await senderFromJsonWebKey(publicKey);
-    const recipient = await recipientFromJsonWebKey(privateKey);
-    const keySizeInBytes = 16;
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const hkdfHash = 'SHA-256';
-    const hkdfInfo = Random.randBytes(16);
-    const hkdfSalt = Random.randBytes(16);
-    const kemKeyToken = await sender.encapsulate(
-        keySizeInBytes, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
+	it("decap, non integer key size", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		const sender = await senderFromJsonWebKey(publicKey);
+		const recipient = await recipientFromJsonWebKey(privateKey);
+		const keySizeInBytes = 16;
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const hkdfHash = "SHA-256";
+		const hkdfInfo = Random.randBytes(16);
+		const hkdfSalt = Random.randBytes(16);
+		const kemKeyToken = await sender.encapsulate(
+			keySizeInBytes,
+			pointFormat,
+			hkdfHash,
+			hkdfInfo,
+			hkdfSalt
+		);
 
-    try {
-      await recipient.decapsulate(
-          kemKeyToken['token'], NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be an integer');
-    }
+		try {
+			await recipient.decapsulate(
+				kemKeyToken["token"],
+				NaN,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be an integer"
+			);
+		}
 
-    try {
-      await recipient.decapsulate(
-          kemKeyToken['token'], 1.8, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be an integer');
-    }
-  });
+		try {
+			await recipient.decapsulate(
+				kemKeyToken["token"],
+				1.8,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be an integer"
+			);
+		}
+	});
 
-  it('new instance, invalid parameters', async function() {
-    // Test newInstance with public key instead private key.
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    try {
-      await recipientFromJsonWebKey(publicKey);
-      fail('An exception should be thrown.');
-    } catch (e) {
-    }
-  });
+	it("new instance, invalid parameters", async () => {
+		// Test newInstance with public key instead private key.
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		try {
+			await recipientFromJsonWebKey(publicKey);
+			fail("An exception should be thrown.");
+		} catch (e) {}
+	});
 
-  it('new instance, invalid private key', async function() {
-    for (const testVector of TEST_VECTORS) {
-      const ellipticCurveString = EllipticCurves.curveToString(testVector.crv);
-      const privateJwk = EllipticCurves.pointDecode(
-          ellipticCurveString, testVector.pointFormat,
-          Bytes.fromHex(testVector.privateKeyPoint));
-      privateJwk['d'] = Bytes.toBase64(
-          Bytes.fromHex(testVector.privateKeyValue), /* opt_webSafe = */ true);
+	it("new instance, invalid private key", async () => {
+		for (const testVector of TEST_VECTORS) {
+			const ellipticCurveString = EllipticCurves.curveToString(
+				testVector.crv
+			);
+			const privateJwk = EllipticCurves.pointDecode(
+				ellipticCurveString,
+				testVector.pointFormat,
+				Bytes.fromHex(testVector.privateKeyPoint)
+			);
+			privateJwk["d"] = Bytes.toBase64(
+				Bytes.fromHex(testVector.privateKeyValue),
+				/* opt_webSafe = */ true
+			);
 
-      // Change the x value such that the key si no more valid. Recipient should
-      // either throw an exception or ignore the x value and compute the same
-      // output value.
-      const xLength = EllipticCurves.fieldSizeInBytes(testVector.crv);
-      privateJwk['x'] =
-          Bytes.toBase64(new Uint8Array(xLength), /* opt_webSafe = */ true);
-      let output;
-      try {
-        const recipient = await recipientFromJsonWebKey(privateJwk);
-        const hkdfInfo = Bytes.fromHex(testVector.hkdfInfo);
-        const salt = Bytes.fromHex(testVector.salt);
-        output = await recipient.decapsulate(
-            Bytes.fromHex(testVector.token), testVector.outputLength,
-            testVector.pointFormat, testVector.hashType, hkdfInfo, salt);
-      } catch (e) {
-        // Everything works properly if exception was thrown.
-        return;
-      }
-      // If there was no exception, the output should be still correct (x value
-      // should be ignored during the computation).
-      expect(Bytes.toHex(output)).toBe(testVector.expectedOutput);
-    }
-  });
+			// Change the x value such that the key si no more valid. Recipient should
+			// either throw an exception or ignore the x value and compute the same
+			// output value.
+			const xLength = EllipticCurves.fieldSizeInBytes(testVector.crv);
+			privateJwk["x"] = Bytes.toBase64(
+				new Uint8Array(xLength),
+				/* opt_webSafe = */ true
+			);
+			let output;
+			try {
+				const recipient = await recipientFromJsonWebKey(privateJwk);
+				const hkdfInfo = Bytes.fromHex(testVector.hkdfInfo);
+				const salt = Bytes.fromHex(testVector.salt);
+				output = await recipient.decapsulate(
+					Bytes.fromHex(testVector.token),
+					testVector.outputLength,
+					testVector.pointFormat,
+					testVector.hashType,
+					hkdfInfo,
+					salt
+				);
+			} catch (e) {
+				// Everything works properly if exception was thrown.
+				return;
+			}
+			// If there was no exception, the output should be still correct (x value
+			// should be ignored during the computation).
+			expect(Bytes.toHex(output)).toBe(testVector.expectedOutput);
+		}
+	});
 
-  it('constructor, invalid parameters', async function() {
-    // Test public key instead of private key.
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    try {
-      new EciesHkdfKemRecipient(keyPair.publicKey!);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: Expected crypto key of type: private.');
-    }
-  });
+	it("constructor, invalid parameters", async () => {
+		// Test public key instead of private key.
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		try {
+			new EciesHkdfKemRecipient(keyPair.publicKey!);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Expected crypto key of type: private."
+			);
+		}
+	});
 
-  it('encap decap, different params', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    const hashTypes = ['SHA-1', 'SHA-256', 'SHA-512'];
-    for (const curve of curveTypes) {
-      const curveString = EllipticCurves.curveToString(curve);
-      for (const hashType of hashTypes) {
-        const keyPair =
-            await EllipticCurves.generateKeyPair('ECDH', curveString);
-        const keySizeInBytes = 32;
-        const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-        const hkdfInfo = Random.randBytes(8);
-        const hkdfSalt = Random.randBytes(16);
+	it("encap decap, different params", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		const hashTypes = ["SHA-1", "SHA-256", "SHA-512"];
+		for (const curve of curveTypes) {
+			const curveString = EllipticCurves.curveToString(curve);
+			for (const hashType of hashTypes) {
+				const keyPair = await EllipticCurves.generateKeyPair(
+					"ECDH",
+					curveString
+				);
+				const keySizeInBytes = 32;
+				const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+				const hkdfInfo = Random.randBytes(8);
+				const hkdfSalt = Random.randBytes(16);
 
-        const publicKey =
-            await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-        const sender = await senderFromJsonWebKey(publicKey);
-        const kemKeyToken = await sender.encapsulate(
-            keySizeInBytes, pointFormat, hashType, hkdfInfo, hkdfSalt);
+				const publicKey = await EllipticCurves.exportCryptoKey(
+					keyPair.publicKey!
+				);
+				const sender = await senderFromJsonWebKey(publicKey);
+				const kemKeyToken = await sender.encapsulate(
+					keySizeInBytes,
+					pointFormat,
+					hashType,
+					hkdfInfo,
+					hkdfSalt
+				);
 
-        const privateKey =
-            await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-        const recipient = await recipientFromJsonWebKey(privateKey);
-        const key = await recipient.decapsulate(
-            kemKeyToken['token'], keySizeInBytes, pointFormat, hashType,
-            hkdfInfo, hkdfSalt);
+				const privateKey = await EllipticCurves.exportCryptoKey(
+					keyPair.privateKey!
+				);
+				const recipient = await recipientFromJsonWebKey(privateKey);
+				const key = await recipient.decapsulate(
+					kemKeyToken["token"],
+					keySizeInBytes,
+					pointFormat,
+					hashType,
+					hkdfInfo,
+					hkdfSalt
+				);
 
-        expect(kemKeyToken['key'].length).toBe(keySizeInBytes);
-        expect(Bytes.toHex(kemKeyToken['key'])).toBe(Bytes.toHex(key));
-      }
-    }
-  });
+				expect(kemKeyToken["key"].length).toBe(keySizeInBytes);
+				expect(Bytes.toHex(kemKeyToken["key"])).toBe(Bytes.toHex(key));
+			}
+		}
+	});
 
-  it('encap decap, modified token', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    const hashTypes = ['SHA-1', 'SHA-256', 'SHA-512'];
-    for (let curve of curveTypes) {
-      const curveString = EllipticCurves.curveToString(curve);
-      for (let hashType of hashTypes) {
-        const keyPair =
-            await EllipticCurves.generateKeyPair('ECDH', curveString);
-        const privateKey =
-            await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-        const recipient = await recipientFromJsonWebKey(privateKey);
-        const keySizeInBytes = 32;
-        const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-        const hkdfInfo = Random.randBytes(8);
-        const hkdfSalt = Random.randBytes(16);
+	it("encap decap, modified token", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		const hashTypes = ["SHA-1", "SHA-256", "SHA-512"];
+		for (let curve of curveTypes) {
+			const curveString = EllipticCurves.curveToString(curve);
+			for (let hashType of hashTypes) {
+				const keyPair = await EllipticCurves.generateKeyPair(
+					"ECDH",
+					curveString
+				);
+				const privateKey = await EllipticCurves.exportCryptoKey(
+					keyPair.privateKey!
+				);
+				const recipient = await recipientFromJsonWebKey(privateKey);
+				const keySizeInBytes = 32;
+				const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+				const hkdfInfo = Random.randBytes(8);
+				const hkdfSalt = Random.randBytes(16);
 
-        // Create invalid token (EC point), while preserving the 0x04 prefix
-        // byte.
-        const token = Random.randBytes(
-            EllipticCurves.encodingSizeInBytes(curve, pointFormat));
-        token[0] = 0x04;
-        try {
-          await recipient.decapsulate(
-              token, keySizeInBytes, pointFormat, hashType, hkdfInfo, hkdfSalt);
-          fail('Should throw an exception');
-        } catch (e) {
-        }
-      }
-    }
-  });
+				// Create invalid token (EC point), while preserving the 0x04 prefix
+				// byte.
+				const token = Random.randBytes(
+					EllipticCurves.encodingSizeInBytes(curve, pointFormat)
+				);
+				token[0] = 0x04;
+				try {
+					await recipient.decapsulate(
+						token,
+						keySizeInBytes,
+						pointFormat,
+						hashType,
+						hkdfInfo,
+						hkdfSalt
+					);
+					fail("Should throw an exception");
+				} catch (e) {}
+			}
+		}
+	});
 
-  it('decapsulate, test vectors generated by java', async function() {
-    for (const testVector of TEST_VECTORS) {
-      const ellipticCurveString = EllipticCurves.curveToString(testVector.crv);
-      const privateJwk = EllipticCurves.pointDecode(
-          ellipticCurveString, testVector.pointFormat,
-          Bytes.fromHex(testVector.privateKeyPoint));
-      privateJwk['d'] = Bytes.toBase64(
-          Bytes.fromHex(testVector.privateKeyValue), /* opt_webSafe = */ true);
-      const recipient = await recipientFromJsonWebKey(privateJwk);
-      const hkdfInfo = Bytes.fromHex(testVector.hkdfInfo);
-      const salt = Bytes.fromHex(testVector.salt);
-      const output = await recipient.decapsulate(
-          Bytes.fromHex(testVector.token), testVector.outputLength,
-          testVector.pointFormat, testVector.hashType, hkdfInfo, salt);
-      expect(Bytes.toHex(output)).toBe(testVector.expectedOutput);
-    }
-  });
+	it("decapsulate, test vectors generated by java", async () => {
+		for (const testVector of TEST_VECTORS) {
+			const ellipticCurveString = EllipticCurves.curveToString(
+				testVector.crv
+			);
+			const privateJwk = EllipticCurves.pointDecode(
+				ellipticCurveString,
+				testVector.pointFormat,
+				Bytes.fromHex(testVector.privateKeyPoint)
+			);
+			privateJwk["d"] = Bytes.toBase64(
+				Bytes.fromHex(testVector.privateKeyValue),
+				/* opt_webSafe = */ true
+			);
+			const recipient = await recipientFromJsonWebKey(privateJwk);
+			const hkdfInfo = Bytes.fromHex(testVector.hkdfInfo);
+			const salt = Bytes.fromHex(testVector.salt);
+			const output = await recipient.decapsulate(
+				Bytes.fromHex(testVector.token),
+				testVector.outputLength,
+				testVector.pointFormat,
+				testVector.hashType,
+				hkdfInfo,
+				salt
+			);
+			expect(Bytes.toHex(output)).toBe(testVector.expectedOutput);
+		}
+	});
 });
 
-
 class TestVector {
-  constructor(
-      readonly crv: EllipticCurves.CurveType, readonly hashType: string,
-      readonly pointFormat: EllipticCurves.PointFormatType,
-      readonly token: string, readonly privateKeyPoint: string,
-      readonly privateKeyValue: string, readonly salt: string,
-      readonly hkdfInfo: string, readonly outputLength: number,
-      readonly expectedOutput: string) {}
+	constructor(
+		readonly crv: EllipticCurves.CurveType,
+		readonly hashType: string,
+		readonly pointFormat: EllipticCurves.PointFormatType,
+		readonly token: string,
+		readonly privateKeyPoint: string,
+		readonly privateKeyValue: string,
+		readonly salt: string,
+		readonly hkdfInfo: string,
+		readonly outputLength: number,
+		readonly expectedOutput: string
+	) {}
 }
 
 // Test vectors generated by Java version of Tink.
 //
 // Token (i.e. sender public key) and privateKeyPoint values are in UNCOMPRESSED
-// EcPoint encoding (i.e. it has prefix '04' followed by x and y values).
+// EcPoint encoding (i.e. it has prefix "04" followed by x and y values).
 const TEST_VECTORS: TestVector[] = [
-  new TestVector(
-      EllipticCurves.CurveType.P256, 'SHA-256',
-      EllipticCurves.PointFormatType.UNCOMPRESSED,
-      /* token = */ '04' +
-          '5cdd8e426d11970a610f0e5f9b27f247a421c477b379f2ff3fd3bac50dfff9ff' +
-          '7cada79ab1de9ce4aeaff45fcd2628d1b6d7ecac99d4c26409d4ab8a362c8e7a',
-      /* privateKeyPoint = */ '04' +
-          '4adf0fff84b995bb97af250128a3d779c86ba3cd7e5c0fa2c10895d0b995aaee' +
-          'cdced57616ebb04c808f191c2bf3848c495dcfddcdd1bb73d8ea7a15c642af05',
-      /* privateKeyValue = */
-      'da73e10f7d81483daa63438b982c879706bcf8fef8c7c4d3071c3ef2367714f3',
-      /* salt = */ 'abcdef',
-      /* hkdfInfo = */ 'aaaaaaaaaaaaaaaa',
-      /* outputLength = */ 32,
-      /* expectedOutput = */
-      'aeeee35a14967310798f037e2f126e2e326369115eb9e2d1a34d9c6761f60511'),
-  new TestVector(
-      EllipticCurves.CurveType.P384, 'SHA-1',
-      EllipticCurves.PointFormatType.UNCOMPRESSED,
-      /* token = */ '04' +
-          '75bc8a2e6cf80ce2e0a1cd60ab3d68e4d357b58ff69f0de14b7ec13c58a79750496e07db3f933167148d80730b96f000' +
-          '9389967de410535ca3e103e7ce73dae9525f934589a6cd1fca37e61411985788dcedc71b35ef63b7365e391f6e2a945f',
-      /* privateKeyPoint = */ '04' +
-          '5f81886c4202897355b1da79348d53abd9e9119a7de6f5f10dfe751f7ca9c807035c029bac59499337c4af185fe61728' +
-          'f132bfb234365a9c61e1e56c11acca3bee6621961c7c38eb9dcbd39b332fd35006876dccdb206a7b2d43cf70589c3356',
-      /* privateKeyValue = */
-      '544b5f32731d6277fa71e756f0b2d6840f62e6b744a8b8cdf91f8cf29e6d8562f6237369721f756ab044711e0d42c53c',
-      /* salt = */ 'ababcdcd',
-      /* hkdfInfo = */ '100000000000000001',
-      /* outputLength = */ 32,
-      /* expectedOutput = */
-      '7a25c525eabaa0d994c27f7661a208b5ea25c2a778198237de6e4f235cd64a33'),
-  new TestVector(
-      EllipticCurves.CurveType.P521, 'SHA-512',
-      EllipticCurves.PointFormatType.UNCOMPRESSED,
-      /* token = */ '04' +
-          '0075192f8decddf7a0371b2c859aad738cc5424fa70e74b560070ed8309ae8a6064b06f9aaad8020ac8620e62a6c1196efa44180d325a36a54945743b9382bd49bc1' +
-          '000dfa1e30b228e975998b7afeaaf30235ec505960e58bf3269b69fffcbce9f15fc1441fab2ed97f554ae4bde8b956efb2372c5b330cb1aa0ab81b99e792acd7f5a8',
-      /* privateKeyPoint = */ '04' +
-          '00e57037a96bcbca532ef2f75646d825304ea716bbc9c4bf953455074347158f4818122c76e26a4cf94b39f451b7f5960b9cda43d49999ddc401c1be7f082052b387' +
-          '0147197ba83ec55c8b02e6cbe7b49ce6d6c238edb89561bde6b4574a585c684379d8040888117866823258216344a7268dc696c3a2d192824a1e693609b44661fc2c',
-      /* privateKeyValue = */
-      '001e5410117d22e95c5768b82a786dd66fa8c326b938a3a81fdd6113499437ae9f74e9f876adf085c187c6a147abc13460b8ed3050a6b228005426b61f2b616a79c6',
-      /* salt = */ '00001111',
-      /* hkdfInfo = */ '1234123412341234',
-      /* outputLength = */ 32,
-      /* expectedOutput = */
-      '3f7f64c7aba2cb012c9b5a952385290604b3b5843ec6e6714647a9c9d6ac87be')
+	new TestVector(
+		EllipticCurves.CurveType.P256,
+		"SHA-256",
+		EllipticCurves.PointFormatType.UNCOMPRESSED,
+		/* token = */ "04" +
+			"5cdd8e426d11970a610f0e5f9b27f247a421c477b379f2ff3fd3bac50dfff9ff" +
+			"7cada79ab1de9ce4aeaff45fcd2628d1b6d7ecac99d4c26409d4ab8a362c8e7a",
+		/* privateKeyPoint = */ "04" +
+			"4adf0fff84b995bb97af250128a3d779c86ba3cd7e5c0fa2c10895d0b995aaee" +
+			"cdced57616ebb04c808f191c2bf3848c495dcfddcdd1bb73d8ea7a15c642af05",
+		/* privateKeyValue = */
+		"da73e10f7d81483daa63438b982c879706bcf8fef8c7c4d3071c3ef2367714f3",
+		/* salt = */ "abcdef",
+		/* hkdfInfo = */ "aaaaaaaaaaaaaaaa",
+		/* outputLength = */ 32,
+		/* expectedOutput = */
+		"aeeee35a14967310798f037e2f126e2e326369115eb9e2d1a34d9c6761f60511"
+	),
+	new TestVector(
+		EllipticCurves.CurveType.P384,
+		"SHA-1",
+		EllipticCurves.PointFormatType.UNCOMPRESSED,
+		/* token = */ "04" +
+			"75bc8a2e6cf80ce2e0a1cd60ab3d68e4d357b58ff69f0de14b7ec13c58a79750496e07db3f933167148d80730b96f000" +
+			"9389967de410535ca3e103e7ce73dae9525f934589a6cd1fca37e61411985788dcedc71b35ef63b7365e391f6e2a945f",
+		/* privateKeyPoint = */ "04" +
+			"5f81886c4202897355b1da79348d53abd9e9119a7de6f5f10dfe751f7ca9c807035c029bac59499337c4af185fe61728" +
+			"f132bfb234365a9c61e1e56c11acca3bee6621961c7c38eb9dcbd39b332fd35006876dccdb206a7b2d43cf70589c3356",
+		/* privateKeyValue = */
+		"544b5f32731d6277fa71e756f0b2d6840f62e6b744a8b8cdf91f8cf29e6d8562f6237369721f756ab044711e0d42c53c",
+		/* salt = */ "ababcdcd",
+		/* hkdfInfo = */ "100000000000000001",
+		/* outputLength = */ 32,
+		/* expectedOutput = */
+		"7a25c525eabaa0d994c27f7661a208b5ea25c2a778198237de6e4f235cd64a33"
+	),
+	new TestVector(
+		EllipticCurves.CurveType.P521,
+		"SHA-512",
+		EllipticCurves.PointFormatType.UNCOMPRESSED,
+		/* token = */ "04" +
+			"0075192f8decddf7a0371b2c859aad738cc5424fa70e74b560070ed8309ae8a6064b06f9aaad8020ac8620e62a6c1196efa44180d325a36a54945743b9382bd49bc1" +
+			"000dfa1e30b228e975998b7afeaaf30235ec505960e58bf3269b69fffcbce9f15fc1441fab2ed97f554ae4bde8b956efb2372c5b330cb1aa0ab81b99e792acd7f5a8",
+		/* privateKeyPoint = */ "04" +
+			"00e57037a96bcbca532ef2f75646d825304ea716bbc9c4bf953455074347158f4818122c76e26a4cf94b39f451b7f5960b9cda43d49999ddc401c1be7f082052b387" +
+			"0147197ba83ec55c8b02e6cbe7b49ce6d6c238edb89561bde6b4574a585c684379d8040888117866823258216344a7268dc696c3a2d192824a1e693609b44661fc2c",
+		/* privateKeyValue = */
+		"001e5410117d22e95c5768b82a786dd66fa8c326b938a3a81fdd6113499437ae9f74e9f876adf085c187c6a147abc13460b8ed3050a6b228005426b61f2b616a79c6",
+		/* salt = */ "00001111",
+		/* hkdfInfo = */ "1234123412341234",
+		/* outputLength = */ 32,
+		/* expectedOutput = */
+		"3f7f64c7aba2cb012c9b5a952385290604b3b5843ec6e6714647a9c9d6ac87be"
+	),
 ];

--- a/javascript/subtle/ecies_hkdf_kem_sender_test.ts
+++ b/javascript/subtle/ecies_hkdf_kem_sender_test.ts
@@ -4,115 +4,149 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bytes from './bytes';
-import {EciesHkdfKemSender, fromJsonWebKey} from './ecies_hkdf_kem_sender';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import { EciesHkdfKemSender, fromJsonWebKey } from "./ecies_hkdf_kem_sender";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
 
-describe('ecies hkdf kem sender test', function() {
-  it('encapsulate, always generate random key', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    const sender = await fromJsonWebKey(publicKey);
-    const keySizeInBytes = 32;
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const hkdfHash = 'SHA-256';
-    const hkdfInfo = Random.randBytes(32);
-    const hkdfSalt = Random.randBytes(32);
-    const keys = new Set();
-    const tokens = new Set();
-    for (let i = 0; i < 20; i++) {
-      const kemKeyToken = await sender.encapsulate(
-          keySizeInBytes, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      keys.add(Bytes.toHex(kemKeyToken['key']));
-      tokens.add(Bytes.toHex(kemKeyToken['token']));
-    }
-    expect(keys.size).toBe(20);
-    expect(tokens.size).toBe(20);
-  });
+describe("ecies hkdf kem sender test", () => {
+	it("encapsulate, always generate random key", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const sender = await fromJsonWebKey(publicKey);
+		const keySizeInBytes = 32;
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const hkdfHash = "SHA-256";
+		const hkdfInfo = Random.randBytes(32);
+		const hkdfSalt = Random.randBytes(32);
+		const keys = new Set();
+		const tokens = new Set();
+		for (let i = 0; i < 20; i++) {
+			const kemKeyToken = await sender.encapsulate(
+				keySizeInBytes,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			keys.add(Bytes.toHex(kemKeyToken["key"]));
+			tokens.add(Bytes.toHex(kemKeyToken["token"]));
+		}
+		expect(keys.size).toBe(20);
+		expect(tokens.size).toBe(20);
+	});
 
-  it('encapsulate, non integer key size', async function() {
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const publicKey = await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-    const sender = await fromJsonWebKey(publicKey);
-    const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const hkdfHash = 'SHA-256';
-    const hkdfInfo = Random.randBytes(32);
-    const hkdfSalt = Random.randBytes(32);
-    try {
-      await sender.encapsulate(NaN, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be an integer');
-    }
-    try {
-      await sender.encapsulate(0, pointFormat, hkdfHash, hkdfInfo, hkdfSalt);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be positive');
-    }
-  });
+	it("encapsulate, non integer key size", async () => {
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const publicKey = await EllipticCurves.exportCryptoKey(
+			keyPair.publicKey!
+		);
+		const sender = await fromJsonWebKey(publicKey);
+		const pointFormat = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const hkdfHash = "SHA-256";
+		const hkdfInfo = Random.randBytes(32);
+		const hkdfSalt = Random.randBytes(32);
+		try {
+			await sender.encapsulate(
+				NaN,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be an integer"
+			);
+		}
+		try {
+			await sender.encapsulate(
+				0,
+				pointFormat,
+				hkdfHash,
+				hkdfInfo,
+				hkdfSalt
+			);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be positive"
+			);
+		}
+	});
 
-  it('new instance, invalid parameters', async function() {
-    // Test fromJsonWebKey with public key instead private key.
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const privateKey =
-        await EllipticCurves.exportCryptoKey(keyPair.privateKey!);
-    try {
-      await fromJsonWebKey(privateKey);
-      fail('An exception should be thrown.');
-    } catch (e) {
-    }
-  });
+	it("new instance, invalid parameters", async () => {
+		// Test fromJsonWebKey with public key instead private key.
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		const privateKey = await EllipticCurves.exportCryptoKey(
+			keyPair.privateKey!
+		);
+		try {
+			await fromJsonWebKey(privateKey);
+			fail("An exception should be thrown.");
+		} catch (e) {}
+	});
 
-  it('new instance, invalid public key', async function() {
-    for (const curve
-             of [EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-                 EllipticCurves.CurveType.P521]) {
-      const crvString = EllipticCurves.curveToString(curve);
-      const keyPair = await EllipticCurves.generateKeyPair('ECDH', crvString);
-      const publicJwk =
-          await EllipticCurves.exportCryptoKey(keyPair.publicKey!);
-      // Change the 'x' value to make the public key invalid. Either getting new
-      // recipient with corrupted public key or trying to encapsulate with this
-      // recipient should fail.
-      const xLength = EllipticCurves.fieldSizeInBytes(curve);
-      publicJwk['x'] =
-          Bytes.toBase64(new Uint8Array(xLength), /* opt_webSafe = */ true);
-      const hkdfInfo = Random.randBytes(10);
-      const salt = Random.randBytes(8);
-      try {
-        const sender = await fromJsonWebKey(publicJwk);
-        await sender.encapsulate(
-            /* keySizeInBytes = */ 32,
-            EllipticCurves.PointFormatType.UNCOMPRESSED,
-            /* hkdfHash = */ 'SHA-256', hkdfInfo, salt);
-        fail('Should throw an exception.');
-      } catch (e) {
-      }
-    }
-  });
+	it("new instance, invalid public key", async () => {
+		for (const curve of [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		]) {
+			const crvString = EllipticCurves.curveToString(curve);
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDH",
+				crvString
+			);
+			const publicJwk = await EllipticCurves.exportCryptoKey(
+				keyPair.publicKey!
+			);
+			// Change the "x" value to make the public key invalid. Either getting new
+			// recipient with corrupted public key or trying to encapsulate with this
+			// recipient should fail.
+			const xLength = EllipticCurves.fieldSizeInBytes(curve);
+			publicJwk["x"] = Bytes.toBase64(
+				new Uint8Array(xLength),
+				/* opt_webSafe = */ true
+			);
+			const hkdfInfo = Random.randBytes(10);
+			const salt = Random.randBytes(8);
+			try {
+				const sender = await fromJsonWebKey(publicJwk);
+				await sender.encapsulate(
+					/* keySizeInBytes = */ 32,
+					EllipticCurves.PointFormatType.UNCOMPRESSED,
+					/* hkdfHash = */ "SHA-256",
+					hkdfInfo,
+					salt
+				);
+				fail("Should throw an exception.");
+			} catch (e) {}
+		}
+	});
 
-  it('constructor, invalid parameters', async function() {
-    // Test constructor with public key instead private key.
-    const keyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    try {
-      new EciesHkdfKemSender(keyPair.privateKey!);
-      fail('An exception should be thrown.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: Expected Crypto key of type: public.');
-    }
-  });
+	it("constructor, invalid parameters", async () => {
+		// Test constructor with public key instead private key.
+		const keyPair = await EllipticCurves.generateKeyPair("ECDH", "P-256");
+		try {
+			new EciesHkdfKemSender(keyPair.privateKey!);
+			fail("An exception should be thrown.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: Expected Crypto key of type: public."
+			);
+		}
+	});
 });

--- a/javascript/subtle/elliptic_curves_test.ts
+++ b/javascript/subtle/elliptic_curves_test.ts
@@ -4,437 +4,549 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {assertExists} from '../testing/internal/test_utils';
+import { assertExists } from "../testing/internal/test_utils";
 
-import * as Bytes from './bytes';
-import * as EllipticCurves from './elliptic_curves';
-import * as Random from './random';
-import {WYCHEPROOF_ECDH_TEST_VECTORS} from './wycheproof_ecdh_test_vectors';
+import * as Bytes from "./bytes";
+import * as EllipticCurves from "./elliptic_curves";
+import * as Random from "./random";
+import { WYCHEPROOF_ECDH_TEST_VECTORS } from "./wycheproof_ecdh_test_vectors";
 
-describe('elliptic curves test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("elliptic curves test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('compute ecdh shared secret', async function() {
-    const aliceKeyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const bobKeyPair = await EllipticCurves.generateKeyPair('ECDH', 'P-256');
-    const sharedSecret1 = await EllipticCurves.computeEcdhSharedSecret(
-        aliceKeyPair.privateKey!, bobKeyPair.publicKey!);
-    const sharedSecret2 = await EllipticCurves.computeEcdhSharedSecret(
-        bobKeyPair.privateKey!, aliceKeyPair.publicKey!);
-    expect(Bytes.toHex(sharedSecret2)).toBe(Bytes.toHex(sharedSecret1));
-  });
+	it("compute ecdh shared secret", async () => {
+		const aliceKeyPair = await EllipticCurves.generateKeyPair(
+			"ECDH",
+			"P-256"
+		);
+		const bobKeyPair = await EllipticCurves.generateKeyPair(
+			"ECDH",
+			"P-256"
+		);
+		const sharedSecret1 = await EllipticCurves.computeEcdhSharedSecret(
+			aliceKeyPair.privateKey!,
+			bobKeyPair.publicKey!
+		);
+		const sharedSecret2 = await EllipticCurves.computeEcdhSharedSecret(
+			bobKeyPair.privateKey!,
+			aliceKeyPair.publicKey!
+		);
+		expect(Bytes.toHex(sharedSecret2)).toBe(Bytes.toHex(sharedSecret1));
+	});
 
-  it('wycheproof, wycheproof webcrypto', async function() {
-    for (const testGroup of WYCHEPROOF_ECDH_TEST_VECTORS['testGroups']) {
-      let errors = '';
-      for (const test of testGroup['tests']) {
-        errors += await runWycheproofTest(test);
-      }
-      if (errors !== '') {
-        fail(errors);
-      }
-    }
-  });
+	it("wycheproof, wycheproof webcrypto", async () => {
+		for (const testGroup of WYCHEPROOF_ECDH_TEST_VECTORS["testGroups"]) {
+			let errors = "";
+			for (const test of testGroup["tests"]) {
+				errors += await runWycheproofTest(test);
+			}
+			if (errors !== "") {
+				fail(errors);
+			}
+		}
+	});
 
-  // Test that both ECDH public and private key are defined in the result.
-  it('generate key pair e c d h', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    for (const curve of curveTypes) {
-      const curveTypeString = EllipticCurves.curveToString(curve);
-      const keyPair =
-          await EllipticCurves.generateKeyPair('ECDH', curveTypeString);
-      expect(keyPair.privateKey! != null).toBe(true);
-      expect(keyPair.publicKey! != null).toBe(true);
-    }
-  });
+	// Test that both ECDH public and private key are defined in the result.
+	it("generate key pair e c d h", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		for (const curve of curveTypes) {
+			const curveTypeString = EllipticCurves.curveToString(curve);
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDH",
+				curveTypeString
+			);
+			expect(keyPair.privateKey! != null).toBe(true);
+			expect(keyPair.publicKey! != null).toBe(true);
+		}
+	});
 
-  // Test that both ECDSA public and private key are defined in the result.
-  it('generate key pair e c d s a', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    for (const curve of curveTypes) {
-      const curveTypeString = EllipticCurves.curveToString(curve);
-      const keyPair =
-          await EllipticCurves.generateKeyPair('ECDSA', curveTypeString);
-      expect(keyPair.privateKey! != null).toBe(true);
-      expect(keyPair.publicKey! != null).toBe(true);
-    }
-  });
+	// Test that both ECDSA public and private key are defined in the result.
+	it("generate key pair e c d s a", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		for (const curve of curveTypes) {
+			const curveTypeString = EllipticCurves.curveToString(curve);
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				curveTypeString
+			);
+			expect(keyPair.privateKey! != null).toBe(true);
+			expect(keyPair.publicKey! != null).toBe(true);
+		}
+	});
 
-  // Test that when ECDH crypto key is exported and imported it gives the same
-  // key as the original one.
-  it('import export crypto key e c d h', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    for (const curve of curveTypes) {
-      const curveTypeString = EllipticCurves.curveToString(curve);
-      const keyPair =
-          await EllipticCurves.generateKeyPair('ECDH', curveTypeString);
+	// Test that when ECDH crypto key is exported and imported it gives the same
+	// key as the original one.
+	it("import export crypto key e c d h", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		for (const curve of curveTypes) {
+			const curveTypeString = EllipticCurves.curveToString(curve);
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDH",
+				curveTypeString
+			);
 
-      const publicKey = keyPair.publicKey!;
-      const publicCryptoKey = await EllipticCurves.exportCryptoKey(publicKey);
-      const importedPublicKey =
-          await EllipticCurves.importPublicKey('ECDH', publicCryptoKey);
-      expect(importedPublicKey).toEqual(publicKey);
+			const publicKey = keyPair.publicKey!;
+			const publicCryptoKey = await EllipticCurves.exportCryptoKey(
+				publicKey
+			);
+			const importedPublicKey = await EllipticCurves.importPublicKey(
+				"ECDH",
+				publicCryptoKey
+			);
+			expect(importedPublicKey).toEqual(publicKey);
 
-      const privateKey = keyPair.privateKey!;
-      const privateCryptoKey = await EllipticCurves.exportCryptoKey(privateKey);
-      const importedPrivateKey =
-          await EllipticCurves.importPrivateKey('ECDH', privateCryptoKey);
-      expect(importedPrivateKey).toEqual(privateKey);
-    }
-  });
+			const privateKey = keyPair.privateKey!;
+			const privateCryptoKey = await EllipticCurves.exportCryptoKey(
+				privateKey
+			);
+			const importedPrivateKey = await EllipticCurves.importPrivateKey(
+				"ECDH",
+				privateCryptoKey
+			);
+			expect(importedPrivateKey).toEqual(privateKey);
+		}
+	});
 
-  // Test that when ECDSA crypto key is exported and imported it gives the same
-  // key as the original one.
-  it('import export crypto key e c d s a', async function() {
-    const curveTypes = [
-      EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-      EllipticCurves.CurveType.P521
-    ];
-    for (const curve of curveTypes) {
-      const curveTypeString = EllipticCurves.curveToString(curve);
-      const keyPair =
-          await EllipticCurves.generateKeyPair('ECDSA', curveTypeString);
+	// Test that when ECDSA crypto key is exported and imported it gives the same
+	// key as the original one.
+	it("import export crypto key e c d s a", async () => {
+		const curveTypes = [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		];
+		for (const curve of curveTypes) {
+			const curveTypeString = EllipticCurves.curveToString(curve);
+			const keyPair = await EllipticCurves.generateKeyPair(
+				"ECDSA",
+				curveTypeString
+			);
 
-      const publicKey = keyPair.publicKey!;
-      const publicCryptoKey = await EllipticCurves.exportCryptoKey(publicKey);
-      const importedPublicKey =
-          await EllipticCurves.importPublicKey('ECDSA', publicCryptoKey);
-      expect(importedPublicKey).toEqual(publicKey);
+			const publicKey = keyPair.publicKey!;
+			const publicCryptoKey = await EllipticCurves.exportCryptoKey(
+				publicKey
+			);
+			const importedPublicKey = await EllipticCurves.importPublicKey(
+				"ECDSA",
+				publicCryptoKey
+			);
+			expect(importedPublicKey).toEqual(publicKey);
 
-      const privateKey = keyPair.privateKey!;
-      const privateCryptoKey = await EllipticCurves.exportCryptoKey(privateKey);
-      const importedPrivateKey =
-          await EllipticCurves.importPrivateKey('ECDSA', privateCryptoKey);
-      expect(importedPrivateKey).toEqual(privateKey);
-    }
-  });
+			const privateKey = keyPair.privateKey!;
+			const privateCryptoKey = await EllipticCurves.exportCryptoKey(
+				privateKey
+			);
+			const importedPrivateKey = await EllipticCurves.importPrivateKey(
+				"ECDSA",
+				privateCryptoKey
+			);
+			expect(importedPrivateKey).toEqual(privateKey);
+		}
+	});
 
-  // Test that when JSON ECDH web key is imported and exported it gives the same
-  // key as the original one.
-  it('import export json key e c d h', async function() {
-    for (const testKey of TEST_KEYS) {
-      const jwk: JsonWebKey = ({
-        'kty': 'EC',
-        'crv': testKey.curve,
-        'x': Bytes.toBase64(Bytes.fromHex(testKey.x), true),
-        'y': Bytes.toBase64(Bytes.fromHex(testKey.y), true),
-        'ext': true,
-      });
+	// Test that when JSON ECDH web key is imported and exported it gives the same
+	// key as the original one.
+	it("import export json key e c d h", async () => {
+		for (const testKey of TEST_KEYS) {
+			const jwk: JsonWebKey = {
+				kty: "EC",
+				crv: testKey.curve,
+				x: Bytes.toBase64(Bytes.fromHex(testKey.x), true),
+				y: Bytes.toBase64(Bytes.fromHex(testKey.y), true),
+				ext: true,
+			};
 
-      let importedKey;
-      if (!testKey.d) {
-        jwk['key_ops'] = [];
-        importedKey = await EllipticCurves.importPublicKey('ECDH', jwk);
-      } else {
-        jwk['key_ops'] = ['deriveKey', 'deriveBits'];
-        jwk['d'] = Bytes.toBase64(Bytes.fromHex(testKey.d), true);
-        importedKey = await EllipticCurves.importPrivateKey('ECDH', jwk);
-      }
+			let importedKey;
+			if (!testKey.d) {
+				jwk["key_ops"] = [];
+				importedKey = await EllipticCurves.importPublicKey("ECDH", jwk);
+			} else {
+				jwk["key_ops"] = ["deriveKey", "deriveBits"];
+				jwk["d"] = Bytes.toBase64(Bytes.fromHex(testKey.d), true);
+				importedKey = await EllipticCurves.importPrivateKey(
+					"ECDH",
+					jwk
+				);
+			}
 
-      const exportedKey = await EllipticCurves.exportCryptoKey(importedKey);
-      expect(exportedKey).toEqual(jwk);
-    }
-  });
+			const exportedKey = await EllipticCurves.exportCryptoKey(
+				importedKey
+			);
+			expect(exportedKey).toEqual(jwk);
+		}
+	});
 
-  // Test that when JSON ECDSA web key is imported and exported it gives the
-  // same key as the original one.
-  it('import export json key e c d s a', async function() {
-    for (const testKey of TEST_KEYS) {
-      const jwk: JsonWebKey = ({
-        'kty': 'EC',
-        'crv': testKey.curve,
-        'x': Bytes.toBase64(Bytes.fromHex(testKey.x), true),
-        'y': Bytes.toBase64(Bytes.fromHex(testKey.y), true),
-        'ext': true,
-      });
+	// Test that when JSON ECDSA web key is imported and exported it gives the
+	// same key as the original one.
+	it("import export json key e c d s a", async () => {
+		for (const testKey of TEST_KEYS) {
+			const jwk: JsonWebKey = {
+				kty: "EC",
+				crv: testKey.curve,
+				x: Bytes.toBase64(Bytes.fromHex(testKey.x), true),
+				y: Bytes.toBase64(Bytes.fromHex(testKey.y), true),
+				ext: true,
+			};
 
-      let importedKey;
-      if (!testKey.d) {
-        jwk['key_ops'] = ['verify'];
-        importedKey = await EllipticCurves.importPublicKey('ECDSA', jwk);
-      } else {
-        jwk['key_ops'] = ['sign'];
-        jwk['d'] = Bytes.toBase64(Bytes.fromHex(testKey.d), true);
-        importedKey = await EllipticCurves.importPrivateKey('ECDSA', jwk);
-      }
+			let importedKey;
+			if (!testKey.d) {
+				jwk["key_ops"] = ["verify"];
+				importedKey = await EllipticCurves.importPublicKey(
+					"ECDSA",
+					jwk
+				);
+			} else {
+				jwk["key_ops"] = ["sign"];
+				jwk["d"] = Bytes.toBase64(Bytes.fromHex(testKey.d), true);
+				importedKey = await EllipticCurves.importPrivateKey(
+					"ECDSA",
+					jwk
+				);
+			}
 
-      const exportedKey = await EllipticCurves.exportCryptoKey(importedKey);
-      expect(exportedKey).toEqual(jwk);
-    }
-  });
+			const exportedKey = await EllipticCurves.exportCryptoKey(
+				importedKey
+			);
+			expect(exportedKey).toEqual(jwk);
+		}
+	});
 
-  it('curve to string', function() {
-    expect(EllipticCurves.curveToString(EllipticCurves.CurveType.P256))
-        .toBe('P-256');
-    expect(EllipticCurves.curveToString(EllipticCurves.CurveType.P384))
-        .toBe('P-384');
-    expect(EllipticCurves.curveToString(EllipticCurves.CurveType.P521))
-        .toBe('P-521');
-  });
+	it("curve to string", () => {
+		expect(
+			EllipticCurves.curveToString(EllipticCurves.CurveType.P256)
+		).toBe("P-256");
+		expect(
+			EllipticCurves.curveToString(EllipticCurves.CurveType.P384)
+		).toBe("P-384");
+		expect(
+			EllipticCurves.curveToString(EllipticCurves.CurveType.P521)
+		).toBe("P-521");
+	});
 
-  it('curve from string', function() {
-    expect(EllipticCurves.curveFromString('P-256'))
-        .toBe(EllipticCurves.CurveType.P256);
-    expect(EllipticCurves.curveFromString('P-384'))
-        .toBe(EllipticCurves.CurveType.P384);
-    expect(EllipticCurves.curveFromString('P-521'))
-        .toBe(EllipticCurves.CurveType.P521);
-  });
+	it("curve from string", () => {
+		expect(EllipticCurves.curveFromString("P-256")).toBe(
+			EllipticCurves.CurveType.P256
+		);
+		expect(EllipticCurves.curveFromString("P-384")).toBe(
+			EllipticCurves.CurveType.P384
+		);
+		expect(EllipticCurves.curveFromString("P-521")).toBe(
+			EllipticCurves.CurveType.P521
+		);
+	});
 
-  it('field size in bytes', function() {
-    expect(EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P256))
-        .toBe(256 / 8);
-    expect(EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P384))
-        .toBe(384 / 8);
-    expect(EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P521))
-        .toBe((521 + 7) / 8);
-  });
+	it("field size in bytes", () => {
+		expect(
+			EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P256)
+		).toBe(256 / 8);
+		expect(
+			EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P384)
+		).toBe(384 / 8);
+		expect(
+			EllipticCurves.fieldSizeInBytes(EllipticCurves.CurveType.P521)
+		).toBe((521 + 7) / 8);
+	});
 
-  it('encoding size in bytes, uncompressed point format type', function() {
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P256,
-               EllipticCurves.PointFormatType.UNCOMPRESSED))
-        .toBe(2 * (256 / 8) + 1);
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P384,
-               EllipticCurves.PointFormatType.UNCOMPRESSED))
-        .toBe(2 * (384 / 8) + 1);
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P521,
-               EllipticCurves.PointFormatType.UNCOMPRESSED))
-        .toBe(2 * ((521 + 7) / 8) + 1);
-  });
+	it("encoding size in bytes, uncompressed point format type", () => {
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P256,
+				EllipticCurves.PointFormatType.UNCOMPRESSED
+			)
+		).toBe(2 * (256 / 8) + 1);
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P384,
+				EllipticCurves.PointFormatType.UNCOMPRESSED
+			)
+		).toBe(2 * (384 / 8) + 1);
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P521,
+				EllipticCurves.PointFormatType.UNCOMPRESSED
+			)
+		).toBe(2 * ((521 + 7) / 8) + 1);
+	});
 
-  it('encoding size in bytes, compressed point format type', function() {
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P256,
-               EllipticCurves.PointFormatType.COMPRESSED))
-        .toBe((256 / 8) + 1);
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P384,
-               EllipticCurves.PointFormatType.COMPRESSED))
-        .toBe((384 / 8) + 1);
-    expect(EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P521,
-               EllipticCurves.PointFormatType.COMPRESSED))
-        .toBe(((521 + 7) / 8) + 1);
-  });
+	it("encoding size in bytes, compressed point format type", () => {
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P256,
+				EllipticCurves.PointFormatType.COMPRESSED
+			)
+		).toBe(256 / 8 + 1);
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P384,
+				EllipticCurves.PointFormatType.COMPRESSED
+			)
+		).toBe(384 / 8 + 1);
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P521,
+				EllipticCurves.PointFormatType.COMPRESSED
+			)
+		).toBe((521 + 7) / 8 + 1);
+	});
 
-  it('encoding size in bytes, crunchy uncompressed point format type',
-     function() {
-       expect(
-           EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P256,
-               EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED))
-           .toBe(2 * (256 / 8));
-       expect(
-           EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P384,
-               EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED))
-           .toBe(2 * (384 / 8));
-       expect(
-           EllipticCurves.encodingSizeInBytes(
-               EllipticCurves.CurveType.P521,
-               EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED))
-           .toBe(2 * ((521 + 7) / 8));
-     });
+	it("encoding size in bytes, crunchy uncompressed point format type", () => {
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P256,
+				EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED
+			)
+		).toBe(2 * (256 / 8));
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P384,
+				EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED
+			)
+		).toBe(2 * (384 / 8));
+		expect(
+			EllipticCurves.encodingSizeInBytes(
+				EllipticCurves.CurveType.P521,
+				EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED
+			)
+		).toBe(2 * ((521 + 7) / 8));
+	});
 
-  it('point decode, wrong point size', function() {
-    const point = new Uint8Array(10);
-    const format = EllipticCurves.PointFormatType.UNCOMPRESSED;
+	it("point decode, wrong point size", () => {
+		const point = new Uint8Array(10);
+		const format = EllipticCurves.PointFormatType.UNCOMPRESSED;
 
-    for (const curve
-             of [EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-                 EllipticCurves.CurveType.P521]) {
-      const curveTypeString = EllipticCurves.curveToString(curve);
+		for (const curve of [
+			EllipticCurves.CurveType.P256,
+			EllipticCurves.CurveType.P384,
+			EllipticCurves.CurveType.P521,
+		]) {
+			const curveTypeString = EllipticCurves.curveToString(curve);
 
-      // It should throw an exception as the point array is too short.
-      try {
-        EllipticCurves.pointDecode(curveTypeString, format, point);
-        fail('Should throw an exception.');
-        // Preserving old behavior when moving to
-        // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-        // tslint:disable-next-line:no-any
-      } catch (e: any) {
-        expect(e.toString()).toBe('InvalidArgumentsException: invalid point');
-      }
-    }
-  });
+			// It should throw an exception as the point array is too short.
+			try {
+				EllipticCurves.pointDecode(curveTypeString, format, point);
+				fail("Should throw an exception.");
+				// Preserving old behavior when moving to
+				// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+				// tslint:disable-next-line:no-any
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"InvalidArgumentsException: invalid point"
+				);
+			}
+		}
+	});
 
-  it('point decode, unknown curve', function() {
-    const point = new Uint8Array(10);
-    const format = EllipticCurves.PointFormatType.UNCOMPRESSED;
-    const curve = 'some-unknown-curve';
+	it("point decode, unknown curve", () => {
+		const point = new Uint8Array(10);
+		const format = EllipticCurves.PointFormatType.UNCOMPRESSED;
+		const curve = "some-unknown-curve";
 
-    try {
-      EllipticCurves.pointDecode(curve, format, point);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString().includes('unknown curve')).toBe(true);
-    }
-  });
+		try {
+			EllipticCurves.pointDecode(curve, format, point);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString().includes("unknown curve")).toBe(true);
+		}
+	});
 
-  it('point encode, compressed', () => {
-    for (const test of TEST_VECTORS) {
-      const format = EllipticCurves.formatFromString(test.format);
-      if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
-        // TODO(b/214598739): Investigate compatibility of other formats with
-        // Java test vectors.
-        continue;
-      }
-      const point: JsonWebKey = {
-        kty: 'EC',
-        crv: test.curve,
-        x: Bytes.toBase64(
-            EllipticCurves.integerToByteArray(BigInt('0x' + test.x)),
-            /* websafe = */ true),
-        y: Bytes.toBase64(
-            EllipticCurves.integerToByteArray(BigInt('0x' + test.y)),
-            /* websafe = */ true),
-        ext: true,
-      };
+	it("point encode, compressed", () => {
+		for (const test of TEST_VECTORS) {
+			const format = EllipticCurves.formatFromString(test.format);
+			if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
+				// TODO(b/214598739): Investigate compatibility of other formats with
+				// Java test vectors.
+				continue;
+			}
+			const point: JsonWebKey = {
+				kty: "EC",
+				crv: test.curve,
+				x: Bytes.toBase64(
+					EllipticCurves.integerToByteArray(BigInt("0x" + test.x)),
+					/* websafe = */ true
+				),
+				y: Bytes.toBase64(
+					EllipticCurves.integerToByteArray(BigInt("0x" + test.y)),
+					/* websafe = */ true
+				),
+				ext: true,
+			};
 
-      const encodedPoint =
-          EllipticCurves.pointEncode(assertExists(point.crv), format, point);
+			const encodedPoint = EllipticCurves.pointEncode(
+				assertExists(point.crv),
+				format,
+				point
+			);
 
-      expect(Bytes.toHex(encodedPoint)).toEqual(test.encoded);
-    }
-  });
+			expect(Bytes.toHex(encodedPoint)).toEqual(test.encoded);
+		}
+	});
 
-  it('point decode, compressed', () => {
-    for (const test of TEST_VECTORS) {
-      const format = EllipticCurves.formatFromString(test.format);
-      if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
-        // TODO(b/214598739): Investigate compatibility of other formats with
-        // Java test vectors.
-        continue;
-      }
-      const decodedPoint = EllipticCurves.pointDecode(
-          test.curve, format, Bytes.fromHex(test.encoded));
-      // NOTE: Any leading zero inserted by Bytes.toHex() must be removed.
-      const decodedX =
-          Bytes.toHex(Bytes.fromBase64(assertExists(decodedPoint.x), true))
-              .replace(/^0?/, '');
-      const decodedY =
-          Bytes.toHex(Bytes.fromBase64(assertExists(decodedPoint.y), true))
-              .replace(/^0?/, '');
+	it("point decode, compressed", () => {
+		for (const test of TEST_VECTORS) {
+			const format = EllipticCurves.formatFromString(test.format);
+			if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
+				// TODO(b/214598739): Investigate compatibility of other formats with
+				// Java test vectors.
+				continue;
+			}
+			const decodedPoint = EllipticCurves.pointDecode(
+				test.curve,
+				format,
+				Bytes.fromHex(test.encoded)
+			);
+			// NOTE: Any leading zero inserted by Bytes.toHex() must be removed.
+			const decodedX = Bytes.toHex(
+				Bytes.fromBase64(assertExists(decodedPoint.x), true)
+			).replace(/^0?/, "");
+			const decodedY = Bytes.toHex(
+				Bytes.fromBase64(assertExists(decodedPoint.y), true)
+			).replace(/^0?/, "");
 
-      expect(decodedX).toEqual(test.x);
-      expect(decodedY).toEqual(test.y);
-    }
-  });
+			expect(decodedX).toEqual(test.x);
+			expect(decodedY).toEqual(test.y);
+		}
+	});
 
-  it('point encode decode', () => {
-    for (const test of TEST_VECTORS) {
-      const format = EllipticCurves.formatFromString(test.format);
-      if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
-        // TODO(b/214598739): Investigate compatibility of other formats with
-        // Java test vectors.
-        continue;
-      }
-      const point: JsonWebKey = {
-        kty: 'EC',
-        crv: test.curve,
-        x: Bytes.toBase64(
-            EllipticCurves.integerToByteArray(BigInt('0x' + test.x)),
-            /* websafe = */ true),
-        y: Bytes.toBase64(
-            EllipticCurves.integerToByteArray(BigInt('0x' + test.y)),
-            /* websafe = */ true),
-        ext: true,
-      };
+	it("point encode decode", () => {
+		for (const test of TEST_VECTORS) {
+			const format = EllipticCurves.formatFromString(test.format);
+			if (format !== EllipticCurves.PointFormatType.COMPRESSED) {
+				// TODO(b/214598739): Investigate compatibility of other formats with
+				// Java test vectors.
+				continue;
+			}
+			const point: JsonWebKey = {
+				kty: "EC",
+				crv: test.curve,
+				x: Bytes.toBase64(
+					EllipticCurves.integerToByteArray(BigInt("0x" + test.x)),
+					/* websafe = */ true
+				),
+				y: Bytes.toBase64(
+					EllipticCurves.integerToByteArray(BigInt("0x" + test.y)),
+					/* websafe = */ true
+				),
+				ext: true,
+			};
 
-      const encodedPoint =
-          EllipticCurves.pointEncode(assertExists(point.crv), format, point);
-      const decodedPoint = EllipticCurves.pointDecode(
-          assertExists(point.crv), format, encodedPoint);
+			const encodedPoint = EllipticCurves.pointEncode(
+				assertExists(point.crv),
+				format,
+				point
+			);
+			const decodedPoint = EllipticCurves.pointDecode(
+				assertExists(point.crv),
+				format,
+				encodedPoint
+			);
 
-      expect(decodedPoint).toEqual(point);
-    }
-  });
+			expect(decodedPoint).toEqual(point);
+		}
+	});
 
-  it('point encode decode, random points', () => {
-    for (const format of
-             [EllipticCurves.PointFormatType.UNCOMPRESSED,
-              EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED]) {
-      for (const curveType
-               of [EllipticCurves.CurveType.P256, EllipticCurves.CurveType.P384,
-                   EllipticCurves.CurveType.P521]) {
-        const curveTypeString = EllipticCurves.curveToString(curveType);
-        const x = Random.randBytes(EllipticCurves.fieldSizeInBytes(curveType));
-        const y = Random.randBytes(EllipticCurves.fieldSizeInBytes(curveType));
-        const point: JsonWebKey = {
-          kty: 'EC',
-          crv: curveTypeString,
-          x: Bytes.toBase64(x, /* websafe = */ true),
-          y: Bytes.toBase64(y, /* websafe = */ true),
-          ext: true,
-        };
+	it("point encode decode, random points", () => {
+		for (const format of [
+			EllipticCurves.PointFormatType.UNCOMPRESSED,
+			EllipticCurves.PointFormatType.DO_NOT_USE_CRUNCHY_UNCOMPRESSED,
+		]) {
+			for (const curveType of [
+				EllipticCurves.CurveType.P256,
+				EllipticCurves.CurveType.P384,
+				EllipticCurves.CurveType.P521,
+			]) {
+				const curveTypeString = EllipticCurves.curveToString(curveType);
+				const x = Random.randBytes(
+					EllipticCurves.fieldSizeInBytes(curveType)
+				);
+				const y = Random.randBytes(
+					EllipticCurves.fieldSizeInBytes(curveType)
+				);
+				const point: JsonWebKey = {
+					kty: "EC",
+					crv: curveTypeString,
+					x: Bytes.toBase64(x, /* websafe = */ true),
+					y: Bytes.toBase64(y, /* websafe = */ true),
+					ext: true,
+				};
 
-        const encodedPoint =
-            EllipticCurves.pointEncode(assertExists(point.crv), format, point);
-        const decodedPoint =
-            EllipticCurves.pointDecode(curveTypeString, format, encodedPoint);
+				const encodedPoint = EllipticCurves.pointEncode(
+					assertExists(point.crv),
+					format,
+					point
+				);
+				const decodedPoint = EllipticCurves.pointDecode(
+					curveTypeString,
+					format,
+					encodedPoint
+				);
 
-        expect(decodedPoint).toEqual(point);
-      }
-    }
-  });
+				expect(decodedPoint).toEqual(point);
+			}
+		}
+	});
 
-  it('ecdsa der2 ieee', function() {
-    for (const test of ECDSA_IEEE_DER_TEST_VECTORS) {
-      expect(EllipticCurves.ecdsaDer2Ieee(test.der, test.ieee.length))
-          .toEqual(test.ieee);
-    }
-  });
+	it("ecdsa der2 ieee", () => {
+		for (const test of ECDSA_IEEE_DER_TEST_VECTORS) {
+			expect(
+				EllipticCurves.ecdsaDer2Ieee(test.der, test.ieee.length)
+			).toEqual(test.ieee);
+		}
+	});
 
-  it('ecdsa der2 ieee with invalid signatures', function() {
-    for (const test of INVALID_DER_ECDSA_SIGNATURES) {
-      try {
-        EllipticCurves.ecdsaDer2Ieee(
-            Bytes.fromHex(test), 1 /* ieeeLength, ignored */);
-        // Preserving old behavior when moving to
-        // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-        // tslint:disable-next-line:no-any
-      } catch (e: any) {
-        expect(e.toString())
-            .toBe('InvalidArgumentsException: invalid DER signature');
-      }
-    }
-  });
+	it("ecdsa der2 ieee with invalid signatures", () => {
+		for (const test of INVALID_DER_ECDSA_SIGNATURES) {
+			try {
+				EllipticCurves.ecdsaDer2Ieee(
+					Bytes.fromHex(test),
+					1 /* ieeeLength, ignored */
+				);
+				// Preserving old behavior when moving to
+				// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+				// tslint:disable-next-line:no-any
+			} catch (e: any) {
+				expect(e.toString()).toBe(
+					"InvalidArgumentsException: invalid DER signature"
+				);
+			}
+		}
+	});
 
-  it('ecdsa ieee2 der', function() {
-    for (const test of ECDSA_IEEE_DER_TEST_VECTORS) {
-      expect(EllipticCurves.ecdsaIeee2Der(test.ieee)).toEqual(test.der);
-    }
-  });
+	it("ecdsa ieee2 der", () => {
+		for (const test of ECDSA_IEEE_DER_TEST_VECTORS) {
+			expect(EllipticCurves.ecdsaIeee2Der(test.ieee)).toEqual(test.der);
+		}
+	});
 
-  it('is valid der ecdsa signature', function() {
-    for (const test of INVALID_DER_ECDSA_SIGNATURES) {
-      expect(EllipticCurves.isValidDerEcdsaSignature(Bytes.fromHex(test)))
-          .toBe(false);
-    }
-  });
+	it("is valid der ecdsa signature", () => {
+		for (const test of INVALID_DER_ECDSA_SIGNATURES) {
+			expect(
+				EllipticCurves.isValidDerEcdsaSignature(Bytes.fromHex(test))
+			).toBe(false);
+		}
+	});
 });
 
 /**
@@ -442,418 +554,457 @@ describe('elliptic curves test', function() {
  * string or a text describing the failure.
  */
 async function runWycheproofTest(test: {
-  'tcId': number,
-  'public': JsonWebKey,
-  'private': JsonWebKey,
-  'shared': string,
-  'result': string,
+	tcId: number;
+	public: JsonWebKey;
+	private: JsonWebKey;
+	shared: string;
+	result: string;
 }): Promise<string> {
-  try {
-    const privateKey =
-        await EllipticCurves.importPrivateKey('ECDH', test['private']);
-    try {
-      const publicKey =
-          await EllipticCurves.importPublicKey('ECDH', test['public']);
-      const sharedSecret =
-          await EllipticCurves.computeEcdhSharedSecret(privateKey, publicKey);
-      if (test['result'] === 'invalid') {
-        return 'Fail on test ' + test['tcId'] + ': No exception thrown.\n';
-      }
-      const sharedSecretHex = Bytes.toHex(sharedSecret);
-      if (sharedSecretHex !== test['shared']) {
-        return 'Fail on test ' + test['tcId'] + ': unexpected result was "' +
-            sharedSecretHex + '".\n';
-      }
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      if (test['result'] === 'valid') {
-        return 'Fail on test ' + test['tcId'] + ': unexpected exception "' +
-            e.toString() + '".\n';
-      }
-    }
-    // Preserving old behavior when moving to
-    // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-    // tslint:disable-next-line:no-any
-  } catch (e: any) {
-    if (test['result'] === 'valid') {
-      if (test['private']['crv'] == "P-256K") {
-        // P-256K doesn't have to be supported. Hence failing to import the
-        // key is OK.
-        return '';
-      }
-      return 'Fail on test ' + test['tcId'] +
-          ': unexpected exception trying to import private key "' +
-          e.toString() + '".\n';
-    }
-  }
-  // If the test passes return an empty string.
-  return '';
+	try {
+		const privateKey = await EllipticCurves.importPrivateKey(
+			"ECDH",
+			test["private"]
+		);
+		try {
+			const publicKey = await EllipticCurves.importPublicKey(
+				"ECDH",
+				test["public"]
+			);
+			const sharedSecret = await EllipticCurves.computeEcdhSharedSecret(
+				privateKey,
+				publicKey
+			);
+			if (test["result"] === "invalid") {
+				return (
+					"Fail on test " + test["tcId"] + ": No exception thrown.\n"
+				);
+			}
+			const sharedSecretHex = Bytes.toHex(sharedSecret);
+			if (sharedSecretHex !== test["shared"]) {
+				return (
+					"Fail on test " +
+					test["tcId"] +
+					": unexpected result was "" +
+					sharedSecretHex +
+					"".\n"
+				);
+			}
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			if (test["result"] === "valid") {
+				return (
+					"Fail on test " +
+					test["tcId"] +
+					": unexpected exception "" +
+					e.toString() +
+					"".\n"
+				);
+			}
+		}
+		// Preserving old behavior when moving to
+		// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+		// tslint:disable-next-line:no-any
+	} catch (e: any) {
+		if (test["result"] === "valid") {
+			if (test["private"]["crv"] == "P-256K") {
+				// P-256K doesn"t have to be supported. Hence failing to import the
+				// key is OK.
+				return "";
+			}
+			return (
+				"Fail on test " +
+				test["tcId"] +
+				": unexpected exception trying to import private key "" +
+				e.toString() +
+				"".\n"
+			);
+		}
+	}
+	// If the test passes return an empty string.
+	return "";
 }
 
 class TestKey {
-  constructor(
-      readonly curve: string, readonly x: string, readonly y: string,
-      readonly d?: string) {}
+	constructor(
+		readonly curve: string,
+		readonly x: string,
+		readonly y: string,
+		readonly d?: string
+	) {}
 }
 
 // This set of keys was generated by Java version of Tink.
 // It contains one private and one public key for each curve type supported by
 // Tink.
 const TEST_KEYS: TestKey[] = [
-  new TestKey(
-      /* curve = */ 'P-256',
-      /* x = */
-      '2eab800e5d8e9b15d0f87c55324b477ffc9382d7137599e0203113a4e41b50d0',
-      /* y = */
-      '50bb2c11cfb72f3c380c2f93ea088d6938b91bcf581cd94a73ed0a3f623a6b8b'),
-  new TestKey(
-      /* curve = */ 'P-256',
-      /* x = */
-      '844c085cc4450297b681126356e10da074dea817f69bc2b1f3d6b1fc82593c7d',
-      /* y = */
-      '3cdb41fc89867d2066cc9c4f9ad7e890152bad24de20621abfe608234cbe40f1',
-      /* opt_d = */
-      'f96796cc28b36038817cc5d7db01c52ee0411dd848dc0833e9e26e989e4a64db'),
-  new TestKey(
-      /* curve = */ 'P-384',
-      /* x = */
-      'f3290cc80faa65e8821b0bf835f51e3431a4d78dcebd81b74c53b9b704bd995df93b648d51057a9a96a654fb8332391e',
-      /* y = */
-      '7e52bb9f654781a6894ef5ae77869207fa32ddbcec4a02d27ba1ead5472b3b9f39b09e9bca7d936809c143e99c655401'),
-  new TestKey(
-      /* curve = */ 'P-384',
-      /* x = */
-      'be9df79abedb82fc0e527630955f63f2f74b4984f0a4ac063a089565393ed20ac7a784f4efa434f5b1fa1837c76c8472',
-      /* y = */
-      'cf34ad0d4f3f2cbd546780509ec7073bb26fa0547d09ed10b83bf9b90903037ac956dbd661d02ce3e397e0547356b331',
-      /* opt_d = */
-      '34d86595280a8bdca23ccd60eeac9581016e895c2bc867c26dc2f99f6d0f627ce586ad36d1d2981968d8852dc9276d12'),
-  new TestKey(
-      /* curve = */ 'P-521',
-      /* x = */
-      '012f2211ec7e634919857be3066becf20c438b84ff24501712c91c98f527b44c7b001f8611935cb1179541c2b3cc3a1fc9259d50cd4842a847ea0cafe22cd75fe788',
-      /* y = */
-      '016b5d3f5480122643a26ef9e7c7e36875f53c28167d6afc35777d32ea76127d34287325bf14779f2e4cf3864fcc951ba601cec92b03291e34db2e815d4bd6fc2045'),
-  new TestKey(
-      /* curve = */ 'P-521',
-      /* x = */
-      '01ee3aabecef323cb4581e044be21914b567c426eae18d71720a71a0b236f5324ef9666fe855f5d7986d3e33a9250396f63c780572b3ad9417d69c2a87773ce39194',
-      /* y = */
-      '0036bea90db019304719d269e5335f9790e730e241a1b02cfdab8bdcfd0bcff8bdcb3ddeb9c3a94ecff1ab6abb80b0c1655f871c6089d3a4bf8625cf6bd182897f1b',
-      /* opt_d = */
-      '00b9f9f5d91cbfa9b7f92b041b137ac9822ca4a38f71ce227f624cac6178ca8351fab24bc2cc3f85d7ab72f54a0f9d1bb11a888a79a9c7b1ca267ddc82043585e437')
+	new TestKey(
+		/* curve = */ "P-256",
+		/* x = */
+		"2eab800e5d8e9b15d0f87c55324b477ffc9382d7137599e0203113a4e41b50d0",
+		/* y = */
+		"50bb2c11cfb72f3c380c2f93ea088d6938b91bcf581cd94a73ed0a3f623a6b8b"
+	),
+	new TestKey(
+		/* curve = */ "P-256",
+		/* x = */
+		"844c085cc4450297b681126356e10da074dea817f69bc2b1f3d6b1fc82593c7d",
+		/* y = */
+		"3cdb41fc89867d2066cc9c4f9ad7e890152bad24de20621abfe608234cbe40f1",
+		/* opt_d = */
+		"f96796cc28b36038817cc5d7db01c52ee0411dd848dc0833e9e26e989e4a64db"
+	),
+	new TestKey(
+		/* curve = */ "P-384",
+		/* x = */
+		"f3290cc80faa65e8821b0bf835f51e3431a4d78dcebd81b74c53b9b704bd995df93b648d51057a9a96a654fb8332391e",
+		/* y = */
+		"7e52bb9f654781a6894ef5ae77869207fa32ddbcec4a02d27ba1ead5472b3b9f39b09e9bca7d936809c143e99c655401"
+	),
+	new TestKey(
+		/* curve = */ "P-384",
+		/* x = */
+		"be9df79abedb82fc0e527630955f63f2f74b4984f0a4ac063a089565393ed20ac7a784f4efa434f5b1fa1837c76c8472",
+		/* y = */
+		"cf34ad0d4f3f2cbd546780509ec7073bb26fa0547d09ed10b83bf9b90903037ac956dbd661d02ce3e397e0547356b331",
+		/* opt_d = */
+		"34d86595280a8bdca23ccd60eeac9581016e895c2bc867c26dc2f99f6d0f627ce586ad36d1d2981968d8852dc9276d12"
+	),
+	new TestKey(
+		/* curve = */ "P-521",
+		/* x = */
+		"012f2211ec7e634919857be3066becf20c438b84ff24501712c91c98f527b44c7b001f8611935cb1179541c2b3cc3a1fc9259d50cd4842a847ea0cafe22cd75fe788",
+		/* y = */
+		"016b5d3f5480122643a26ef9e7c7e36875f53c28167d6afc35777d32ea76127d34287325bf14779f2e4cf3864fcc951ba601cec92b03291e34db2e815d4bd6fc2045"
+	),
+	new TestKey(
+		/* curve = */ "P-521",
+		/* x = */
+		"01ee3aabecef323cb4581e044be21914b567c426eae18d71720a71a0b236f5324ef9666fe855f5d7986d3e33a9250396f63c780572b3ad9417d69c2a87773ce39194",
+		/* y = */
+		"0036bea90db019304719d269e5335f9790e730e241a1b02cfdab8bdcfd0bcff8bdcb3ddeb9c3a94ecff1ab6abb80b0c1655f871c6089d3a4bf8625cf6bd182897f1b",
+		/* opt_d = */
+		"00b9f9f5d91cbfa9b7f92b041b137ac9822ca4a38f71ce227f624cac6178ca8351fab24bc2cc3f85d7ab72f54a0f9d1bb11a888a79a9c7b1ca267ddc82043585e437"
+	),
 ];
 
 class EcdsaIeeeDerTestVector {
-  ieee: Uint8Array;
-  der: Uint8Array;
+	ieee: Uint8Array;
+	der: Uint8Array;
 
-  constructor(ieee: string, der: string) {
-    this.ieee = Bytes.fromHex(ieee);
-    this.der = Bytes.fromHex(der);
-  }
+	constructor(ieee: string, der: string) {
+		this.ieee = Bytes.fromHex(ieee);
+		this.der = Bytes.fromHex(der);
+	}
 }
 const ECDSA_IEEE_DER_TEST_VECTORS: EcdsaIeeeDerTestVector[] = [
-  new EcdsaIeeeDerTestVector(  // normal case, short-form length
-      '0102030405060708090a0b0c0d0e0f100102030405060708090a0b0c0d0e0f10',
-      '302402100102030405060708090a0b0c0d0e0f1002100102030405060708090a0b0c0d0e0f10'),
-  new EcdsaIeeeDerTestVector(  // normal case, long-form length
-      '010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203',
-      '30818802420100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000002030242010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203'),
-  new EcdsaIeeeDerTestVector(  // zero prefix.
-      '0002030405060708090a0b0c0d0e0f100002030405060708090a0b0c0d0e0f10',
-      '3022020f02030405060708090a0b0c0d0e0f10020f02030405060708090a0b0c0d0e0f10'),
-  new EcdsaIeeeDerTestVector(  // highest bit is set.
-      '00ff030405060708090a0b0c0d0e0f1000ff030405060708090a0b0c0d0e0f10',
-      '3024021000ff030405060708090a0b0c0d0e0f10021000ff030405060708090a0b0c0d0e0f10'),
-  new EcdsaIeeeDerTestVector(  // highest bit is set, full length.
-      'ff02030405060708090a0b0c0d0e0f10ff02030405060708090a0b0c0d0e0f10',
-      '3026021100ff02030405060708090a0b0c0d0e0f10021100ff02030405060708090a0b0c0d0e0f10'),
-  new EcdsaIeeeDerTestVector(  // all zeros.
-      '0000000000000000000000000000000000000000000000000000000000000000',
-      '3006020100020100'),
+	new EcdsaIeeeDerTestVector( // normal case, short-form length
+		"0102030405060708090a0b0c0d0e0f100102030405060708090a0b0c0d0e0f10",
+		"302402100102030405060708090a0b0c0d0e0f1002100102030405060708090a0b0c0d0e0f10"
+	),
+	new EcdsaIeeeDerTestVector( // normal case, long-form length
+		"010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203",
+		"30818802420100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000002030242010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000203"
+	),
+	new EcdsaIeeeDerTestVector( // zero prefix.
+		"0002030405060708090a0b0c0d0e0f100002030405060708090a0b0c0d0e0f10",
+		"3022020f02030405060708090a0b0c0d0e0f10020f02030405060708090a0b0c0d0e0f10"
+	),
+	new EcdsaIeeeDerTestVector( // highest bit is set.
+		"00ff030405060708090a0b0c0d0e0f1000ff030405060708090a0b0c0d0e0f10",
+		"3024021000ff030405060708090a0b0c0d0e0f10021000ff030405060708090a0b0c0d0e0f10"
+	),
+	new EcdsaIeeeDerTestVector( // highest bit is set, full length.
+		"ff02030405060708090a0b0c0d0e0f10ff02030405060708090a0b0c0d0e0f10",
+		"3026021100ff02030405060708090a0b0c0d0e0f10021100ff02030405060708090a0b0c0d0e0f10"
+	),
+	new EcdsaIeeeDerTestVector( // all zeros.
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"3006020100020100"
+	),
 ];
 
 const INVALID_DER_ECDSA_SIGNATURES: string[] = [
-  '2006020101020101',    // 1st byte is not 0x30 (SEQUENCE tag)
-  '3006050101020101',    // 3rd byte is not 0x02 (INTEGER tag)
-  '3006020101050101',    // 6th byte is not 0x02 (INTEGER tag)
-  '308206020101020101',  // long form length is not 0x81
-  '30ff020101020101',    // invalid total length
-  '3006020201020101',    // invalid rLength
-  '3006020101020201',    // invalid sLength
-  '30060201ff020101',    // no extra zero when highest bit of r is set
-  '30060201010201ff',    // no extra zero when highest bit of s is set
+	"2006020101020101", // 1st byte is not 0x30 (SEQUENCE tag)
+	"3006050101020101", // 3rd byte is not 0x02 (INTEGER tag)
+	"3006020101050101", // 6th byte is not 0x02 (INTEGER tag)
+	"308206020101020101", // long form length is not 0x81
+	"30ff020101020101", // invalid total length
+	"3006020201020101", // invalid rLength
+	"3006020101020201", // invalid sLength
+	"30060201ff020101", // no extra zero when highest bit of r is set
+	"30060201010201ff", // no extra zero when highest bit of s is set
 ];
 
-// Following test vectors copied from 'testVectors2' variable in
+// Following test vectors copied from "testVectors2" variable in
 // /src/test/java/com/google/crypto/tink/subtle/EllipticCurvesTest.java.
 class TestVector {
-  constructor(
-      readonly curve: string, readonly format: string, readonly x: string,
-      readonly y: string, readonly encoded: string) {}
+	constructor(
+		readonly curve: string,
+		readonly format: string,
+		readonly x: string,
+		readonly y: string,
+		readonly encoded: string
+	) {}
 }
 
-const TEST_VECTORS:
-    TestVector[] =
-        [
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              'b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a',
-              /* y = */
-              '1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7',
-              /* encoded = */
-              '04b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'DO_NOT_USE_CRUNCHY_UNCOMPRESSED',
-              /* x = */
-              'b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a',
-              /* y = */
-              '1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7',
-              /* encoded = */
-              'b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              'b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a',
-              /* y = */
-              '1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7',
-              /* encoded = */
-              '03b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              '66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4',
-              /* encoded = */
-              '04000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'DO_NOT_USE_CRUNCHY_UNCOMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              '66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4',
-              /* encoded = */
-              '000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              '66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4',
-              /* encoded = */
-              '020000000000000000000000000000000000000000000000000000000000000000',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              'ffffffff00000001000000000000000000000000fffffffffffffffffffffffc',
-              /* y = */
-              '19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121',
-              /* encoded = */
-              '04ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'DO_NOT_USE_CRUNCHY_UNCOMPRESSED',
-              /* x = */
-              'ffffffff00000001000000000000000000000000fffffffffffffffffffffffc',
-              /* y = */
-              '19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121',
-              /* encoded = */
-              'ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121',
-              ),
-          new TestVector(
-              /* curve = */ 'P-256',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              'ffffffff00000001000000000000000000000000fffffffffffffffffffffffc',
-              /* y = */
-              '19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121',
-              /* encoded = */
-              '03ffffffff00000001000000000000000000000000fffffffffffffffffffffffc',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              'aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7',
-              /* y = */
-              '3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f',
-              /* encoded = */
-              '04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              'aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7',
-              /* y = */
-              '3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f',
-              /* encoded = */
-              '03aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              '3cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e',
-              /* encoded = */
-              '040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              '3cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e',
-              /* encoded = */
-              '02000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '2',
-              /* y = */
-              '732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3',
-              /* encoded = */
-              '04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '2',
-              /* y = */
-              '732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3',
-              /* encoded = */
-              '03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              'fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc',
-              /* y = */
-              '2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17',
-              /* encoded = */
-              '04fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17',
-              ),
-          new TestVector(
-              /* curve = */ 'P-384',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              'fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc',
-              /* y = */
-              '2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17',
-              /* encoded = */
-              '03fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              'c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66',
-              /* y = */
-              '11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650',
-              /* encoded = */
-              '0400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              'c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66',
-              /* y = */
-              '11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650',
-              /* encoded = */
-              '0200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              'd20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87',
-              /* encoded = */
-              '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '0',
-              /* y = */
-              'd20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87',
-              /* encoded = */
-              '03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '1',
-              /* y = */
-              '10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              /* encoded = */
-              '040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010010e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '1',
-              /* y = */
-              '10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              /* encoded = */
-              '02000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */ '2',
-              /* y = */
-              'd9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf',
-              /* encoded = */
-              '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200d9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'COMPRESSED',
-              /* x = */ '2',
-              /* y = */
-              'd9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf',
-              /* encoded = */
-              '03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'UNCOMPRESSED',
-              /* x = */
-              '1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd',
-              /* y = */
-              '10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              /* encoded = */
-              '0401fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0010e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              ),
-          new TestVector(
-              /* curve = */ 'P-521',
-              /* format = */ 'COMPRESSED',
-              /* x = */
-              '1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd',
-              /* y = */
-              '10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564',
-              /* encoded = */
-              '0201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd',
-              )
-        ];
+const TEST_VECTORS: TestVector[] = [
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a",
+		/* y = */
+		"1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7",
+		/* encoded = */
+		"04b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "DO_NOT_USE_CRUNCHY_UNCOMPRESSED",
+		/* x = */
+		"b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a",
+		/* y = */
+		"1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7",
+		/* encoded = */
+		"b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a",
+		/* y = */
+		"1886ccdca5487a6772f9401888203f90587cc00a730e2b83d5c6f89b3b568df7",
+		/* encoded = */
+		"03b0cfc7bc02fc980d858077552947ffb449b10df8949dee4e56fe21e016dcb25a"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+		/* encoded = */
+		"04000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "DO_NOT_USE_CRUNCHY_UNCOMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+		/* encoded = */
+		"000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "COMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+		/* encoded = */
+		"020000000000000000000000000000000000000000000000000000000000000000"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"ffffffff00000001000000000000000000000000fffffffffffffffffffffffc",
+		/* y = */
+		"19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121",
+		/* encoded = */
+		"04ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "DO_NOT_USE_CRUNCHY_UNCOMPRESSED",
+		/* x = */
+		"ffffffff00000001000000000000000000000000fffffffffffffffffffffffc",
+		/* y = */
+		"19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121",
+		/* encoded = */
+		"ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121"
+	),
+	new TestVector(
+		/* curve = */ "P-256",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"ffffffff00000001000000000000000000000000fffffffffffffffffffffffc",
+		/* y = */
+		"19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121",
+		/* encoded = */
+		"03ffffffff00000001000000000000000000000000fffffffffffffffffffffffc"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+		/* y = */
+		"3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
+		/* encoded = */
+		"04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+		/* y = */
+		"3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
+		/* encoded = */
+		"03aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"3cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e",
+		/* encoded = */
+		"040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "COMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"3cf99ef04f51a5ea630ba3f9f960dd593a14c9be39fd2bd215d3b4b08aaaf86bbf927f2c46e52ab06fb742b8850e521e",
+		/* encoded = */
+		"02000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "2",
+		/* y = */
+		"732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3",
+		/* encoded = */
+		"04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "COMPRESSED",
+		/* x = */ "2",
+		/* y = */
+		"732152442fb6ee5c3e6ce1d920c059bc623563814d79042b903ce60f1d4487fccd450a86da03f3e6ed525d02017bfdb3",
+		/* encoded = */
+		"03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc",
+		/* y = */
+		"2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17",
+		/* encoded = */
+		"04fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17"
+	),
+	new TestVector(
+		/* curve = */ "P-384",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc",
+		/* y = */
+		"2de9de09a95b74e6b2c430363e1afb8dff7164987a8cfe0a0d5139250ac02f797f81092a9bdc0e09b574a8f43bf80c17",
+		/* encoded = */
+		"03fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
+		/* y = */
+		"11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
+		/* encoded = */
+		"0400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
+		/* y = */
+		"11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
+		/* encoded = */
+		"0200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"d20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87",
+		/* encoded = */
+		"0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "COMPRESSED",
+		/* x = */ "0",
+		/* y = */
+		"d20ec9fea6b577c10d26ca1bb446f40b299e648b1ad508aad068896fee3f8e614bc63054d5772bf01a65d412e0bcaa8e965d2f5d332d7f39f846d440ae001f4f87",
+		/* encoded = */
+		"03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "1",
+		/* y = */
+		"10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564",
+		/* encoded = */
+		"040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010010e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "COMPRESSED",
+		/* x = */ "1",
+		/* y = */
+		"10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564",
+		/* encoded = */
+		"02000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */ "2",
+		/* y = */
+		"d9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf",
+		/* encoded = */
+		"0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200d9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "COMPRESSED",
+		/* x = */ "2",
+		/* y = */
+		"d9254fdf800496acb33790b103c5ee9fac12832fe546c632225b0f7fce3da4574b1a879b623d722fa8fc34d5fc2a8731aad691a9a8bb8b554c95a051d6aa505acf",
+		/* encoded = */
+		"03000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "UNCOMPRESSED",
+		/* x = */
+		"1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd",
+		/* y = */
+		"10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564",
+		/* encoded = */
+		"0401fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0010e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564"
+	),
+	new TestVector(
+		/* curve = */ "P-521",
+		/* format = */ "COMPRESSED",
+		/* x = */
+		"1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd",
+		/* y = */
+		"10e59be93c4f269c0269c79e2afd65d6aeaa9b701eacc194fb3ee03df47849bf550ec636ebee0ddd4a16f1cd9406605af38f584567770e3f272d688c832e843564",
+		/* encoded = */
+		"0201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd"
+	),
+];

--- a/javascript/subtle/encrypt_then_authenticate_test.ts
+++ b/javascript/subtle/encrypt_then_authenticate_test.ts
@@ -4,194 +4,224 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bytes from './bytes';
-import {aesCtrHmacFromRawKeys} from './encrypt_then_authenticate';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import { aesCtrHmacFromRawKeys } from "./encrypt_then_authenticate";
+import * as Random from "./random";
 
-describe('encrypt then authenticate test', function() {
-  beforeEach(function() {
-    // Use a generous promise timeout for running continuously.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000;  // 1000s
-  });
+describe("encrypt then authenticate test", () => {
+	beforeEach(() => {
+		// Use a generous promise timeout for running continuously.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 1000; // 1000s
+	});
 
-  afterEach(function() {
-    // Reset the promise timeout to default value.
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;  // 1s
-  });
+	afterEach(() => {
+		// Reset the promise timeout to default value.
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000; // 1s
+	});
 
-  it('basic', async function() {
-    const aead = await aesCtrHmacFromRawKeys(
-        Random.randBytes(16) /* aesKey */, 12 /* ivSize */, 'SHA-256',
-        Random.randBytes(16) /* hmacKey */, 10 /* tagSize */);
-    for (let i = 0; i < 100; i++) {
-      const msg = Random.randBytes(20);
-      let ciphertext = await aead.encrypt(msg);
-      let plaintext = await aead.decrypt(ciphertext);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+	it("basic", async () => {
+		const aead = await aesCtrHmacFromRawKeys(
+			Random.randBytes(16) /* aesKey */,
+			12 /* ivSize */,
+			"SHA-256",
+			Random.randBytes(16) /* hmacKey */,
+			10 /* tagSize */
+		);
+		for (let i = 0; i < 100; i++) {
+			const msg = Random.randBytes(20);
+			let ciphertext = await aead.encrypt(msg);
+			let plaintext = await aead.decrypt(ciphertext);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
 
-      ciphertext = await aead.encrypt(msg);
-      plaintext = await aead.decrypt(ciphertext);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+			ciphertext = await aead.encrypt(msg);
+			plaintext = await aead.decrypt(ciphertext);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
 
-      const aad = Random.randBytes(20);
-      ciphertext = await aead.encrypt(msg, aad);
-      plaintext = await aead.decrypt(ciphertext, aad);
-      expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
-    }
-  });
+			const aad = Random.randBytes(20);
+			ciphertext = await aead.encrypt(msg, aad);
+			plaintext = await aead.decrypt(ciphertext, aad);
+			expect(Bytes.toHex(plaintext)).toBe(Bytes.toHex(msg));
+		}
+	});
 
-  it('probabilistic encryption', async function() {
-    const aead = await aesCtrHmacFromRawKeys(
-        Random.randBytes(16) /* aesKey */, 12 /* ivSize */, 'SHA-256',
-        Random.randBytes(16) /* hmacKey */, 10 /* tagSize */);
-    const msg = Random.randBytes(20);
-    const aad = Random.randBytes(20);
-    const results = new Set();
-    for (let i = 0; i < 100; i++) {
-      const ciphertext = await aead.encrypt(msg, aad);
-      results.add(Bytes.toHex(ciphertext));
-    }
-    expect(results.size).toBe(100);
-  });
+	it("probabilistic encryption", async () => {
+		const aead = await aesCtrHmacFromRawKeys(
+			Random.randBytes(16) /* aesKey */,
+			12 /* ivSize */,
+			"SHA-256",
+			Random.randBytes(16) /* hmacKey */,
+			10 /* tagSize */
+		);
+		const msg = Random.randBytes(20);
+		const aad = Random.randBytes(20);
+		const results = new Set();
+		for (let i = 0; i < 100; i++) {
+			const ciphertext = await aead.encrypt(msg, aad);
+			results.add(Bytes.toHex(ciphertext));
+		}
+		expect(results.size).toBe(100);
+	});
 
-  it('bit flip ciphertext', async function() {
-    const aead = await aesCtrHmacFromRawKeys(
-        Random.randBytes(16) /* aesKey */, 16 /* ivSize */, 'SHA-256',
-        Random.randBytes(16) /* hmacKey */, 16 /* tagSize */);
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 0; i < ciphertext.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const c1 = new Uint8Array(ciphertext);
-        c1[i] = (c1[i] ^ (1 << j));
-        try {
-          await aead.decrypt(c1, aad);
-          fail('Should throw an exception.');
-          // Preserving old behavior when moving to
-          // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-          // tslint:disable-next-line:no-any
-        } catch (e: any) {
-          expect(e.toString()).toBe('SecurityException: invalid MAC');
-        }
-      }
-    }
-  });
+	it("bit flip ciphertext", async () => {
+		const aead = await aesCtrHmacFromRawKeys(
+			Random.randBytes(16) /* aesKey */,
+			16 /* ivSize */,
+			"SHA-256",
+			Random.randBytes(16) /* hmacKey */,
+			16 /* tagSize */
+		);
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 0; i < ciphertext.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const c1 = new Uint8Array(ciphertext);
+				c1[i] = c1[i] ^ (1 << j);
+				try {
+					await aead.decrypt(c1, aad);
+					fail("Should throw an exception.");
+					// Preserving old behavior when moving to
+					// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+					// tslint:disable-next-line:no-any
+				} catch (e: any) {
+					expect(e.toString()).toBe("SecurityException: invalid MAC");
+				}
+			}
+		}
+	});
 
-  it('bit flip aad', async function() {
-    const aead = await aesCtrHmacFromRawKeys(
-        Random.randBytes(16) /* aesKey */, 16 /* ivSize */, 'SHA-256',
-        Random.randBytes(16) /* hmacKey */, 16 /* tagSize */);
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 0; i < aad.length; i++) {
-      for (let j = 0; j < 8; j++) {
-        const aad1 = new Uint8Array(aad);
-        aad1[i] = (aad1[i] ^ (1 << j));
-        try {
-          await aead.decrypt(ciphertext, aad1);
-          fail('Should throw an exception.');
-          // Preserving old behavior when moving to
-          // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-          // tslint:disable-next-line:no-any
-        } catch (e: any) {
-          expect(e.toString()).toBe('SecurityException: invalid MAC');
-        }
-      }
-    }
-  });
+	it("bit flip aad", async () => {
+		const aead = await aesCtrHmacFromRawKeys(
+			Random.randBytes(16) /* aesKey */,
+			16 /* ivSize */,
+			"SHA-256",
+			Random.randBytes(16) /* hmacKey */,
+			16 /* tagSize */
+		);
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 0; i < aad.length; i++) {
+			for (let j = 0; j < 8; j++) {
+				const aad1 = new Uint8Array(aad);
+				aad1[i] = aad1[i] ^ (1 << j);
+				try {
+					await aead.decrypt(ciphertext, aad1);
+					fail("Should throw an exception.");
+					// Preserving old behavior when moving to
+					// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+					// tslint:disable-next-line:no-any
+				} catch (e: any) {
+					expect(e.toString()).toBe("SecurityException: invalid MAC");
+				}
+			}
+		}
+	});
 
-  it('truncation', async function() {
-    const aead = await aesCtrHmacFromRawKeys(
-        Random.randBytes(16) /* aesKey */, 16 /* ivSize */, 'SHA-256',
-        Random.randBytes(16) /* hmacKey */, 16 /* tagSize */);
-    const plaintext = Random.randBytes(8);
-    const aad = Random.randBytes(8);
-    const ciphertext = await aead.encrypt(plaintext, aad);
-    for (let i = 1; i <= ciphertext.length; i++) {
-      const c1 = new Uint8Array(ciphertext.buffer, 0, ciphertext.length - i);
-      try {
-        await aead.decrypt(c1, aad);
-        fail('Should throw an exception.');
-        // Preserving old behavior when moving to
-        // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-        // tslint:disable-next-line:no-any
-      } catch (e: any) {
-        if (c1.length < 32) {
-          expect(e.toString()).toBe('SecurityException: ciphertext too short');
-        } else {
-          expect(e.toString()).toBe('SecurityException: invalid MAC');
-        }
-      }
-    }
-  });
+	it("truncation", async () => {
+		const aead = await aesCtrHmacFromRawKeys(
+			Random.randBytes(16) /* aesKey */,
+			16 /* ivSize */,
+			"SHA-256",
+			Random.randBytes(16) /* hmacKey */,
+			16 /* tagSize */
+		);
+		const plaintext = Random.randBytes(8);
+		const aad = Random.randBytes(8);
+		const ciphertext = await aead.encrypt(plaintext, aad);
+		for (let i = 1; i <= ciphertext.length; i++) {
+			const c1 = new Uint8Array(
+				ciphertext.buffer,
+				0,
+				ciphertext.length - i
+			);
+			try {
+				await aead.decrypt(c1, aad);
+				fail("Should throw an exception.");
+				// Preserving old behavior when moving to
+				// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+				// tslint:disable-next-line:no-any
+			} catch (e: any) {
+				if (c1.length < 32) {
+					expect(e.toString()).toBe(
+						"SecurityException: ciphertext too short"
+					);
+				} else {
+					expect(e.toString()).toBe("SecurityException: invalid MAC");
+				}
+			}
+		}
+	});
 
-  it('with rfc test vectors', async function() {
-    // Test data from
-    // https://tools.ietf.org/html/draft-mcgrew-aead-aes-cbc-hmac-sha2-05. As we
-    // use CTR while RFC uses CBC mode, it's not possible to compare plaintexts.
-    // However, the test is still valueable to make sure that we correcly
-    // compute HMAC over ciphertext and aad.
-    const RFC_TEST_VECTORS = [
-      {
-        'macKey': '000102030405060708090a0b0c0d0e0f',
-        'encryptionKey': '101112131415161718191a1b1c1d1e1f',
-        'ciphertext': '1af38c2dc2b96ffdd86694092341bc04' +
-            'c80edfa32ddf39d5ef00c0b468834279' +
-            'a2e46a1b8049f792f76bfe54b903a9c9' +
-            'a94ac9b47ad2655c5f10f9aef71427e2' +
-            'fc6f9b3f399a221489f16362c7032336' +
-            '09d45ac69864e3321cf82935ac4096c8' +
-            '6e133314c54019e8ca7980dfa4b9cf1b' +
-            '384c486f3a54c51078158ee5d79de59f' +
-            'bd34d848b3d69550a67646344427ade5' +
-            '4b8851ffb598f7f80074b9473c82e2db' +
-            '652c3fa36b0a7c5b3219fab3a30bc1c4',
-        'aad': '546865207365636f6e64207072696e63' +
-            '69706c65206f66204175677573746520' +
-            '4b6572636b686f666673',
-        'hashAlgoName': 'SHA-256',
-        'ivSize': 16,
-        'tagSize': 16
-      },
-      {
-        'macKey':
-            '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
-        'encryptionKey':
-            '202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f',
-        'ciphertext': '1af38c2dc2b96ffdd86694092341bc04' +
-            '4affaaadb78c31c5da4b1b590d10ffbd' +
-            '3dd8d5d302423526912da037ecbcc7bd' +
-            '822c301dd67c373bccb584ad3e9279c2' +
-            'e6d12a1374b77f077553df829410446b' +
-            '36ebd97066296ae6427ea75c2e0846a1' +
-            '1a09ccf5370dc80bfecbad28c73f09b3' +
-            'a3b75e662a2594410ae496b2e2e6609e' +
-            '31e6e02cc837f053d21f37ff4f51950b' +
-            'be2638d09dd7a4930930806d0703b1f6' +
-            '4dd3b4c088a7f45c216839645b2012bf' +
-            '2e6269a8c56a816dbc1b267761955bc5',
-        'aad':
-            '546865207365636f6e64207072696e6369706c65206f662041756775737465204b6572636b686f666673',
-        'hashAlgoName': 'SHA-512',
-        'ivSize': 16,
-        'tagSize': 32
-      },
-    ];
-    for (let i = 0; i < RFC_TEST_VECTORS.length; i++) {
-      const testVector = RFC_TEST_VECTORS[i];
-      const aead = await aesCtrHmacFromRawKeys(
-          Bytes.fromHex(testVector['encryptionKey']), testVector['ivSize'],
-          testVector['hashAlgoName'], Bytes.fromHex(testVector['macKey']),
-          testVector['tagSize']);
-      const ciphertext = Bytes.fromHex(testVector['ciphertext']);
-      const aad = Bytes.fromHex(testVector['aad']);
-      try {
-        await aead.decrypt(ciphertext, aad);
-      } catch (e) {
-        fail(e);
-      }
-    }
-  });
+	it("with rfc test vectors", async () => {
+		// Test data from
+		// https://tools.ietf.org/html/draft-mcgrew-aead-aes-cbc-hmac-sha2-05. As we
+		// use CTR while RFC uses CBC mode, it"s not possible to compare plaintexts.
+		// However, the test is still valueable to make sure that we correcly
+		// compute HMAC over ciphertext and aad.
+		const RFC_TEST_VECTORS = [
+			{
+				macKey: "000102030405060708090a0b0c0d0e0f",
+				encryptionKey: "101112131415161718191a1b1c1d1e1f",
+				ciphertext:
+					"1af38c2dc2b96ffdd86694092341bc04" +
+					"c80edfa32ddf39d5ef00c0b468834279" +
+					"a2e46a1b8049f792f76bfe54b903a9c9" +
+					"a94ac9b47ad2655c5f10f9aef71427e2" +
+					"fc6f9b3f399a221489f16362c7032336" +
+					"09d45ac69864e3321cf82935ac4096c8" +
+					"6e133314c54019e8ca7980dfa4b9cf1b" +
+					"384c486f3a54c51078158ee5d79de59f" +
+					"bd34d848b3d69550a67646344427ade5" +
+					"4b8851ffb598f7f80074b9473c82e2db" +
+					"652c3fa36b0a7c5b3219fab3a30bc1c4",
+				aad:
+					"546865207365636f6e64207072696e63" +
+					"69706c65206f66204175677573746520" +
+					"4b6572636b686f666673",
+				hashAlgoName: "SHA-256",
+				ivSize: 16,
+				tagSize: 16,
+			},
+			{
+				macKey: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+				encryptionKey:
+					"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+				ciphertext:
+					"1af38c2dc2b96ffdd86694092341bc04" +
+					"4affaaadb78c31c5da4b1b590d10ffbd" +
+					"3dd8d5d302423526912da037ecbcc7bd" +
+					"822c301dd67c373bccb584ad3e9279c2" +
+					"e6d12a1374b77f077553df829410446b" +
+					"36ebd97066296ae6427ea75c2e0846a1" +
+					"1a09ccf5370dc80bfecbad28c73f09b3" +
+					"a3b75e662a2594410ae496b2e2e6609e" +
+					"31e6e02cc837f053d21f37ff4f51950b" +
+					"be2638d09dd7a4930930806d0703b1f6" +
+					"4dd3b4c088a7f45c216839645b2012bf" +
+					"2e6269a8c56a816dbc1b267761955bc5",
+				aad: "546865207365636f6e64207072696e6369706c65206f662041756775737465204b6572636b686f666673",
+				hashAlgoName: "SHA-512",
+				ivSize: 16,
+				tagSize: 32,
+			},
+		];
+		for (let i = 0; i < RFC_TEST_VECTORS.length; i++) {
+			const testVector = RFC_TEST_VECTORS[i];
+			const aead = await aesCtrHmacFromRawKeys(
+				Bytes.fromHex(testVector["encryptionKey"]),
+				testVector["ivSize"],
+				testVector["hashAlgoName"],
+				Bytes.fromHex(testVector["macKey"]),
+				testVector["tagSize"]
+			);
+			const ciphertext = Bytes.fromHex(testVector["ciphertext"]);
+			const aad = Bytes.fromHex(testVector["aad"]);
+			try {
+				await aead.decrypt(ciphertext, aad);
+			} catch (e) {
+				fail(e);
+			}
+		}
+	});
 });

--- a/javascript/subtle/hkdf_test.ts
+++ b/javascript/subtle/hkdf_test.ts
@@ -4,202 +4,224 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bytes from './bytes';
-import * as Hkdf from './hkdf';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import * as Hkdf from "./hkdf";
+import * as Random from "./random";
 
-describe('hkdf test', function() {
-  it('constructor', async function() {
-    const ikm = Random.randBytes(16);
-    const info = Random.randBytes(16);
-    try {
-      await Hkdf.compute(0, 'SHA-256', ikm, info);  // 0 output size
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be positive');
-    }
+describe("hkdf test", () => {
+	it("constructor", async () => {
+		const ikm = Random.randBytes(16);
+		const info = Random.randBytes(16);
+		try {
+			await Hkdf.compute(0, "SHA-256", ikm, info); // 0 output size
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be positive"
+			);
+		}
 
-    try {
-      await Hkdf.compute(-1, 'SHA-256', ikm, info);  // negative output size
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be positive');
-    }
+		try {
+			await Hkdf.compute(-1, "SHA-256", ikm, info); // negative output size
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be positive"
+			);
+		}
 
-    try {
-      await Hkdf.compute(
-          /** 255 * digestSize + 1 */ (255 * 20) + 1, 'SHA-1', ikm,
-          info);  // size too large
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('InvalidArgumentsException: size too large');
-    }
+		try {
+			await Hkdf.compute(
+				/** 255 * digestSize + 1 */ 255 * 20 + 1,
+				"SHA-1",
+				ikm,
+				info
+			); // size too large
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size too large"
+			);
+		}
 
-    try {
-      await Hkdf.compute(
-          /** 255 * digestSize + 1 */ (255 * 32) + 1, 'SHA-256', ikm,
-          info);  // size too large
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('InvalidArgumentsException: size too large');
-    }
+		try {
+			await Hkdf.compute(
+				/** 255 * digestSize + 1 */ 255 * 32 + 1,
+				"SHA-256",
+				ikm,
+				info
+			); // size too large
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size too large"
+			);
+		}
 
-    try {
-      await Hkdf.compute(
-          /** 255 * digestSize + 1 */ (255 * 64) + 1, 'SHA-512', ikm,
-          info);  // size too large
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString()).toBe('InvalidArgumentsException: size too large');
-    }
-  });
+		try {
+			await Hkdf.compute(
+				/** 255 * digestSize + 1 */ 255 * 64 + 1,
+				"SHA-512",
+				ikm,
+				info
+			); // size too large
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size too large"
+			);
+		}
+	});
 
-  it('constructor, non integer output size', async function() {
-    const ikm = Random.randBytes(16);
-    const info = Random.randBytes(16);
-    try {
-      await Hkdf.compute(NaN, 'SHA-256', ikm, info);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be an integer');
-    }
+	it("constructor, non integer output size", async () => {
+		const ikm = Random.randBytes(16);
+		const info = Random.randBytes(16);
+		try {
+			await Hkdf.compute(NaN, "SHA-256", ikm, info);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be an integer"
+			);
+		}
 
-    try {
-      await Hkdf.compute(1.5, 'SHA-256', ikm, info);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: size must be an integer');
-    }
-  });
+		try {
+			await Hkdf.compute(1.5, "SHA-256", ikm, info);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: size must be an integer"
+			);
+		}
+	});
 
-  it('with test vectors', async function() {
-    // Test cases are specified in Appendix A of RFC 5869.
-    const TEST_VECTORS = [
-      {
-        'hash': 'SHA-256',
-        'output':
-            '3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865',
-        'outputSize': 42,
-        'ikm': '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b',
-        'salt': '000102030405060708090a0b0c',
-        'info': 'f0f1f2f3f4f5f6f7f8f9',
-      },
-      {
-        'hash': 'SHA-256',
-        'output':
-            'b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c' +
-            '59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71' +
-            'cc30c58179ec3e87c14c01d5c1f3434f1d87',
-        'outputSize': 82,
-        'ikm':
-            '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' +
-            '202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f' +
-            '404142434445464748494a4b4c4d4e4f',
-        'salt':
-            '606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f' +
-            '808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f' +
-            'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf',
-        'info':
-            'b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf' +
-            'd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef' +
-            'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff',
-      },
-      // Salt is empty
-      {
-        'hash': 'SHA-256',
-        'output':
-            '8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d' +
-            '9d201395faa4b61a96c8',
-        'outputSize': 42,
-        'ikm': '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b',
-        'salt': '',
-        'info': '',
-      },
-      {
-        'hash': 'SHA-1',
-        'output':
-            '085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896',
-        'outputSize': 42,
-        'ikm': '0b0b0b0b0b0b0b0b0b0b0b',
-        'salt': '000102030405060708090a0b0c',
-        'info': 'f0f1f2f3f4f5f6f7f8f9',
-      },
-      {
-        'hash': 'SHA-1',
-        'output':
-            '0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe' +
-            '8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e' +
-            '927336d0441f4c4300e2cff0d0900b52d3b4',
-        'outputSize': 82,
-        'ikm':
-            '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' +
-            '202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f' +
-            '404142434445464748494a4b4c4d4e4f',
-        'salt':
-            '606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f' +
-            '808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f' +
-            'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf',
-        'info':
-            'b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf' +
-            'd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef' +
-            'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff',
-      },
-      // Salt is empty
-      {
-        'hash': 'SHA-1',
-        'output':
-            '0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0' +
-            'ea00033de03984d34918',
-        'outputSize': 42,
-        'ikm': '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b',
-        'salt': '',
-        'info': '',
-      },
-      // Salt is empty
-      {
-        'hash': 'SHA-1',
-        'output':
-            '2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5' +
-            '673a081d70cce7acfc48',
-        'outputSize': 42,
-        'ikm': '0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c',
-        'salt': '',
-        'info': '',
-      },
-    ];
-    for (let i = 0; i < TEST_VECTORS.length; i++) {
-      const testVector = TEST_VECTORS[i];
-      const ikm = Bytes.fromHex(testVector['ikm']);
-      const salt = Bytes.fromHex(testVector['salt']);
-      const info = Bytes.fromHex(testVector['info']);
-      const hkdf = await Hkdf.compute(
-          testVector['outputSize'], testVector['hash'], ikm, info, salt);
-      expect(testVector['output']).toBe(Bytes.toHex(hkdf));
-    }
-  });
+	it("with test vectors", async () => {
+		// Test cases are specified in Appendix A of RFC 5869.
+		const TEST_VECTORS = [
+			{
+				hash: "SHA-256",
+				output: "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+				outputSize: 42,
+				ikm: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+				salt: "000102030405060708090a0b0c",
+				info: "f0f1f2f3f4f5f6f7f8f9",
+			},
+			{
+				hash: "SHA-256",
+				output:
+					"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c" +
+					"59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71" +
+					"cc30c58179ec3e87c14c01d5c1f3434f1d87",
+				outputSize: 82,
+				ikm:
+					"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+					"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f" +
+					"404142434445464748494a4b4c4d4e4f",
+				salt:
+					"606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f" +
+					"808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f" +
+					"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+				info:
+					"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+					"d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+					"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+			},
+			// Salt is empty
+			{
+				hash: "SHA-256",
+				output:
+					"8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d" +
+					"9d201395faa4b61a96c8",
+				outputSize: 42,
+				ikm: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+				salt: "",
+				info: "",
+			},
+			{
+				hash: "SHA-1",
+				output: "085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896",
+				outputSize: 42,
+				ikm: "0b0b0b0b0b0b0b0b0b0b0b",
+				salt: "000102030405060708090a0b0c",
+				info: "f0f1f2f3f4f5f6f7f8f9",
+			},
+			{
+				hash: "SHA-1",
+				output:
+					"0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe" +
+					"8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e" +
+					"927336d0441f4c4300e2cff0d0900b52d3b4",
+				outputSize: 82,
+				ikm:
+					"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+					"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f" +
+					"404142434445464748494a4b4c4d4e4f",
+				salt:
+					"606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f" +
+					"808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f" +
+					"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+				info:
+					"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+					"d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+					"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+			},
+			// Salt is empty
+			{
+				hash: "SHA-1",
+				output:
+					"0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0" +
+					"ea00033de03984d34918",
+				outputSize: 42,
+				ikm: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+				salt: "",
+				info: "",
+			},
+			// Salt is empty
+			{
+				hash: "SHA-1",
+				output:
+					"2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5" +
+					"673a081d70cce7acfc48",
+				outputSize: 42,
+				ikm: "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+				salt: "",
+				info: "",
+			},
+		];
+		for (let i = 0; i < TEST_VECTORS.length; i++) {
+			const testVector = TEST_VECTORS[i];
+			const ikm = Bytes.fromHex(testVector["ikm"]);
+			const salt = Bytes.fromHex(testVector["salt"]);
+			const info = Bytes.fromHex(testVector["info"]);
+			const hkdf = await Hkdf.compute(
+				testVector["outputSize"],
+				testVector["hash"],
+				ikm,
+				info,
+				salt
+			);
+			expect(testVector["output"]).toBe(Bytes.toHex(hkdf));
+		}
+	});
 });

--- a/javascript/subtle/hmac_test.ts
+++ b/javascript/subtle/hmac_test.ts
@@ -4,246 +4,242 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bytes from './bytes';
-import {fromRawKey as hmacFromRawKey} from './hmac';
-import * as Random from './random';
+import * as Bytes from "./bytes";
+import { fromRawKey as hmacFromRawKey } from "./hmac";
+import * as Random from "./random";
 
-describe('hmac test', function() {
-  it('basic', async function() {
-    const key = Random.randBytes(16);
-    const msg = Random.randBytes(4);
-    const hmac = await hmacFromRawKey('SHA-1', key, 10);
-    const tag = await hmac.computeMac(msg);
-    expect(tag.length).toBe(10);
-    expect(await hmac.verifyMac(tag, msg)).toBe(true);
-  });
+describe("hmac test", () => {
+	it("basic", async () => {
+		const key = Random.randBytes(16);
+		const msg = Random.randBytes(4);
+		const hmac = await hmacFromRawKey("SHA-1", key, 10);
+		const tag = await hmac.computeMac(msg);
+		expect(tag.length).toBe(10);
+		expect(await hmac.verifyMac(tag, msg)).toBe(true);
+	});
 
-  it('constructor', async function() {
-    try {
-      await hmacFromRawKey(
-          'blah', Random.randBytes(16), 16);  // invalid HMAC algo name
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('InvalidArgumentsException: blah is not supported');
-    }
+	it("constructor", async () => {
+		try {
+			await hmacFromRawKey("blah", Random.randBytes(16), 16); // invalid HMAC algo name
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: blah is not supported"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-1', Random.randBytes(15), 16);  // invalid key size
-      // TODO(b/115974209): This case does not throw an exception.
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: key too short, must be at least 16 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-1", Random.randBytes(15), 16); // invalid key size
+			// TODO(b/115974209): This case does not throw an exception.
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: key too short, must be at least 16 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-1', Random.randBytes(16), 9);  // tag size too short
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too short, must be at least 10 bytes');
-    }
-    try {
-      await hmacFromRawKey(
-          'SHA-1', Random.randBytes(16), 21);  // tag size too long
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too long, must not be larger than 20 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-1", Random.randBytes(16), 9); // tag size too short
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too short, must be at least 10 bytes"
+			);
+		}
+		try {
+			await hmacFromRawKey("SHA-1", Random.randBytes(16), 21); // tag size too long
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too long, must not be larger than 20 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-256', Random.randBytes(15), 16);  // invalid key size
-      // TODO(b/115974209): This case does not throw an exception.
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: key too short, must be at least 16 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-256", Random.randBytes(15), 16); // invalid key size
+			// TODO(b/115974209): This case does not throw an exception.
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: key too short, must be at least 16 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-256', Random.randBytes(16), 9);  // tag size too short
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too short, must be at least 10 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-256", Random.randBytes(16), 9); // tag size too short
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too short, must be at least 10 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-256', Random.randBytes(16), 33);  // tag size too long
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too long, must not be larger than 32 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-256", Random.randBytes(16), 33); // tag size too long
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too long, must not be larger than 32 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-512', Random.randBytes(15), 16);  // invalid key size
-      // TODO(b/115974209): This case does not throw an exception.
+		try {
+			await hmacFromRawKey("SHA-512", Random.randBytes(15), 16); // invalid key size
+			// TODO(b/115974209): This case does not throw an exception.
 
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe('SecurityException: key too short, must be at least 16 bytes');
-    }
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"SecurityException: key too short, must be at least 16 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-512', Random.randBytes(16), 9);  // tag size too short
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too short, must be at least 10 bytes');
-    }
+		try {
+			await hmacFromRawKey("SHA-512", Random.randBytes(16), 9); // tag size too short
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too short, must be at least 10 bytes"
+			);
+		}
 
-    try {
-      await hmacFromRawKey(
-          'SHA-512', Random.randBytes(16), 65);  // tag size too long
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: tag too long, must not be larger than 64 bytes');
-    }
-  });
+		try {
+			await hmacFromRawKey("SHA-512", Random.randBytes(16), 65); // tag size too long
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: tag too long, must not be larger than 64 bytes"
+			);
+		}
+	});
 
-  it('constructor, invalid tag sizes', async function() {
-    try {
-      await hmacFromRawKey('SHA-512', Random.randBytes(16), NaN);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: invalid tag size, must be an integer');
-    }
+	it("constructor, invalid tag sizes", async () => {
+		try {
+			await hmacFromRawKey("SHA-512", Random.randBytes(16), NaN);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: invalid tag size, must be an integer"
+			);
+		}
 
-    try {
-      await hmacFromRawKey('SHA-512', Random.randBytes(16), 12.5);
-      fail('Should throw an exception.');
-      // Preserving old behavior when moving to
-      // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
-      // tslint:disable-next-line:no-any
-    } catch (e: any) {
-      expect(e.toString())
-          .toBe(
-              'InvalidArgumentsException: invalid tag size, must be an integer');
-    }
-  });
+		try {
+			await hmacFromRawKey("SHA-512", Random.randBytes(16), 12.5);
+			fail("Should throw an exception.");
+			// Preserving old behavior when moving to
+			// https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
+			// tslint:disable-next-line:no-any
+		} catch (e: any) {
+			expect(e.toString()).toBe(
+				"InvalidArgumentsException: invalid tag size, must be an integer"
+			);
+		}
+	});
 
-  it('modify', async function() {
-    const key = Random.randBytes(16);
-    const msg = Random.randBytes(8);
-    const hmac = await hmacFromRawKey('SHA-1', key, 20);
-    const tag = await hmac.computeMac(msg);
+	it("modify", async () => {
+		const key = Random.randBytes(16);
+		const msg = Random.randBytes(8);
+		const hmac = await hmacFromRawKey("SHA-1", key, 20);
+		const tag = await hmac.computeMac(msg);
 
-    // Modify tag.
-    for (let i = 0; i < tag.length; i++) {
-      const tag1 = new Uint8Array(tag);
-      tag1[i] = tag[i] ^ 0xff;
-      expect(await hmac.verifyMac(tag1, msg)).toBe(false);
-    }
+		// Modify tag.
+		for (let i = 0; i < tag.length; i++) {
+			const tag1 = new Uint8Array(tag);
+			tag1[i] = tag[i] ^ 0xff;
+			expect(await hmac.verifyMac(tag1, msg)).toBe(false);
+		}
 
-    // Modify msg.
-    for (let i = 0; i < msg.length; i++) {
-      const msg1 = new Uint8Array(msg);
-      msg1[i] = msg1[i] ^ 0xff;
-      expect(await hmac.verifyMac(tag, msg1)).toBe(false);
-    }
-  });
+		// Modify msg.
+		for (let i = 0; i < msg.length; i++) {
+			const msg1 = new Uint8Array(msg);
+			msg1[i] = msg1[i] ^ 0xff;
+			expect(await hmac.verifyMac(tag, msg1)).toBe(false);
+		}
+	});
 
-  it('with test vectors', async function() {
-    // Test data from
-    // http://csrc.nist.gov/groups/STM/cavp/message-authentication.html#testing.
-    const NIST_TEST_VECTORS = [
-      {
-        'algo': 'SHA-1',
-        'key':
-            '816aa4c3ee066310ac1e6666cf830c375355c3c8ba18cfe1f50a48c988b46272',
-        'message':
-            '220248f5e6d7a49335b3f91374f18bb8b0ff5e8b9a5853f3cfb293855d78301d' +
-            '837a0a2eb9e4f056f06c08361bd07180ee802651e69726c28910d2baef379606' +
-            '815dcbab01d0dc7acb0ba8e65a2928130da0522f2b2b3d05260885cf1c64f14c' +
-            'a3145313c685b0274bf6a1cb38e4f99895c6a8cc72fbe0e52c01766fede78a1a',
-        'tag': '17cb2e9e98b748b5ae0f7078ea5519e5'
-      },
-      {
-        'algo': 'SHA-256',
-        'key':
-            '6f35628d65813435534b5d67fbdb54cb33403d04e843103e6399f806cb5df95' +
-            'febbdd61236f33245',
-        'message':
-            '752cff52e4b90768558e5369e75d97c69643509a5e5904e0a386cbe4d0970ef7' +
-            '3f918f675945a9aefe26daea27587e8dc909dd56fd0468805f834039b345f855' +
-            'cfe19c44b55af241fff3ffcd8045cd5c288e6c4e284c3720570b58e4d47b8fee' +
-            'edc52fd1401f698a209fccfa3b4c0d9a797b046a2759f82a54c41ccd7b5f592b',
-        'tag': '05d1243e6465ed9620c9aec1c351a186'
-      },
-      {
-        'algo': 'SHA-512',
-        'key':
-            '726374c4b8df517510db9159b730f93431e0cd468d4f3821eab0edb93abd0fba' +
-            '46ab4f1ef35d54fec3d85fa89ef72ff3d35f22cf5ab69e205c10afcdf4aaf113' +
-            '38dbb12073474fddb556e60b8ee52f91163ba314303ee0c910e64e87fbf30221' +
-            '4edbe3f2',
-        'message':
-            'ac939659dc5f668c9969c0530422e3417a462c8b665e8db25a883a625f7aa59b' +
-            '89c5ad0ece5712ca17442d1798c6dea25d82c5db260cb59c75ae650be56569c1' +
-            'bd2d612cc57e71315917f116bbfa65a0aeb8af7840ee83d3e7101c52cf652d27' +
-            '73531b7a6bdd690b846a741816c860819270522a5b0cdfa1d736c501c583d916',
+	it("with test vectors", async () => {
+		// Test data from
+		// http://csrc.nist.gov/groups/STM/cavp/message-authentication.html#testing.
+		const NIST_TEST_VECTORS = [
+			{
+				algo: "SHA-1",
+				key: "816aa4c3ee066310ac1e6666cf830c375355c3c8ba18cfe1f50a48c988b46272",
+				message:
+					"220248f5e6d7a49335b3f91374f18bb8b0ff5e8b9a5853f3cfb293855d78301d" +
+					"837a0a2eb9e4f056f06c08361bd07180ee802651e69726c28910d2baef379606" +
+					"815dcbab01d0dc7acb0ba8e65a2928130da0522f2b2b3d05260885cf1c64f14c" +
+					"a3145313c685b0274bf6a1cb38e4f99895c6a8cc72fbe0e52c01766fede78a1a",
+				tag: "17cb2e9e98b748b5ae0f7078ea5519e5",
+			},
+			{
+				algo: "SHA-256",
+				key:
+					"6f35628d65813435534b5d67fbdb54cb33403d04e843103e6399f806cb5df95" +
+					"febbdd61236f33245",
+				message:
+					"752cff52e4b90768558e5369e75d97c69643509a5e5904e0a386cbe4d0970ef7" +
+					"3f918f675945a9aefe26daea27587e8dc909dd56fd0468805f834039b345f855" +
+					"cfe19c44b55af241fff3ffcd8045cd5c288e6c4e284c3720570b58e4d47b8fee" +
+					"edc52fd1401f698a209fccfa3b4c0d9a797b046a2759f82a54c41ccd7b5f592b",
+				tag: "05d1243e6465ed9620c9aec1c351a186",
+			},
+			{
+				algo: "SHA-512",
+				key:
+					"726374c4b8df517510db9159b730f93431e0cd468d4f3821eab0edb93abd0fba" +
+					"46ab4f1ef35d54fec3d85fa89ef72ff3d35f22cf5ab69e205c10afcdf4aaf113" +
+					"38dbb12073474fddb556e60b8ee52f91163ba314303ee0c910e64e87fbf30221" +
+					"4edbe3f2",
+				message:
+					"ac939659dc5f668c9969c0530422e3417a462c8b665e8db25a883a625f7aa59b" +
+					"89c5ad0ece5712ca17442d1798c6dea25d82c5db260cb59c75ae650be56569c1" +
+					"bd2d612cc57e71315917f116bbfa65a0aeb8af7840ee83d3e7101c52cf652d27" +
+					"73531b7a6bdd690b846a741816c860819270522a5b0cdfa1d736c501c583d916",
 
-        'tag':
-            'bd3d2df6f9d284b421a43e5f9cb94bc4ff88a88243f1f0133bad0fb1791f6569'
-      },
-    ];
-    for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
-      const testVector = NIST_TEST_VECTORS[i];
-      const key = Bytes.fromHex(testVector['key']);
-      const message = Bytes.fromHex(testVector['message']);
-      const tag = Bytes.fromHex(testVector['tag']);
-      const hmac = await hmacFromRawKey(testVector['algo'], key, tag.length);
-      expect(await hmac.verifyMac(tag, message)).toBe(true);
-    }
-  });
+				tag: "bd3d2df6f9d284b421a43e5f9cb94bc4ff88a88243f1f0133bad0fb1791f6569",
+			},
+		];
+		for (let i = 0; i < NIST_TEST_VECTORS.length; i++) {
+			const testVector = NIST_TEST_VECTORS[i];
+			const key = Bytes.fromHex(testVector["key"]);
+			const message = Bytes.fromHex(testVector["message"]);
+			const tag = Bytes.fromHex(testVector["tag"]);
+			const hmac = await hmacFromRawKey(
+				testVector["algo"],
+				key,
+				tag.length
+			);
+			expect(await hmac.verifyMac(tag, message)).toBe(true);
+		}
+	});
 });


### PR DESCRIPTION
# Javascript - Improve code style consistency among typescript tests:
- Introduce double quotes instead of single quotes. (Different were present in different files)
- Change the function keywords in some files to anonymous functions syntax
- Remove redundant wrapping of keys in objects
- Add multiline for multiple arguments and multiple imports for code clearance

_Note for future: I strongly recommend introducing configuration file `.prettierc` in order to state clearly the ways of code style_