### PR TITLE
fix typos and spelling errors

### DIFF
--- a/docs/JWT-HOWTO.md
+++ b/docs/JWT-HOWTO.md
@@ -44,7 +44,7 @@ entity. The algorithms supported by this primitive are `HS256`, `HS384` and
 `HS512`.
 
 In [Tinkey](TINKEY.md), all templates that can be used with the JWT primitives
-start with `JWT_`, followed by the algorithm and some additonal paramters. For
+start with `JWT_`, followed by the algorithm and some additional parameters. For
 example `JWT_HS256`, `JWT_ES256`, `JWT_RS256_3072_F4` or `JWT_PS256_3072_F4`.
 
 ## Public keyset distribution

--- a/java_src/examples/encryptedkeyset/README.md
+++ b/java_src/examples/encryptedkeyset/README.md
@@ -5,7 +5,7 @@ primitive, and use the primitive to do crypto.
 
 ## Build and run
 
-### Prequisite
+### Prerequisite
 
 This example uses a Cloud KMS key as a key-encryption key (KEK) to
 encrypt/decrypt a keyset, which in turn is used to encrypt files.

--- a/java_src/examples/envelopeaead/README.md
+++ b/java_src/examples/envelopeaead/README.md
@@ -21,7 +21,7 @@ The CLI takes the following arguments:
 
 ## Build and Run
 
-### Prequisite
+### Prerequisite
 
 This envelope encryption example uses a Cloud KMS key as a key-encryption key
 (KEK). In order to run it, you need to:

--- a/java_src/examples/gcs/README.md
+++ b/java_src/examples/gcs/README.md
@@ -35,7 +35,7 @@ When mode is "decrypt", it takes the following additional arguments:
 
 ## Build and Run
 
-### Prequisite
+### Prerequisite
 
 This envelope encryption example uses a Cloud KMS key as a key-encryption key
 (KEK). In order to run it, you need to:

--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -15,7 +15,7 @@ Continuous builds are triggered for every new commit to the master branch and
 the current release branch.
 
 For the master branch, at the end of a successful
-continious build, a snapshot of Tink and the example apps are created and
+continuous build, a snapshot of Tink and the example apps are created and
 uploaded to Maven.
 
 ## Presubmit testing

--- a/python/examples/encrypted_keyset/README.md
+++ b/python/examples/encrypted_keyset/README.md
@@ -5,7 +5,7 @@ primitive, and use the primitive to do crypto.
 
 ## Build and run
 
-### Prequisite
+### Prerequisite
 
 This example uses a Cloud KMS key as a key-encryption key (KEK) to
 encrypt/decrypt a keyset, which in turn is used to encrypt files.

--- a/python/examples/envelope_aead/README.md
+++ b/python/examples/envelope_aead/README.md
@@ -19,7 +19,7 @@ The CLI takes 5 arguments:
 
 ## Build and Run
 
-### Prequisite
+### Prerequisite
 
 This envelope encryption example uses a Cloud KMS key as a key-encryption key
 (KEK). In order to run it, you need to:

--- a/python/examples/gcs/README.md
+++ b/python/examples/gcs/README.md
@@ -30,7 +30,7 @@ The CLI takes the following required arguments:
 
 ## Build and run
 
-### Prequisite
+### Prerequisite
 
 This envelope encryption example uses a Cloud KMS key as a key-encryption key
 (KEK). In order to run it, you need to:


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.