### PR TITLE
Export `ErrInvalidSignature` for use with `errors.Is`.

### DIFF
--- a/go/signature/verifier_factory.go
+++ b/go/signature/verifier_factory.go
@@ -87,13 +87,14 @@ func createVerifierLogger(ps *primitiveset.PrimitiveSet) (monitoring.Logger, err
 	})
 }
 
-var errInvalidSignature = errors.New("verifier_factory: invalid signature")
+// ErrInvalidSignature is returned when a signature is invalid.
+var ErrInvalidSignature = errors.New("verifier_factory: invalid signature")
 
 // Verify checks whether the given signature is a valid signature of the given data.
 func (v *wrappedVerifier) Verify(signature, data []byte) error {
 	prefixSize := cryptofmt.NonRawPrefixSize
 	if len(signature) < prefixSize {
-		return errInvalidSignature
+		return ErrInvalidSignature
 	}
 
 	// try non-raw keys
@@ -139,5 +140,5 @@ func (v *wrappedVerifier) Verify(signature, data []byte) error {
 		}
 	}
 	v.logger.LogFailure()
-	return errInvalidSignature
+	return ErrInvalidSignature
 }


### PR DESCRIPTION
This allows use of `errors.Is(err, signature.ErrInvalidSignature)` rather than `strings.Contains(err.Error(), "verifier_factory: invalid signature")`