### PR TITLE
Rewrite Vault transit mount parsing

### DIFF
--- a/go/integration/hcvault/hcvault_client.go
+++ b/go/integration/hcvault/hcvault_client.go
@@ -14,7 +14,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-// Package hcvault provides integration with the HashiCorp Vault (https://www.vaultproject.io/).
+// Package hcvault provides integration with the [HashiCorp Vault].
+//
+//	[HashiCorp Vault]: https://www.vaultproject.io/.
 package hcvault
 
 import (
@@ -25,9 +27,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/vault/api"
 	"github.com/google/tink/go/core/registry"
 	"github.com/google/tink/go/tink"
+	"github.com/hashicorp/vault/api"
 )
 
 const (


### PR DESCRIPTION
At work our Vault instance is set up to add Transit to sub-paths (mounts), so something like `/teams/billing/my-service/transit/keys/foo` (mount: `/teams/billing/my-service/transit`) is perfectly valid. In fact, the transit mount can be named anything, and doesn't have to end in `/transit`!

The Tink Vault path parser did not support this flexibility, however, assuming that paths are always `/transit/keys/foo`. That's only true for the root `/transit` mount.

So rewrite the Vault transit URL path parser to support any URL ending in `{mount}/keys/{keyName}`. The key name cannot contain any unescaped slashes, so remove that support, too.

The result is one new method, `getEndpointPaths()`, which replaces `getEncryptionPath()`, `getDecryptionPath()`, and `extractKey()`, parses the key URL just once, and returns both the encrypt and decrypt endpoints. Also replace `TestExtractKey()` with `TestGetPaths()` to test all the variations.
