### PR TITLE
aead/subtle: change bazel visibility to public

### DIFF
--- a/go/aead/subtle/BUILD.bazel
+++ b/go/aead/subtle/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "xchacha20poly1305.go",
     ],
     importpath = "github.com/google/tink/go/aead/subtle",
+    visibility = ["//visibility:public"],
     deps = [
         "//internal/aead",
         "//subtle/random",


### PR DESCRIPTION
Hey.
Thanks for the nice library!

We want to use aead/subtle in a project that is built with Bazel. However, aead/subtle's default visibilty stops us from doing that. I understand the docs in a way that suggests using subtle pkgs is intended use; keeping in mind that extra care is required. Thus, add public visibility on the Bazel level, just like [kwp/subtle](https://github.com/google/tink/blob/go/v1.7.0/go/kwp/subtle/BUILD.bazel#L9) does it.

Cheers.