### PR TITLE
Improve AesGcmSiv `Aead` performance by optimizing classpath check

### DIFF
--- a/java_src/src/main/java/com/google/crypto/tink/aead/subtle/AesGcmSiv.java
+++ b/java_src/src/main/java/com/google/crypto/tink/aead/subtle/AesGcmSiv.java
@@ -16,19 +16,21 @@
 
 package com.google.crypto.tink.aead.subtle;
 
+import java.security.GeneralSecurityException;
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
 import com.google.crypto.tink.Aead;
 import com.google.crypto.tink.annotations.Alpha;
 import com.google.crypto.tink.subtle.EngineFactory;
 import com.google.crypto.tink.subtle.Random;
 import com.google.crypto.tink.subtle.SubtleUtil;
 import com.google.crypto.tink.subtle.Validators;
-import java.security.GeneralSecurityException;
-import java.security.spec.AlgorithmParameterSpec;
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * This primitive implements AES-GCM-SIV (as defined in RFC 8452) using JCE.
@@ -57,6 +59,18 @@ public final class AesGcmSiv implements Aead {
   // All instances of this class use a 12 byte IV and a 16 byte tag.
   private static final int IV_SIZE_IN_BYTES = 12;
   private static final int TAG_SIZE_IN_BYTES = 16;
+
+  private static final boolean HAS_GCM_PARAMETER_SPEC_CLASS;
+
+  static {
+    boolean hasGcmParameterSpecClass = true;
+    try {
+      Class.forName("javax.crypto.spec.GCMParameterSpec");
+    } catch (ClassNotFoundException e) {
+      hasGcmParameterSpecClass = false;
+    }
+    HAS_GCM_PARAMETER_SPEC_CLASS = hasGcmParameterSpecClass;
+  }
 
   private final SecretKey keySpec;
 
@@ -128,17 +142,15 @@ public final class AesGcmSiv implements Aead {
 
   private static AlgorithmParameterSpec getParams(final byte[] buf, int offset, int len)
       throws GeneralSecurityException {
-    try {
-      Class.forName("javax.crypto.spec.GCMParameterSpec");
+    if (HAS_GCM_PARAMETER_SPEC_CLASS) {
       return new GCMParameterSpec(8 * TAG_SIZE_IN_BYTES, buf, offset, len);
-    } catch (ClassNotFoundException e) {
-      if (SubtleUtil.isAndroid()) {
-        // GCMParameterSpec should always be present in Java 7 or newer, but it's missing on Android
-        // devices with API level < 19. Fortunately, with a modern copy of Conscrypt (either through
-        // GMS or bundled with the app) we can initialize the cipher with just an IvParameterSpec.
-        // It will use a tag size of 128 bits. We'd double check the tag size in encrypt().
-        return new IvParameterSpec(buf, offset, len);
-      }
+    }
+    if (SubtleUtil.isAndroid()) {
+      // GCMParameterSpec should always be present in Java 7 or newer, but it's missing on Android
+      // devices with API level < 19. Fortunately, with a modern copy of Conscrypt (either through
+      // GMS or bundled with the app) we can initialize the cipher with just an IvParameterSpec.
+      // It will use a tag size of 128 bits. We'd double check the tag size in encrypt().
+      return new IvParameterSpec(buf, offset, len);
     }
     throw new GeneralSecurityException(
         "cannot use AES-GCM: javax.crypto.spec.GCMParameterSpec not found");


### PR DESCRIPTION
### Motivation:

`Aead` implementation for `AesGcmSiv` checks if `GCMParameterSpec` class exists in classpath by invoking `Class#forName` method whenever data gets encrypted or decrypted.

A benchmark on `AesGcmSiv` claims that `Class#forName` accounts for 4-5% of the CPU cycles consumed to encrypt and decrypt data and 12% or more throughput gain can be obtained by optimizing away the `Class#forName` invocation.


### Modification:

Cache the result of the classpath check in `AesGcmSiv`


### BM Results:

* [BM Code](https://github.com/ks-yim/tink-bm/blob/master/src/jmh/java/com/example/tink/bm/AesGcmSivBenchmark.java)
* Run on:
  - MacBook Pro (16-inch, 2021) Apple M1 Pro 32GB, MacOS Monterey version 12.6.2
  - Used `Conscrypt` custom build based on [3051cda](https://github.com/google/conscrypt/tree/3051cda0556eb142274d637443c7f5ae3b55a61f) to utilize AES-NI on Apple Silicon.

* Before
  ```
  # JMH version: 1.35
  # VM version: JDK 11.0.17, OpenJDK 64-Bit Server VM, 11.0.17+8
  # VM invoker: /Users/ks-yim/.sdkman/candidates/java/11.0.17-tem/bin/java
  # VM options: -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/Users/ks-yim/IdeaProjects/tink-bm/build/tmp/jmh - 
  Duser.country=KR -Duser.language=en -Duser.variant
  # Blackhole mode: full + dont-inline hint (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
  # Warmup: 1 iterations, 10 s each
  # Measurement: 1 iterations, 10 s each
  # Timeout: 10 min per iteration
  # Threads: 8 threads, will synchronize iterations
  # Benchmark mode: Throughput, ops/time
  # Benchmark: com.example.tink.bm.AesGcmSivBenchmark.conscrypt_encrypt
  
  Benchmark                                             Mode  Cnt       Score   Error  Units
  AesGcmSivBenchmark.bc_decrypt                        thrpt       140397.856          ops/s
  AesGcmSivBenchmark.bc_encrypt                        thrpt       161178.303          ops/s
  AesGcmSivBenchmark.conscrypt_decrypt                 thrpt       487751.715          ops/s
  AesGcmSivBenchmark.conscrypt_encrypt                 thrpt       462492.430          ops/s
  ```

* After
  ```
  Benchmark                                             Mode  Cnt       Score   Error  Units
  AesGcmSivBenchmark.bc_decrypt                        thrpt       168118.773          ops/s
  AesGcmSivBenchmark.bc_encrypt                        thrpt       172307.366          ops/s
  AesGcmSivBenchmark.conscrypt_decrypt                 thrpt       546720.978          ops/s
  AesGcmSivBenchmark.conscrypt_encrypt                 thrpt       551282.859          ops/s
  ```

### CPU Profiling Result:

* Before
  - Encryption
    ![flame-graph-cpu](https://user-images.githubusercontent.com/35995647/222684677-b31213e1-b876-4228-a609-2c9015ac88e5.svg)

  - Decryption
    ![flame-graph-cpu](https://user-images.githubusercontent.com/35995647/222685025-681fed16-480e-412c-83ec-74c9294e8874.svg)

* After
  - Encryption
    ![flame-graph-cpu](https://user-images.githubusercontent.com/35995647/222685439-cb92ccee-9c2f-4cc8-bda0-86bfcd95bf6c.svg)

  - Decryption
    ![flame-graph-cpu](https://user-images.githubusercontent.com/35995647/222685359-6be89698-1514-4509-890b-38799bf6bf62.svg)
