### PR TITLE
Export ErrInvalidSignature for use with errors.Is.

### DIFF
--- a/go/signature/verifier_factory.go
+++ b/go/signature/verifier_factory.go
@@ -87,7 +87,8 @@ func createVerifierLogger(ps *primitiveset.PrimitiveSet) (monitoring.Logger, err
 	})
 }
 
-var errInvalidSignature = errors.New("verifier_factory: invalid signature")
+// ErrInvalidSignature is returned when a signature is invalid.
+var ErrInvalidSignature = errors.New("verifier_factory: invalid signature")
 
 // Verify checks whether the given signature is a valid signature of the given data.
 func (v *wrappedVerifier) Verify(signature, data []byte) error {


### PR DESCRIPTION
This allows use of `errors.Is(err, signature.ErrInvalidSignature)` rather than `strings.Contains(err.Error(), "verifier_factory: invalid signature")`